### PR TITLE
【TEST】补充math和agieval数据集的冒烟用例

### DIFF
--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/ais_bench_configs/datasets/agieval/accuracy_agieval.py
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/ais_bench_configs/datasets/agieval/accuracy_agieval.py
@@ -1,0 +1,11 @@
+from mmengine import read_base
+
+with read_base():
+    from .agieval_gen_0_shot_chat_prompt import agieval_datasets
+
+# 冒烟：仅取一个子集、小样本
+agieval_datasets = agieval_datasets[:1]
+agieval_datasets[0]['reader_cfg'] = dict(
+    agieval_datasets[0]['reader_cfg'],
+    test_range='[0:10]',
+)

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/ais_bench_configs/models/vllm_api/accuracy_agieval.py
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/ais_bench_configs/models/vllm_api/accuracy_agieval.py
@@ -1,0 +1,8 @@
+from mmengine import read_base
+
+with read_base():
+    from .vllm_api_general_chat import models
+
+models[0]['model'] = "qwen"
+models[0]['max_out_len'] = 64
+models[0]['batch_size'] = 16

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/case.yml
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/case.yml
@@ -1,0 +1,13 @@
+case_type: benchmark
+case_group:
+  - run_server_accuracy
+  - llm_datasets_main
+  - short
+  - refactor_success_1202
+case_name: accuracy_agieval # 在整个工程的case中必须唯一
+enable: y
+script:
+  start: run.sh
+  end: clean.sh
+timeout: 90
+rank_size: 3

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/clean.sh
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+CUR_DIR=$(dirname $(readlink -f $0))
+[ -f "${CUR_DIR}/tmplog.txt" ] && rm -f "${CUR_DIR}/tmplog.txt"
+exit 0

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/run.sh
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/run.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+declare -i ret_ok=0
+declare -i ret_failed=1
+
+CUR_DIR=$(dirname $(readlink -f $0))
+CASE_NAME=$(basename "$CUR_DIR")
+LAST_3_DIRNAME=$(echo  $CUR_DIR | rev | cut -d'/' -f1-3 | rev)
+CASE_OUTPUT_PATH=${PROJECT_OUTPUT_PATH}/${LAST_3_DIRNAME}
+AIS_BENCH_CODE_CONFIGS_DIR=${PROJECT_PATH}/../ais_bench/benchmark/configs
+CONFIG_DATASET_NAME="agieval"
+# 冒烟仅跑一个子集，输出名为该子集 abbr（agieval-gaokao-chinese）
+OUTPUT_DATASET_NAME="agieval-gaokao-chinese"
+CURR_API="vllm-api-general-chat"
+
+if [ ! -d ${CASE_OUTPUT_PATH} ];then
+    mkdir -p ${CASE_OUTPUT_PATH}
+fi
+rm -rf ${CASE_OUTPUT_PATH}/*
+
+echo "Copying config files..."
+cp -r ${CUR_DIR}/ais_bench_configs/* ${AIS_BENCH_CODE_CONFIGS_DIR}/
+
+{
+    echo ""
+    echo "models[0]['host_ip'] = '${AISBENCH_SMOKE_SERVICE_IP}'"
+    echo "models[0]['host_port'] = ${AISBENCH_SMOKE_SERVICE_PORT}"
+    echo "models[0]['path'] = '${AISBENCH_SMOKE_MODEL_PATH}'"
+} >> "${AIS_BENCH_CODE_CONFIGS_DIR}/models/vllm_api/${CASE_NAME}.py"
+
+echo -e "\033[1;32m[1/1]\033[0m Test case - ${CASE_NAME}"
+
+set -o pipefail
+ais_bench --models ${CASE_NAME} --datasets ${CASE_NAME} --work-dir ${CASE_OUTPUT_PATH} 2>&1 | tee ${CUR_DIR}/tmplog.txt
+if [ $? -ne 0 ]
+then
+    echo "Run $CASE_NAME test: Failed"
+    exit $ret_failed
+fi
+echo "Run $CASE_NAME test: Success"
+
+WORK_DIR_INFO=$(cat ${CUR_DIR}/tmplog.txt | grep 'Current exp folder: ')
+TIMESTAMP="${WORK_DIR_INFO##*/}"
+
+CURR_OUTPUT_PATH=${CASE_OUTPUT_PATH}/${TIMESTAMP}
+LOG_EVAL_OUTPUT_PATH=${CURR_OUTPUT_PATH}/logs/eval/${CURR_API}/${OUTPUT_DATASET_NAME}.out
+LOG_INFER_OUTPUT_PATH=${CURR_OUTPUT_PATH}/logs/infer/${CURR_API}/${OUTPUT_DATASET_NAME}.out
+PREDICTIONS_OUTPUT_PATH=${CURR_OUTPUT_PATH}/predictions/${CURR_API}/${OUTPUT_DATASET_NAME}.jsonl
+RESULTS_OUTPUT_PATH=${CURR_OUTPUT_PATH}/results/${CURR_API}/${OUTPUT_DATASET_NAME}.json
+SUMMARY_OUTPUT_PATH=${CURR_OUTPUT_PATH}/summary/summary_${TIMESTAMP}.csv
+
+if [ ! -f "$LOG_EVAL_OUTPUT_PATH" ];then
+    echo "Can't find $LOG_EVAL_OUTPUT_PATH"
+    exit $ret_failed
+fi
+if [ ! -f "$LOG_INFER_OUTPUT_PATH" ];then
+    echo "Can't find $LOG_INFER_OUTPUT_PATH"
+    exit $ret_failed
+fi
+if [ ! -f "$PREDICTIONS_OUTPUT_PATH" ];then
+    echo "Can't find $PREDICTIONS_OUTPUT_PATH"
+    exit $ret_failed
+fi
+if [ ! -f "$RESULTS_OUTPUT_PATH" ];then
+    echo "Can't find $RESULTS_OUTPUT_PATH"
+    exit $ret_failed
+fi
+if [ ! -f "$SUMMARY_OUTPUT_PATH" ];then
+    echo "Can't find $SUMMARY_OUTPUT_PATH"
+    exit $ret_failed
+fi
+
+exit $ret_ok

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/ais_bench_configs/datasets/math/accuracy_math.py
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/ais_bench_configs/datasets/math/accuracy_math.py
@@ -1,0 +1,10 @@
+from mmengine import read_base
+
+with read_base():
+    from .math_prm800k_500_0shot_cot_gen import math_datasets
+
+# 冒烟：小样本
+math_datasets[0]['reader_cfg'] = dict(
+    math_datasets[0]['reader_cfg'],
+    test_range='[0:10]',
+)

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/ais_bench_configs/models/vllm_api/accuracy_math.py
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/ais_bench_configs/models/vllm_api/accuracy_math.py
@@ -1,0 +1,8 @@
+from mmengine import read_base
+
+with read_base():
+    from .vllm_api_general_chat import models
+
+models[0]['model'] = "qwen"
+models[0]['max_out_len'] = 512
+models[0]['batch_size'] = 8

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/case.yml
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/case.yml
@@ -1,0 +1,13 @@
+case_type: benchmark
+case_group:
+  - run_server_accuracy
+  - llm_datasets_main
+  - short
+  - refactor_success_1202
+case_name: accuracy_math # 在整个工程的case中必须唯一
+enable: y
+script:
+  start: run.sh
+  end: clean.sh
+timeout: 90
+rank_size: 3

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/clean.sh
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+CUR_DIR=$(dirname $(readlink -f $0))
+[ -f "${CUR_DIR}/tmplog.txt" ] && rm -f "${CUR_DIR}/tmplog.txt"
+exit 0

