### PR TITLE
[BugFix] Fixed the error in generating HTML files when all RPS values are outliers.

### DIFF
--- a/ais_bench/benchmark/utils/visualization/rps_distribution_plot.py
+++ b/ais_bench/benchmark/utils/visualization/rps_distribution_plot.py
@@ -1346,10 +1346,32 @@ def _export_to_html(fig: go.Figure, output_path: str, save_json: bool = True) ->
         logger.error(f"Unexpected error when saving HTML file: {e}")
 
 
+def _convert_numpy_to_list(obj):
+    """Recursively convert numpy arrays and scalars to Python native types.
+    
+    Args:
+        obj: Object that may contain numpy arrays
+        
+    Returns:
+        Object with all numpy arrays converted to lists
+    """
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    elif isinstance(obj, (np.integer, np.floating)):
+        return obj.item()
+    elif isinstance(obj, dict):
+        return {key: _convert_numpy_to_list(value) for key, value in obj.items()}
+    elif isinstance(obj, (list, tuple)):
+        return [_convert_numpy_to_list(item) for item in obj]
+    else:
+        return obj
+
+
 def _export_to_json(fig: go.Figure, filename: str) -> None:
     """Serialize figure representation to JSON file"""
     try:
         fig_dict = fig.to_dict()
+        fig_dict = _convert_numpy_to_list(fig_dict)
         with open(filename, 'w') as f:
             json.dump(fig_dict, f, indent=2)
     except Exception as e:


### PR DESCRIPTION
Added the `_convert_numpy_to_list` method to recursively clean the results of `Figure.to_dict()`, converting the following content into native Python types:
`numpy.ndarray` → list
`numpy.integer` / `numpy.floating` → int / float
Nested dicts, lists, tuples → recursively processed

This method is called in `_export_to_json` to ensure that the serialized output is compatible with `json.dump()`, preventing errors when generating HTML.

🔧 Changes Made:
- Added the utility method `_convert_numpy_to_list()`.
- Introduced the conversion process in `_export_to_json()` to ensure the output structure of `fig.to_dict()` is safe.
- Fully compatible with various nested structures.

Self-verification report:
<img width="2351" height="564" alt="image" src="https://github.com/user-attachments/assets/9712fa36-a4f0-4f1b-8d8e-130002156b1e" />
