### PR TITLE
local eval add mindformers model

### DIFF
--- a/ais_bench/benchmark/configs/models/mf_models/mf_model.py
+++ b/ais_bench/benchmark/configs/models/mf_models/mf_model.py
@@ -1,4 +1,4 @@
-from ais_bench.benchmark.models import MindFormerModel
+from ais_bench.benchmark.models.local_models.mindformers_model import MindFormerModel
 
 models = [
     dict(
@@ -25,7 +25,8 @@ models = [
         ),
         run_cfg = dict(num_gpus=1, num_procs=1),  # 多卡/多机多卡 参数，使用torchrun拉起任务
         max_out_len=100, # 最大输出token长度
-        batch_size=2, # 每次推理的batch size
+        batch_size=2, # 每次拆分数据集的batch size
+        build_batch_size = 2, # 构建静态图模型时使用的build_batch_size>=batch_size
         max_seq_len=2048,
         batch_padding=True,
     )

--- a/ais_bench/benchmark/configs/models/mf_models/mf_model.py
+++ b/ais_bench/benchmark/configs/models/mf_models/mf_model.py
@@ -1,0 +1,32 @@
+from ais_bench.benchmark.models import MindFormerModel
+
+models = [
+    dict(
+        attr="local", # local or service
+        type=MindFormerModel, #  transformers < 4.33.0 用这个，优先AutoModelForCausalLM.from_pretrained加载模型，失败则用AutoModel.from_pretrained加载
+        abbr='mindformer-model',
+        path='THUDM/chatglm-6b', # path to model dir, current value is just a example
+        checkpoint = 'THUDM/your_checkpoint', # path to checkpoint file, current value is just a example
+        yaml_cfg_file = 'THUDM/your.yaml',
+        tokenizer_path='THUDM/chatglm-6b', # path to tokenizer dir, current value is just a example
+        model_kwargs=dict( # 模型参数参考 huggingface.co/docs/transformers/v4.50.0/en/model_doc/auto#transformers.AutoModel.from_pretrained
+            device_map='npu',
+        ),
+        tokenizer_kwargs=dict( # tokenizer参数参考 huggingface.co/docs/transformers/v4.50.0/en/internal/tokenization_utils#transformers.PreTrainedTokenizerBase
+            padding_side='right',
+        ),
+        generation_kwargs = dict( # 后处理参数参考huggingface.co/docs/transformers/main_classes/test_generation
+            temperature = 0.5,
+            top_k = 10,
+            top_p = 0.95,
+            do_sample = True,
+            seed = None,
+            repetition_penalty = 1.03,
+        ),
+        run_cfg = dict(num_gpus=1, num_procs=1),  # 多卡/多机多卡 参数，使用torchrun拉起任务
+        max_out_len=100, # 最大输出token长度
+        batch_size=2, # 每次推理的batch size
+        max_seq_len=2048,
+        batch_padding=True,
+    )
+]

--- a/ais_bench/benchmark/models/__init__.py
+++ b/ais_bench/benchmark/models/__init__.py
@@ -15,3 +15,4 @@ from ais_bench.benchmark.models.api_models.triton_api import TritonCustomAPIStre
 from ais_bench.benchmark.models.api_models.tgi_api import TGICustomAPIStream # noqa: F401
 from ais_bench.benchmark.models.api_models.vllm_custom_api_chat import VllmMultiturnAPIChatStream # noqa: F401
 from ais_bench.benchmark.models.local_models.vllm_offline_vl import VLLMOfflineVLModel
+from ais_bench.benchmark.models.local_models.mindformers_model import MindFormerModel

--- a/ais_bench/benchmark/models/__init__.py
+++ b/ais_bench/benchmark/models/__init__.py
@@ -15,4 +15,3 @@ from ais_bench.benchmark.models.api_models.triton_api import TritonCustomAPIStre
 from ais_bench.benchmark.models.api_models.tgi_api import TGICustomAPIStream # noqa: F401
 from ais_bench.benchmark.models.api_models.vllm_custom_api_chat import VllmMultiturnAPIChatStream # noqa: F401
 from ais_bench.benchmark.models.local_models.vllm_offline_vl import VLLMOfflineVLModel
-from ais_bench.benchmark.models.local_models.mindformers_model import MindFormerModel

--- a/ais_bench/benchmark/models/local_models/base.py
+++ b/ais_bench/benchmark/models/local_models/base.py
@@ -35,6 +35,7 @@ class BaseModel:
     """
 
     is_api: bool = False
+    launcher: str = "torchrun"
 
     def __init__(self,
                  path: str,

--- a/ais_bench/benchmark/models/local_models/mindformers_model.py
+++ b/ais_bench/benchmark/models/local_models/mindformers_model.py
@@ -1,0 +1,302 @@
+import os, sys
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+import torch
+import transformers
+
+from ais_bench.benchmark.models.local_models.base import BaseModel
+from ais_bench.benchmark.models import APITemplateParser
+from ais_bench.benchmark.registry import MODELS
+
+from mindspore import Tensor, Model
+from mindformers import  MindFormerConfig, build_context
+from mindformers.models import build_network
+from mindformers.core.parallel_config import build_parallel_config
+from mindformers.utils.load_checkpoint_utils import get_load_path_after_hf_convert
+from mindformers.trainer.utils import transform_and_load_checkpoint
+
+
+
+class MultiTokenEOSCriteria(transformers.StoppingCriteria):
+    """Criteria to stop on the specified multi-token sequence."""
+
+    def __init__(
+        self,
+        sequence: str,
+        tokenizer: transformers.PreTrainedTokenizer,
+        batch_size: int,
+    ):
+        self.done_tracker = [False] * batch_size
+        self.sequence = sequence
+        self.sequence_ids = tokenizer.encode(sequence,
+                                             add_special_tokens=False)
+        self.sequence_id_len = len(self.sequence_ids)
+        self.tokenizer = tokenizer
+
+    def __call__(self, input_ids, scores, **kwargs) -> bool:
+        # compare the last len(stop) tokens
+        lookback_ids_batch = input_ids[:, -self.sequence_id_len:]
+        lookback_tokens_batch = self.tokenizer.batch_decode(lookback_ids_batch)
+        for i, done in enumerate(self.done_tracker):
+            if done:
+                continue
+            self.done_tracker[i] = self.sequence in lookback_tokens_batch[i]
+        return False not in self.done_tracker
+
+
+def drop_error_generation_kwargs(generation_kwargs: dict) -> dict:
+    for key in ['is_synthetic', 'batch_size', 'do_performance']:
+        if key in generation_kwargs:
+            generation_kwargs.pop(key)
+    return generation_kwargs
+
+
+@MODELS.register_module()
+class MindFormerModel(BaseModel):
+
+    def __init__(self,
+                 path: str,
+                 checkpoint: Optional[str] = None,
+                 yaml_cfg_file: Optional[str] = None,
+                 batch_size: int = 1,
+                 max_seq_len: int = 2048,
+                 tokenizer_path: Optional[str] = None,
+                 tokenizer_kwargs: dict = dict(),
+                 tokenizer_only: bool = False,
+                 generation_kwargs: dict = dict(),
+                 meta_template: Optional[Dict] = None,
+                 extract_pred_after_decode: bool = False,
+                 batch_padding: bool = False,
+                 pad_token_id: Optional[int] = None,
+                 mode: str = 'none',
+                 use_fastchat_template: bool = False,
+                 end_str: Optional[str] = None,
+                 **kwargs):
+        super().__init__(path=path,
+                         max_seq_len=max_seq_len,
+                         tokenizer_only=tokenizer_only,
+                         meta_template=meta_template)
+        self.batch_size = batch_size
+        self.pad_token_id = pad_token_id
+        self.pretrained_model_path = path
+        if mode not in ['none', 'mid']:
+            raise ValueError(f"mode must be 'none' or 'mid', but got {mode}")
+        self.mode = mode
+        if not yaml_cfg_file:
+            raise ValueError('`yaml_cfg_file` is required for MindFormerModel') 
+        self.config = MindFormerConfig(yaml_cfg_file)
+        self.checkpoint = checkpoint
+        self._load_tokenizer(path=path,
+                             tokenizer_path=tokenizer_path,
+                             tokenizer_kwargs=tokenizer_kwargs)
+        self.batch_padding = batch_padding
+        self.extract_pred_after_decode = extract_pred_after_decode
+        if not tokenizer_only:
+            self._load_model(self.config, self.batch_size, self.max_seq_len)
+        self.generation_kwargs = generation_kwargs
+        self.use_fastchat_template = use_fastchat_template
+        self.end_str = end_str
+
+    def _load_tokenizer(self, path: str, tokenizer_path: Optional[str],
+                        tokenizer_kwargs: dict):
+        from transformers import AutoTokenizer, GenerationConfig
+
+        DEFAULT_TOKENIZER_KWARGS = dict(padding_side='left', truncation_side='left', trust_remote_code=True)
+        kwargs = DEFAULT_TOKENIZER_KWARGS.copy()
+        kwargs.update(tokenizer_kwargs)
+
+        load_path = tokenizer_path if tokenizer_path else path
+        self.tokenizer = AutoTokenizer.from_pretrained(load_path, **kwargs)
+
+        pad_token_id = self.pad_token_id
+
+        # A patch for some models without pad_token_id
+        if pad_token_id is not None:
+            if self.tokenizer.pad_token_id is None:
+                self.logger.debug(f'Using {pad_token_id} as pad_token_id')
+            elif self.tokenizer.pad_token_id != pad_token_id:
+                self.logger.warning(f'pad_token_id is not consistent. Using {pad_token_id} as pad_token_id')
+            self.tokenizer.pad_token_id = pad_token_id
+            return
+        if self.tokenizer.pad_token_id is not None:
+            return
+        self.logger.warning('pad_token_id is not set for the tokenizer.')
+
+        try:
+            generation_config = GenerationConfig.from_pretrained(path)
+        except Exception:
+            generation_config = None
+
+        if generation_config and generation_config.pad_token_id is not None:
+            self.logger.warning(f'Using {generation_config.pad_token_id} as pad_token_id.')
+            self.tokenizer.pad_token_id = generation_config.pad_token_id
+            return
+        if self.tokenizer.eos_token_id is not None:
+            self.logger.warning(f'Using eos_token_id {self.tokenizer.eos_token_id} as pad_token_id.')
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+            return
+        raise ValueError('pad_token_id is not set for this tokenizer. Please set `pad_token_id={PAD_TOKEN_ID}` in model_cfg.')
+
+    def _set_config_from_yaml(self):
+        if self.checkpoint is not None:
+            self.config.load_checkpoint = self.checkpoint
+        elif self.checkpoint is None and self.config.load_checkpoint is None:
+            self.config.load_checkpoint = self.path
+        self.config.model.pretrained_model_dir = self.pretrained_model_path
+        self.config.model.model_config.seq_length = self.max_seq_len
+        build_context(self.config)
+        build_parallel_config(self.config)
+
+    def _load_model(self, config, batch_size, max_seq_len):
+
+        self._set_config_from_yaml()
+        try:   
+            self.model = build_network(
+                config.model,
+                default_args={
+                "parallel_config": config.parallel_config,
+                "moe_config": config.moe_config
+            })
+            self.logger.info("..........Network Built Successfully..........")
+            self.model.set_train(False)
+            config.load_checkpoint = get_load_path_after_hf_convert(config, self.model)
+            self.logger.info(f"load checkpoint path : {config.load_checkpoint}")
+            run_mode = config.get("run_mode", None)
+            if run_mode == "predict":
+                self.model.load_weights(config.load_checkpoint)
+            else:
+                model = Model(self.model)
+                input_ids = Tensor(np.ones((batch_size, max_seq_len), dtype=np.int32))
+                infer_data = self.model.prepare_inputs_for_predict_layout(input_ids)
+                transform_and_load_checkpoint(config, model, self.model, infer_data, do_eval=True)
+
+            self.logger.info("..........Checkpoint Load Successfully..........")
+        except ValueError as e:
+            raise ValueError('Failed to load MindFormers model, please check configuration') from e
+
+
+    def generate(self,
+                 inputs: List[str],
+                 max_out_len: int,
+                 min_out_len: Optional[int] = None,
+                 stopping_criteria: List[str] = [],
+                 **kwargs) -> List[str]:
+        """Generate results given a list of inputs.
+
+        Args:
+            inputs (List[str]): A list of strings.
+            max_out_len (int): The maximum length of the output.
+            min_out_len (Optional[int]): The minimum length of the output.
+
+        Returns:
+            List[str]: A list of generated strings.
+        """
+        generation_kwargs = kwargs.copy()
+        generation_kwargs.update(self.generation_kwargs)
+        
+        messages = list(inputs)
+        batch_size = len(messages)
+        prompt_char_lens = None
+        
+        if self.extract_pred_after_decode:
+            prompt_char_lens = [len(text) for text in messages]
+
+        if self.use_fastchat_template:
+            try:
+                from fastchat.model import get_conversation_template
+            except ModuleNotFoundError:
+                raise ModuleNotFoundError(
+                    'Fastchat is not implemented. You can use '
+                    "'pip install \"fschat[model_worker,webui]\"' "
+                    'to implement fastchat.')
+            for idx, text in enumerate(messages):
+                conv = get_conversation_template('vicuna')
+                conv.append_message(conv.roles[0], text)
+                conv.append_message(conv.roles[1], None)
+                messages[idx] = conv.get_prompt()
+        if self.mode == 'mid':
+            assert len(messages) == 1
+            tokens = self.tokenizer(messages, padding=False, truncation=False, return_tensors='np')
+            input_ids = tokens['input_ids']
+            if input_ids.shape[-1] > self.max_seq_len:
+                input_ids = np.concatenate([input_ids[:, : self.max_seq_len // 2], input_ids[:, - self.max_seq_len // 2:]], axis=-1)
+            tokens = {'input_ids': input_ids}
+        else:
+            tokenize_kwargs = dict(
+                padding=True,
+                truncation=True,
+                max_length=self.max_seq_len,
+                return_tensors='np'
+            )
+            tokens = self.tokenizer(messages, **tokenize_kwargs)
+        
+        input_ids = tokens['input_ids']
+        if len(messages) > 1:
+            attention_mask = tokens.get('attention_mask')
+            prompt_token_lens = (
+                attention_mask.sum(axis=1).astype(int).tolist()
+                if attention_mask is not None else
+                [input_ids.shape[1]] * batch_size
+            )
+        else:
+            prompt_token_lens = [len(ids) for ids in input_ids]
+
+        input_ids_tensor = Tensor(input_ids)
+
+        if min_out_len is not None:
+            generation_kwargs['min_new_tokens'] = min_out_len
+        generation_kwargs['max_new_tokens'] = max_out_len
+        generation_kwargs.setdefault('top_k', 1)
+        generation_kwargs.setdefault('return_dict_in_generate', False)
+
+        origin_stopping_criteria = list(stopping_criteria)
+        if stopping_criteria:
+            if self.tokenizer.eos_token is not None:
+                stopping_criteria = stopping_criteria + [
+                    self.tokenizer.eos_token
+                ]
+            stopping_list = transformers.StoppingCriteriaList([
+                *[
+                    MultiTokenEOSCriteria(sequence, self.tokenizer,
+                                          input_ids_tensor.shape[0])
+                    for sequence in stopping_criteria
+                ],
+            ])
+            generation_kwargs['stopping_criteria'] = stopping_list
+        
+        generation_kwargs = drop_error_generation_kwargs(generation_kwargs)
+
+        outputs = self.model.generate(input_ids=input_ids_tensor,
+                                      **generation_kwargs)
+
+        if isinstance(outputs, dict):
+            outputs = outputs.get('sequences', outputs)
+            if outputs is None:
+                raise ValueError("Model output dictionary is missing 'sequence' key.")
+
+        sequences = [seq.tolist() for seq in outputs]
+
+        if not self.extract_pred_after_decode:
+            sequences = [
+                seq[prompt_len:]
+                for seq, prompt_len in zip(sequences, prompt_token_lens)
+            ]
+
+        decodeds = [
+            self.tokenizer.decode(seq, skip_special_tokens=True)
+            for seq in sequences
+        ]
+
+        if self.extract_pred_after_decode and prompt_char_lens is not None:
+            decodeds = [
+                text[length:]
+                for text, length in zip(decodeds, prompt_char_lens)
+            ]
+
+        if self.end_str:
+            decodeds = [text.split(self.end_str)[0] for text in decodeds]
+        if origin_stopping_criteria:
+            for token in origin_stopping_criteria:
+                decodeds = [text.split(token)[0] for text in decodeds]
+        return decodeds

--- a/ais_bench/benchmark/models/local_models/mindformers_model.py
+++ b/ais_bench/benchmark/models/local_models/mindformers_model.py
@@ -55,6 +55,8 @@ def drop_error_generation_kwargs(generation_kwargs: dict) -> dict:
 @MODELS.register_module()
 class MindFormerModel(BaseModel):
 
+    launcher: str = "msrun"
+
     def __init__(self,
                  path: str,
                  checkpoint: Optional[str] = None,

--- a/ais_bench/benchmark/tasks/openicl_infer.py
+++ b/ais_bench/benchmark/tasks/openicl_infer.py
@@ -5,14 +5,14 @@ import random
 import threading
 import sys
 import time
-from typing import Any
+from typing import Any, Callable, Dict
 
 from mmengine.config import Config, ConfigDict
 from mmengine.utils import mkdir_or_exist
 
 from ais_bench.benchmark.registry import (ICL_INFERENCERS, ICL_RETRIEVERS, TASKS)
 from ais_bench.benchmark.tasks.base import BaseTask
-from ais_bench.benchmark.utils.config import build_dataset_from_cfg
+from ais_bench.benchmark.utils.config import build_dataset_from_cfg, get_model_cls_from_cfg
 from ais_bench.benchmark.utils.core.abbr import task_abbr_from_cfg, model_abbr_from_cfg
 from ais_bench.benchmark.tasks.base import TaskStateManager
 from ais_bench.benchmark.utils.logging import AISLogger
@@ -21,6 +21,51 @@ from ais_bench.benchmark.utils.logging.error_codes import TINFER_CODES
 from ais_bench.benchmark.utils.logging.exceptions import ParameterValueError
 from ais_bench.benchmark.openicl.icl_inferencer.icl_base_local_inferencer import BaseLocalInferencer
 
+
+def _build_msrun_cmd(ctx: Dict[str, Any]) -> str:
+    """Build msrun command from context dict."""
+    parts = [
+        "msrun",
+        f"--worker_num={ctx['worker_num']}",
+        f"--local_worker_num={ctx['local_worker_num']}",
+        f"--master_port={ctx['port']}",
+    ]
+    if ctx.get("master_addr") is not None and ctx.get("node_rank") is not None:
+        parts.extend([
+            f"--master_addr={ctx['master_addr']}",
+            f"--node_rank={ctx['node_rank']}",
+        ])
+    parts.extend([
+        "--log_dir='output/msrun_log'",
+        "--join=True",
+        "--cluster_time_out=7200",
+        ctx["script_path"],
+        ctx["cfg_path"],
+    ])
+    return " ".join(parts)
+
+
+def _build_torchrun_cmd(ctx: Dict[str, Any]) -> str:
+    """Build torchrun command from context dict."""
+    parts = [
+        "torchrun",
+        f"--master_port={ctx['port']}",
+        f"--nproc_per_node {ctx['nproc_per_node']}",
+    ]
+    if ctx.get("nnodes", 1) > 1:
+        parts.extend([
+            f"--nnodes {ctx['nnodes']}",
+            f"--node_rank {ctx['node_rank']}",
+            f"--master_addr {ctx['master_addr']}",
+        ])
+    parts.extend([ctx["script_path"], ctx["cfg_path"]])
+    return " ".join(parts)
+
+
+LAUNCHER_CMD_BUILDERS: Dict[str, Callable[[Dict[str, Any]], str]] = {
+    "msrun": _build_msrun_cmd,
+    "torchrun": _build_torchrun_cmd,
+}
 
 
 @TASKS.register_module()
@@ -43,7 +88,6 @@ class OpenICLInferTask(BaseTask):
         self.node_rank = run_cfg.get('node_rank', 0)
         self.master_addr = run_cfg.get('master_addr', "localhost")
         self.logger.debug(f"Local infer task config: {run_cfg}")
-        self.abbr = self.model_cfg.get('abbr', '')
 
     def get_command(self, cfg_path, template):
         """Get the command template for the task.
@@ -60,45 +104,36 @@ class OpenICLInferTask(BaseTask):
             key in str(self.model_cfg.get('type', ''))
             or key in str(self.model_cfg.get('llm', {}).get('type', ''))
             for key in backend_keys)
