### PR TITLE
Fix max_out_len handling for multi-turn ShareGPT conversations

### DIFF
--- a/ais_bench/benchmark/configs/datasets/sharegpt/sharegpt_gen.py
+++ b/ais_bench/benchmark/configs/datasets/sharegpt/sharegpt_gen.py
@@ -5,7 +5,7 @@ from ais_bench.benchmark.datasets import ShareGPTDataset, ShareGPTEvaluator, mat
 
 
 sharegpt_reader_cfg = dict(
-    input_columns=["question", "answer"],
+    input_columns=["question", "answer", "max_out_len"],
     output_column="answer"
 )
 

--- a/ais_bench/benchmark/datasets/sharegpt.py
+++ b/ais_bench/benchmark/datasets/sharegpt.py
@@ -50,7 +50,7 @@ class ShareGPTDataset(BaseDataset):
                     )
                 except:
                     output_len = None
-                chat["max_out_len"] = output_len
+                chat["max_out_len"].append(output_len)
                 chat["answer"].append(data["conversations"][i + 1]["value"])
             new_dataset.append(chat)
         logger.info(

--- a/ais_bench/benchmark/openicl/icl_inferencer/icl_multiturn_inferencer.py
+++ b/ais_bench/benchmark/openicl/icl_inferencer/icl_multiturn_inferencer.py
@@ -106,9 +106,9 @@ class MultiTurnGenInferencer(BaseApiInferencer, BaseLocalInferencer):
         output = RequestOutput(self.perf_mode)
         output.turn_id, output.uuid = turn_id, uid
 
-        max_out_len = max_out_len[-1] if isinstance(max_out_len, list) else max_out_len
+        cur_max_out_len = max_out_len[-1] if isinstance(max_out_len, list) else max_out_len
         await self.status_counter.post()
-        await self.model.generate(history, max_out_len, output, session=session, **data)
+        await self.model.generate(history, cur_max_out_len, output, session=session, **data)
         if output.success:
             await self.status_counter.rev()
         else:
@@ -140,9 +140,9 @@ class MultiTurnGenInferencer(BaseApiInferencer, BaseLocalInferencer):
             history = await asyncio.to_thread(self.model.parse_template, PromptList(left_prompt + chat[:i] + right_prompt), mode="gen")
             output = RequestOutput(self.perf_mode)
             output.turn_id, output.uuid = turn_id, uid
-            max_out_len = max_out_len[turn_id] if isinstance(max_out_len, list) else max_out_len
+            cur_max_out_len = max_out_len[turn_id] if isinstance(max_out_len, list) else max_out_len
             await self.status_counter.post()
-            await self.model.generate(history, max_out_len, output, session=session, **data)
+            await self.model.generate(history, cur_max_out_len, output, session=session, **data)
             turn_id += 1
             if output.success:
                 await self.status_counter.rev()
@@ -180,9 +180,9 @@ class MultiTurnGenInferencer(BaseApiInferencer, BaseLocalInferencer):
             history = await asyncio.to_thread(self.model.parse_template, PromptList(left_prompt + chat[:i] + right_prompt), mode="gen")
             output = RequestOutput(self.perf_mode)
             output.turn_id, output.uuid = turn_id, uid
-            max_out_len = max_out_len[turn_id] if isinstance(max_out_len, list) else max_out_len
+            cur_max_out_len = max_out_len[turn_id] if isinstance(max_out_len, list) else max_out_len
             await self.status_counter.post()
-            await self.model.generate(history, max_out_len, output, session=session, **data)
+            await self.model.generate(history, cur_max_out_len, output, session=session, **data)
             turn_id += 1
             if output.success:
                 await self.status_counter.rev()


### PR DESCRIPTION
Fix max_out_len handling for multi-turn ShareGPT conversations (#242)

- Add max_out_len to input_columns in sharegpt_gen.py config
- Change dataset to append max_out_len per turn instead of overwriting
- Rename variable to cur_max_out_len in inferencer to avoid shadowing
- Support per-turn max_out_len for infer_last, infer_every, and infer_every_with_gt modes

Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [x] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #242 

## 🔍 Motivation / 变更动机

修复多轮 ShareGPT 对话中 max_out_len 参数的处理问题。在多轮对话场景下，max_out_len 之前会被覆盖而非按轮次独立跟踪，导致每轮对话无法使用正确的输出长度限制。

## 📝 Modification / 修改内容

`sharegpt_gen.py`: 在 `input_columns` 中添加 `max_out_len`，使其能正确传递给推理器
`sharegpt.py`: 将 `chat["max_out_len"] = output_len` 改为 `chat["max_out_len"].append(output_len)`，支持每轮对话独立记录输出长度
`icl_multiturn_inferencer.py`: 变量重命名 `max_out_len → cur_max_out_len` 避免遮蔽，支持 `infer_last`、`infer_every`、`infer_every_with_gt` 三种模式按轮次获取正确的 `max_out_len`

## 📐 Associated Test Results / 关联测试结果

修复后：

* running: 

<img width="1501" height="587" alt="image" src="https://github.com/user-attachments/assets/d763d1d4-26fd-409a-82b9-3b19537a0ec9" />

* results: 
<img width="1411" height="710" alt="image" src="https://github.com/user-attachments/assets/9a640c18-d3d7-488b-a8d6-1242949bb70b" />

* details: 
[sharegpt_details.json](https://github.com/user-attachments/files/26654394/sharegpt_details.json)
```json
{"data_abbr": "sharegpt", "id": 0, "success": true, "error_info": "", "time_points": {"__db_ref__": 1}, "input_tokens": 70, "output_tokens": 242, "ex...
{"data_abbr": "sharegpt", "id": 0, "success": true, "error_info": "", "time_points": {"__db_ref__": 2}, "input_tokens": 155, "output_tokens": 312, "e...
{"data_abbr": "sharegpt", "id": 0, "success": true, "error_info": "", "time_points": {"__db_ref__": 3}, "input_tokens": 367, "output_tokens": 268, "e...
{"data_abbr": "sharegpt", "id": 0, "success": true, "error_info": "", "time_points": {"__db_ref__": 4}, "input_tokens": 679, "output_tokens": 281, "e...
{"data_abbr": "sharegpt", "id": 0, "success": true, "error_info": "", "time_points": {"__db_ref__": 5}, "input_tokens": 849, "output_tokens": 300, "e...
{"data_abbr": "sharegpt", "id": 0, "success": true, "error_info": "", "time_points": {"__db_ref__": 6}, "input_tokens": 917, "output_tokens": 254, "e...
{"data_abbr": "sharegpt", "id": 1, "success": true, "error_info": "", "time_points": {"__db_ref__": 7}, "input_tokens": 55, "output_tokens": 70, "ext...
{"data_abbr": "sharegpt", "id": 2, "success": true, "error_info": "", "time_points": {"__db_ref__": 8}, "input_tokens": 100, "output_tokens": 405, "e...
{"data_abbr": "sharegpt", "id": 3, "success": true, "error_info": "", "time_points": {"__db_ref__": 9}, "input_tokens": 129, "output_tokens": 117, "e...
{"data_abbr": "sharegpt", "id": 3, "success": true, "error_info": "", "time_points": {"__db_ref__": 10}, "input_tokens": 260, "output_tokens": 279, "...
{"data_abbr": "sharegpt", "id": 3, "success": true, "error_info": "", "time_points": {"__db_ref__": 11}, "input_tokens": 553, "output_tokens": 318, "...
{"data_abbr": "sharegpt", "id": 3, "success": true, "error_info": "", "time_points": {"__db_ref__": 12}, "input_tokens": 885, "output_tokens": 357, "...
{"data_abbr": "sharegpt", "id": 3, "success": true, "error_info": "", "time_points": {"__db_ref__": 13}, "input_tokens": 1259, "output_tokens": 394, ...
{"data_abbr": "sharegpt", "id": 3, "success": true, "error_info": "", "time_points": {"__db_ref__": 14}, "input_tokens": 1816, "output_tokens": 418, ...
{"data_abbr": "sharegpt", "id": 4, "success": true, "error_info": "", "time_points": {"__db_ref__": 15}, "input_tokens": 323, "output_tokens": 193, "...
```


## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

 [x] 否，此修改不引入向后不兼容变更

## ⚠️ Performance degradation (Optional) / 性能下降（可选）
 [x] 否，此修改不引入性能下降

## 🌟 Use cases (Optional) / 使用案例（可选）

多轮 ShareGPT 对话评测，每轮对话需要按照数据集，设置不同的输出长度限制

## ✅ Checklist / 检查列表

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [x] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [X] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