--- a/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/run.sh
+++ b/smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_math/run.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+declare -i ret_ok=0
+declare -i ret_failed=1
+
+CUR_DIR=$(dirname $(readlink -f $0))
+CASE_NAME=$(basename "$CUR_DIR")
+LAST_3_DIRNAME=$(echo  $CUR_DIR | rev | cut -d'/' -f1-3 | rev)
+CASE_OUTPUT_PATH=${PROJECT_OUTPUT_PATH}/${LAST_3_DIRNAME}
+AIS_BENCH_CODE_CONFIGS_DIR=${PROJECT_PATH}/../ais_bench/benchmark/configs
+CONFIG_DATASET_NAME="math"
+OUTPUT_DATASET_NAME="math_prm800k_500"
+CURR_API="vllm-api-general-chat"
+
+if [ ! -d ${CASE_OUTPUT_PATH} ];then
+    mkdir -p ${CASE_OUTPUT_PATH}
+fi
+rm -rf ${CASE_OUTPUT_PATH}/*
+
+echo "Copying config files..."
+cp -r ${CUR_DIR}/ais_bench_configs/* ${AIS_BENCH_CODE_CONFIGS_DIR}/
+
+{
+    echo ""
+    echo "models[0]['host_ip'] = '${AISBENCH_SMOKE_SERVICE_IP}'"
+    echo "models[0]['host_port'] = ${AISBENCH_SMOKE_SERVICE_PORT}"
+    echo "models[0]['path'] = '${AISBENCH_SMOKE_MODEL_PATH}'"
+} >> "${AIS_BENCH_CODE_CONFIGS_DIR}/models/vllm_api/${CASE_NAME}.py"
+
+echo -e "\033[1;32m[1/1]\033[0m Test case - ${CASE_NAME}"
+
+set -o pipefail
+ais_bench --models ${CASE_NAME} --datasets ${CASE_NAME} --work-dir ${CASE_OUTPUT_PATH} 2>&1 | tee ${CUR_DIR}/tmplog.txt
+if [ $? -ne 0 ]
+then
+    echo "Run $CASE_NAME test: Failed"
+    exit $ret_failed
+fi
+echo "Run $CASE_NAME test: Success"
+
+WORK_DIR_INFO=$(cat ${CUR_DIR}/tmplog.txt | grep 'Current exp folder: ')
+TIMESTAMP="${WORK_DIR_INFO##*/}"
+
+CURR_OUTPUT_PATH=${CASE_OUTPUT_PATH}/${TIMESTAMP}
+LOG_EVAL_OUTPUT_PATH=${CURR_OUTPUT_PATH}/logs/eval/${CURR_API}/${OUTPUT_DATASET_NAME}.out
+LOG_INFER_OUTPUT_PATH=${CURR_OUTPUT_PATH}/logs/infer/${CURR_API}/${OUTPUT_DATASET_NAME}.out
+PREDICTIONS_OUTPUT_PATH=${CURR_OUTPUT_PATH}/predictions/${CURR_API}/${OUTPUT_DATASET_NAME}.jsonl
+RESULTS_OUTPUT_PATH=${CURR_OUTPUT_PATH}/results/${CURR_API}/${OUTPUT_DATASET_NAME}.json
+SUMMARY_OUTPUT_PATH=${CURR_OUTPUT_PATH}/summary/summary_${TIMESTAMP}.csv
+
+if [ ! -f "$LOG_EVAL_OUTPUT_PATH" ];then
+    echo "Can't find $LOG_EVAL_OUTPUT_PATH"
+    exit $ret_failed
+fi
+if [ ! -f "$LOG_INFER_OUTPUT_PATH" ];then
+    echo "Can't find $LOG_INFER_OUTPUT_PATH"
+    exit $ret_failed
+fi
+if [ ! -f "$PREDICTIONS_OUTPUT_PATH" ];then
+    echo "Can't find $PREDICTIONS_OUTPUT_PATH"
+    exit $ret_failed
+fi
+if [ ! -f "$RESULTS_OUTPUT_PATH" ];then
+    echo "Can't find $RESULTS_OUTPUT_PATH"
+    exit $ret_failed
+fi
+if [ ! -f "$SUMMARY_OUTPUT_PATH" ];then
+    echo "Can't find $SUMMARY_OUTPUT_PATH"
+    exit $ret_failed
+fi
+
+exit $ret_ok


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [x] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)