+        model_cls = get_model_cls_from_cfg(self.model_cfg)
+        launcher = getattr(model_cls, 'launcher', 'torchrun') if model_cls else 'torchrun'
         if self.num_gpus > 1 and not use_backend and self.nnodes == 1:
-            port = random.randint(12000, 32000)
-            if self.abbr == 'mindformer-model':
-                command = (
-                    f"msrun "
-                    f"--worker_num={self.num_gpus} "
-                    f"--local_worker_num={self.num_gpus} "
-                    f"--master_port={port} "
-                    f"--log_dir='output/msrun_log' "
-                    f"--join=True "
-                    f"--cluster_time_out=7200 "
-                    f'{script_path} {cfg_path}'
-                )
-            else :
-                command = (f'torchrun --master_port={port} '
-                           f'--nproc_per_node {self.num_procs} '
-                           f'{script_path} {cfg_path}')
+            ctx = dict(
+                port=random.randint(12000, 32000),
+                script_path=script_path,
+                cfg_path=cfg_path,
+                worker_num=self.num_gpus,
+                local_worker_num=self.num_gpus,
+                nproc_per_node=self.num_procs,
+                nnodes=1,
+                master_addr=None,
+                node_rank=None,
+            )
+            builder = LAUNCHER_CMD_BUILDERS.get(launcher, LAUNCHER_CMD_BUILDERS["torchrun"])
+            command = builder(ctx)
         elif self.nnodes > 1:
