### PR TITLE
Fix the issue where TTFT and TPOT have no data when running Kimi2.5 i…

### DIFF
--- a/ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py
+++ b/ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py
@@ -141,8 +141,8 @@ class VLLMCustomAPIChat(BaseAPIModel):
         for item in json_content.get("choices", []):
             if item["delta"].get("content"):
                 output.content += item["delta"]["content"]
-            if item["delta"].get("reasoning_content") or item["delta"].get("reasoning"):
-                output.reasoning_content += item["delta"].get("reasoning_content") or item["delta"].get("reasoning")
+            if reasoning := item["delta"].get("reasoning_content") or item["delta"].get("reasoning"):
+                output.reasoning_content += reasoning
         await self._parse_usage(json_content, output)
 
     async def parse_text_response(self, json_content, output):


### PR DESCRIPTION
…n a PD separation scenario.

Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [1] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
无

## 🔍 Motivation / 变更动机
Fix the issue where TTFT and TPOT have no data when running Kimi2.5 on PD separation scenario
修复AIS_BENCH在跑kimi2.5 PD分离场景下，TTFT和TPOT没有数据的问题。

## 📝 Modification / 修改内容
ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py文件中

1、函数async def parse_stream_response(self, json_content, output):
修改前：
            if item["delta"].get("reasoning_content"):
                output.reasoning_content += item["delta"]["reasoning_content"]
修改后支持kimi2.5类型：
            if item["delta"].get("reasoning_content") or item["delta"].get("reasoning"):
                output.reasoning_content += item["delta"].get("reasoning_content") or item["delta"].get("reasoning")
2、函数async def parse_text_response(self, json_content, output):
修改前：
            if reasoning_content:=item["message"].get("reasoning_content"):
修改后支持kimi2.5类型：
            if reasoning_content:=item["message"].get("reasoning_content") or item["message"].get("reasoning"):

## 📐 Associated Test Results / 关联测试结果

在Kimi2.5测试可以通过

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