## 🔍 Motivation / 变更动机

为 agieval、math 两个精度评测场景补充 smoke test，便于在 CI 中快速回归 run_server_accuracy / llm_datasets_main 流程，验证配置与环境正确性。
Add smoke tests for agieval and math accuracy evaluation scenarios to enable quick regression of run_server_accuracy / llm_datasets_main in CI and verify config and environment.

## 📝 Modification / 修改内容

- **新增 2 个 smoke test case**：
  - `accuracy_agieval`：agieval 数据集（冒烟仅跑子集 agieval-gaokao-chinese），vllm-api-general-chat。
  - `accuracy_math`：math 数据集（子集 math_prm800k_500），vllm-api-general-chat。
- **每个 case 包含**：`case.yml`、`run.sh`、`clean.sh`，以及 `ais_bench_configs/` 下 datasets、models（vllm_api）配置；目录分别为 `smoke_tests/test-case/run_server_accuracy/llm_datasets_main/accuracy_agieval/` 与 `accuracy_math/`。
- **配置来源**：case 内复制的 config 来自 `ais_bench/benchmark/configs/datasets/` 与 `ais_bench/benchmark/configs/models/` 的现有配置，本次为拷贝到 smoke 用例目录并接好 run/clean，无修改既有业务逻辑。
- 共 10 个文件变更，+214 行。

## 📐 Associated Test Results / 关联测试结果

待 CI 运行后补充。 / To be added after CI run.

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

无。仅新增 smoke test 用例，不涉及下游兼容性。 / None. New smoke test cases only; no downstream compatibility impact.

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

无。 / None.

## 🌟 Use cases (Optional) / 使用案例（可选）

<img width="1447" height="713" alt="image" src="https://github.com/user-attachments/assets/f2896208-749b-438b-954e-fdb2e8d8c153" />



## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