-            port = 12345
-            if self.abbr == "mindformer-model" :
-                command = (
-                    f"msrun "
-                    f"--worker_num={self.nnodes*self.num_procs} "
-                    f"--local_worker_num={self.num_procs} "
-                    f"--master_port={port} "
-                    f"--master_addr={self.master_addr} "
-                    f"--node_rank={self.node_rank} "
-                    f"--log_dir='output/msrun_log' "
-                    f"--join=True "
-                    f"--cluster_time_out=7200 "
-                    f'{script_path} {cfg_path}'
-                )
-            else :
-                command = (f'torchrun --master_port={port} '
-                       f'--nproc_per_node {self.num_procs} '
-                       f'--nnodes {self.nnodes} '
-                       f'--node_rank {self.node_rank} '
-                       f'--master_addr {self.master_addr} '
-                       f'{script_path} {cfg_path}')
+            ctx = dict(
+                port=12345,
+                script_path=script_path,
+                cfg_path=cfg_path,
+                worker_num=self.nnodes * self.num_procs,
+                local_worker_num=self.num_procs,
+                nproc_per_node=self.num_procs,
+                nnodes=self.nnodes,
+                master_addr=self.master_addr,
+                node_rank=self.node_rank,
+            )
+            builder = LAUNCHER_CMD_BUILDERS.get(launcher, LAUNCHER_CMD_BUILDERS["torchrun"])
+            command = builder(ctx)
         else:
             python = sys.executable
             command = f'{python} {script_path} {cfg_path}'

