### PR TITLE
[bugfix] Add postprocessor to extract last option for MMMU datasets

### DIFF
--- a/ais_bench/benchmark/configs/datasets/mmmu/mmmu_gen.py
+++ b/ais_bench/benchmark/configs/datasets/mmmu/mmmu_gen.py
@@ -2,6 +2,7 @@ from ais_bench.benchmark.openicl.icl_prompt_template.icl_prompt_template_mm impo
 from ais_bench.benchmark.openicl.icl_retriever import ZeroRetriever
 from ais_bench.benchmark.openicl.icl_inferencer import GenInferencer
 from ais_bench.benchmark.datasets import MMMUDataset, MMMUEvaluator
+from ais_bench.benchmark.utils.postprocess.text_postprocessors import last_option_postprocess
 
 
 START_TEXT_PROMPT = "Question: "
@@ -30,7 +31,8 @@ mmmu_infer_cfg = dict(
 )
 
 mmmu_eval_cfg = dict(
-    evaluator=dict(type=MMMUEvaluator)
+    evaluator=dict(type=MMMUEvaluator),
+    pred_postprocessor=dict(type=last_option_postprocess, options="ABCD"),
 )
 
 mmmu_datasets = [

--- a/ais_bench/benchmark/configs/datasets/mmmu/mmmu_gen_cot.py
+++ b/ais_bench/benchmark/configs/datasets/mmmu/mmmu_gen_cot.py
@@ -2,6 +2,7 @@ from ais_bench.benchmark.openicl.icl_prompt_template.icl_prompt_template_mm impo
 from ais_bench.benchmark.openicl.icl_retriever import ZeroRetriever
 from ais_bench.benchmark.openicl.icl_inferencer import GenInferencer
 from ais_bench.benchmark.datasets import MMMUDataset, MMMUEvaluator
+from ais_bench.benchmark.utils.postprocess.text_postprocessors import last_option_postprocess
 
 
 START_TEXT_PROMPT = "Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\n\n"
@@ -30,7 +31,8 @@ mmmu_infer_cfg = dict(
 )
 
 mmmu_eval_cfg = dict(
-    evaluator=dict(type=MMMUEvaluator)
+    evaluator=dict(type=MMMUEvaluator),
+    pred_postprocessor=dict(type=last_option_postprocess, options="ABCD"),
 )
 
 mmmu_datasets = [

--- a/ais_bench/benchmark/configs/datasets/mmmu_pro/mmmu_pro_options10_cot_gen.py
+++ b/ais_bench/benchmark/configs/datasets/mmmu_pro/mmmu_pro_options10_cot_gen.py
@@ -2,6 +2,7 @@ from ais_bench.benchmark.openicl.icl_prompt_template.icl_prompt_template_mm impo
 from ais_bench.benchmark.openicl.icl_retriever import ZeroRetriever
 from ais_bench.benchmark.openicl.icl_inferencer import GenInferencer
 from ais_bench.benchmark.datasets import MMMUProOptions10Dataset, MMMUProCotEvaluator
+from ais_bench.benchmark.utils.postprocess.text_postprocessors import last_option_postprocess
 
 
 mmmu_pro_reader_cfg = dict(
@@ -26,7 +27,8 @@ mmmu_pro_infer_cfg = dict(
 )
 
 mmmu_pro_eval_cfg = dict(
-    evaluator=dict(type=MMMUProCotEvaluator)
+    evaluator=dict(type=MMMUProCotEvaluator),
+    pred_postprocessor=dict(type=last_option_postprocess, options="ABCDEFGHIJ"),
 )
 
 mmmu_pro_datasets = [

--- a/ais_bench/benchmark/configs/datasets/mmmu_pro/mmmu_pro_options10_gen.py
+++ b/ais_bench/benchmark/configs/datasets/mmmu_pro/mmmu_pro_options10_gen.py
@@ -2,6 +2,7 @@ from ais_bench.benchmark.openicl.icl_prompt_template.icl_prompt_template_mm impo
 from ais_bench.benchmark.openicl.icl_retriever import ZeroRetriever
 from ais_bench.benchmark.openicl.icl_inferencer import GenInferencer
 from ais_bench.benchmark.datasets import MMMUProOptions10Dataset, MMMUProEvaluator
+from ais_bench.benchmark.utils.postprocess.text_postprocessors import last_option_postprocess
 
 
 mmmu_pro_reader_cfg = dict(
@@ -26,7 +27,8 @@ mmmu_pro_infer_cfg = dict(
 )
 
 mmmu_pro_eval_cfg = dict(
-    evaluator=dict(type=MMMUProEvaluator)
+    evaluator=dict(type=MMMUProEvaluator),
+    pred_postprocessor=dict(type=last_option_postprocess, options="ABCDEFGHIJ"),
 )
 
 mmmu_pro_datasets = [

--- a/ais_bench/benchmark/configs/datasets/mmmu_pro/mmmu_pro_vision_cot_gen.py
+++ b/ais_bench/benchmark/configs/datasets/mmmu_pro/mmmu_pro_vision_cot_gen.py
@@ -2,6 +2,7 @@ from ais_bench.benchmark.openicl.icl_prompt_template.icl_prompt_template_mm impo
 from ais_bench.benchmark.openicl.icl_retriever import ZeroRetriever
 from ais_bench.benchmark.openicl.icl_inferencer import GenInferencer
 from ais_bench.benchmark.datasets import MMMUProVisionDataset, MMMUProCotEvaluator
+from ais_bench.benchmark.utils.postprocess.text_postprocessors import last_option_postprocess
 
 
 mmmu_pro_reader_cfg = dict(
@@ -26,7 +27,8 @@ mmmu_pro_infer_cfg = dict(
 )
 
 mmmu_pro_eval_cfg = dict(
-    evaluator=dict(type=MMMUProCotEvaluator)
+    evaluator=dict(type=MMMUProCotEvaluator),
+    pred_postprocessor=dict(type=last_option_postprocess, options="ABCDEFGHIJ"),
 )
 
 mmmu_pro_datasets = [

--- a/ais_bench/benchmark/configs/datasets/mmmu_pro/mmmu_pro_vision_gen.py
+++ b/ais_bench/benchmark/configs/datasets/mmmu_pro/mmmu_pro_vision_gen.py
@@ -2,6 +2,7 @@ from ais_bench.benchmark.openicl.icl_prompt_template.icl_prompt_template_mm impo
 from ais_bench.benchmark.openicl.icl_retriever import ZeroRetriever
 from ais_bench.benchmark.openicl.icl_inferencer import GenInferencer
 from ais_bench.benchmark.datasets import MMMUProVisionDataset, MMMUProEvaluator
+from ais_bench.benchmark.utils.postprocess.text_postprocessors import last_option_postprocess
 
 
 mmmu_pro_reader_cfg = dict(
@@ -26,7 +27,8 @@ mmmu_pro_infer_cfg = dict(
 )
 
 mmmu_pro_eval_cfg = dict(
-    evaluator=dict(type=MMMUProEvaluator)
+    evaluator=dict(type=MMMUProEvaluator),
+    pred_postprocessor=dict(type=last_option_postprocess, options="ABCDEFGHIJ"),
 )
 
 mmmu_pro_datasets = [


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [x] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Relates to #224 

## 🔍 Motivation / 变更动机

Previously, when benchmarking accuracy with the MMMU dataset, the postprocessing of the original predictions from models is missing/incorrect. The postprocessed predictions were the same as the original predictions. Therefore, even if the model outputs the correct answer, the evaluation process still count it as incorrect, resulting in a low accuracy score. For example,

```json
"0": {
            "prompt": [
                {
                    "role": "HUMAN",
                    "prompt": [
                        {
                            "text": "Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\n\nEach of the following situations relates to a different company. ",
                            "type": "text"
                        },
                        {
                            "image_url": {
                                "url": "file://{project_root}/ais_bench/datasets/mmmu/MMMU_images/1_1.jpg"
                            },
                            "type": "image_url"
                        },
                        {
                            "text": " For company B, find the missing amounts.A. $63,020\nB. $58,410\nC. $71,320\nD. $77,490\n",
                            "type": "text"
                        }
                    ]
                }
            ],
            "origin_prediction": "Let's solve this step by step.\n\n......\n\nANSWER: D",
            "predictions": [
                "Let's solve this step by step.\n\n......\n\nANSWER: D"
            ],
            "references": [
                {
                    "answer": "D",
                    "category": "Business",
                    "choices": "{\"A\": \"$63,020\", \"B\": \"$58,410\", \"C\": \"$71,320\", \"D\": \"$77,490\"}",
                    "l2-category": "Accounting",
                    "split": "dev"
                }
            ],
            "correct": [
                false
            ]
        }
```

## 📝 Modification / 修改内容

This PR adds a `pred_postprocessor` to the MMMU-related evaluation configurations.

## 📐 Associated Test Results / 关联测试结果

Instead of showing the original predictions, the postprocessed predictions is showing a single choice letter:

```json
"0": {
            "prompt": [
                {
                    "role": "HUMAN",
                    "prompt": [
                        {
                            "text": "Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: [LETTER]' (without quotes) where [LETTER] is one of A,B,C,D. Think step by step before answering.\n\nEach of the following situations relates to a different company. ",
                            "type": "text"
                        },
                        {
                            "image_url": {
                                "url": "file://{project_root}/ais_bench/datasets/mmmu/MMMU_images/1_1.jpg"
                            },
                            "type": "image_url"
                        },
                        {
                            "text": " For company B, find the missing amounts.A. $63,020\nB. $58,410\nC. $71,320\nD. $77,490\n",
                            "type": "text"
                        }
                    ]
                }
            ],
            "origin_prediction": "Let's solve this step by step.\n\n......\n\nANSWER: D",
            "predictions": [
                "D"
            ],
            "references": [
                {
                    "answer": "D",
                    "category": "Business",
                    "choices": "{\"A\": \"$63,020\", \"B\": \"$58,410\", \"C\": \"$71,320\", \"D\": \"$77,490\"}",
                    "l2-category": "Accounting",
                    "split": "dev"
                }
            ],
            "correct": [
                true
            ]
        }
```

## ✅ Checklist / 检查列表

**Before PR**:

- [X] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [X] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [X] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [X] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [X] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。