--- a/ais_bench/benchmark/utils/config/build.py
+++ b/ais_bench/benchmark/utils/config/build.py
@@ -135,15 +135,18 @@ def build_model_from_cfg(model_cfg: ConfigDict):
     model_cfg.pop("use_timestamp", None)
     model_cfg.pop("run_cfg", None)
     model_cfg.pop("request_rate", None)
-    model_cfg.pop("batch_size", None)
-    model_cfg.pop("abbr", None)
-    model_cfg.pop("attr", None)
+    batch_size = model_cfg.pop("batch_size", None)
+    abbr = model_cfg.pop("abbr", None)
+    attr = model_cfg.pop("attr", None)
     model_cfg.pop("summarizer_abbr", None)
     model_cfg.pop("pred_postprocessor", None)
     model_cfg.pop("min_out_len", None)
     model_cfg.pop("returns_tool_calls", None)
     model_cfg.pop("traffic_cfg", None)
-    return MODELS.build(model_cfg)
+    if attr == "local" and abbr == "mindformer-model" :
+        return MODELS.build(model_cfg, batch_size = batch_size)
+    else :
+        return MODELS.build(model_cfg)
 
 def build_perf_metric_calculator_from_cfg(metric_cfg: ConfigDict):
     logger.debug(f"Building perf metric calculator config: type={metric_cfg.get('type')}")

--- a/ais_bench/benchmark/utils/config/build.py
+++ b/ais_bench/benchmark/utils/config/build.py
@@ -162,7 +162,7 @@ def build_model_from_cfg(model_cfg: ConfigDict):
     model_cfg.pop("use_timestamp", None)
     model_cfg.pop("run_cfg", None)
     model_cfg.pop("request_rate", None)
-    batch_size = model_cfg.pop("batch_size", None)
+    model_cfg.pop("batch_size", None)
     model_cfg.pop("abbr", None)
     model_cfg.pop("attr", None)
     model_cfg.pop("summarizer_abbr", None)


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [x] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)

## 🔍 Motivation / 变更动机

Please describe the motivation of this PR and the goal you want to achieve through this PR.
请描述您的拉取请求的动机和您希望通过此拉取请求实现的目标。

当前 AISBench 评测工具暂不支持直接加载 MindFormers 训练生成的模型权重进行离线评测，因此需要在 AISBench 侧对 MindFormers/MindSpore 模型进行统一封装适配，以实现兼容评测.

目标：创建 MindFormers 框架的模型加载脚本与对应的aisbench配置文件，令aisbench可通过对应**命令**调用mindformers模型权重进行测评：

` ais_bench --models mf_model --datasets 评测任务`

## 📝 Modifica
tion / 修改内容

Please briefly describe what modification is made in this PR.
请简要描述此拉取请求中进行的修改。

- 1）**增加配置文件:`ais_bench\benchmark\configs\models\mf_models\mindformers_model.py`**

  在Aisbench工具的config文件中，通过设置 `type: MindFormerModel` 来选择mindformers的模型。与HF离线模型配置的差别如下:

  ```
   type=MindFormerModel, 
   abbr='mindformer-model'
   yaml_cfg_path = 'THUDM/your.yaml',	#path to mindformers yaml file, current value is just a example
  ```

  注意:yaml_cfg_path为新增配置,用来指示yaml配置路径。

  2）**增加模型封装文件:`ais_bench/benchmark/ais_bench/benchmark/models/mindformers_model.py`,**

  主要包含：model build ：load_tokenizer、load_model、load_checkpoint。generete调用接口：主要集成mindformers的text_generete的调用，以及部分后处理

  - 利用aisbench的工厂机制,通过 `@MODELS.register_module()`,将mindformers的模型封装类注册进去,

  3）修改aisbench runner 中的逻辑，适配inference任务的subprocess调用的命令，在运行mindformer_model时，**使用msrun代替torchrun**

  ```
  if self.abbr == 'mindformer-model':
      command = (
          f"msrun "
          f"--worker_num={self.num_gpus} "
          f"--local_worker_num={self.node_gpus} "
          f"--master_port={port} "
          f"--log_dir='output/msrun_log' "
          f"--join=True "
          f'{script_path} {cfg_path}'
      )
  else :
      command = (f'torchrun --master_port={port} '
                 f'--nproc_per_node {self.num_procs} '
                 f'{script_path} {cfg_path}')
  ```


## 📐 Associated Test Results / 关联测试结果

Please provide links to the related test results, such as CI pipelines, test reports, etc.
请提供相关测试结果的链接，例如 CI 管道、测试报告等。

Aisbench demo执行结果

黑盒验证：HuggingFace权重转换成minfformers权重，mindformers加载转换后的权重和huggingface流程加载转换前权重得到的评分相同
相同权重经过HuggingFaceModel和MindFormerModel模型进行评测的结果，误差控制在1%内：

Qwen3_0.6B Ceval评分 （**单卡**）

| 评测项目             | MindFormerModel得分 | HuggingFaceModel得分 |
| -------------------- | ------------------- | -------------------- |
| ceval-stem           | 44.27               | 44.58                |
| ceval-social-science | 55.83               | 56.34                |
| ceval-humanities     | 50.72               | 48.74                |
| ceval-other          | 50.30               | 50.49                |
| ceval-hard           | 39.59               | 40.37                |
| ceval                | 49.13               | 48.97                |
| ceval-weighted       | 48.96               | 48.74                |

Qwen3-30B-A3B MMLU得分（**多卡**）

| 评测项目            | MindFormerModel得分 | HuggingFaceModel得分 |
| ------------------- | ------------------- | -------------------- |
| mmlu-humanities     | 79.89               | 80.16                |
| mmlu-stem           | 78.47               | 77.51                |
| mmlu-social-science | 86.15               | 86.32                |
| mmlu-other          | 79.40               | 79.63                |
| mmlu                | 80.62               | 80.86                |
| mmlu-weighted       | 79.19               | 78.99                |



## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
