### PR TITLE
[Bugfix]Fix the tau2 bench  metrics display in pass^k situation

### DIFF
--- a/ais_bench/benchmark/tasks/custom_tasks/tau2_bench_task.py
+++ b/ais_bench/benchmark/tasks/custom_tasks/tau2_bench_task.py
@@ -235,9 +235,10 @@ class TAU2BenchTask(BaseTask):
             return
         out_json = osp.join(f"{self.out_dir}", f"{self.cfg['datasets'][0][0]['abbr']}.json")
         results = {
-            f"pass^{self.run_config.num_trials}": 100 * self.captured_metrics.avg_reward,
             "total_count": self._get_task_count(self.run_config),
         }
+        for k in range(1, self.run_config.num_trials + 1):
+            results[f"pass^{k}"] = 100 * self.captured_metrics.pass_hat_ks[k]
         with open(out_json, "w") as f:
             json.dump(results, f, indent=4)
         self.logger.info(f"Evaluation results saved to {out_json}")

--- a/ais_bench/configs/agent_example/tau2_bench_task.py
+++ b/ais_bench/configs/agent_example/tau2_bench_task.py
@@ -103,8 +103,8 @@ for ds_config in datasets:
 _all_sub_set = [(ds_config["abbr"], f'pass^{datasets[0]["args"]["num_trials"]}') for ds_config in datasets]
 
 tau2_summary_groups = [
-    {'name': 'tau2_bench_avg', 'subsets': _all_sub_set},
-    {'name': 'tau2_bench_avg-weighted', 'subsets': _all_sub_set, 'weights': tau2_task_weights},
+    {'name': f'tau2_bench_pass^{datasets[0]["args"]["num_trials"]}_avg', 'subsets': _all_sub_set},
+    {'name': f'tau2_bench_pass^{datasets[0]["args"]["num_trials"]}_avg-weighted', 'subsets': _all_sub_set, 'weights': tau2_task_weights},
 ]
 
 summarizer = dict(

--- a/docs/source_en/extended_benchmark/agent/tau2_bench.md
+++ b/docs/source_en/extended_benchmark/agent/tau2_bench.md
@@ -140,8 +140,8 @@ During execution, all result files will be generated in the `outputs/default/{ti
 | tau2_bench_airline | / | pass^1 | unknown | 50 | 38.00 |
 | tau2_bench_retail | / | pass^1 | unknown | 114 | 21.05 |
 | tau2_bench_telecom | / | pass^1 | unknown | 114 | 33.33 |
-| tau2_bench_avg | - | naive_average | unknown | / | 30.80 |
-| tau2_bench_avg-weighted | - | weighted_average | unknown | / | 29.14 |
+| tau2_bench_pass^1_avg | - | naive_average | unknown | / | 30.80 |
+| tau2_bench_pass^1_avg-weighted | - | weighted_average | unknown | / | 29.14 |
 ```
 - `tau2_bench_avg` represents the simple average score across the three domains.
 - `tau2_bench_avg-weighted` represents the weighted average score across the three domains (weights are the number of tasks in each domain).
@@ -238,9 +238,21 @@ for task in sub_tasks:
 ```shell
 | dataset | version | metric | mode | total_count | openai-v1-chat |
 |----- | ----- | ----- | ----- | ----- | -----|
-| tau2_bench_airline | / | pass^3 | unknown | 50 | 38.00 |
-| tau2_bench_retail | / | pass^3 | unknown | 114 | 21.05 |
-| tau2_bench_telecom | / | pass^3 | unknown | 114 | 33.33 |
-| tau2_bench_avg | - | naive_average | unknown | / | 30.80 |
-| tau2_bench_avg-weighted | - | weighted_average | unknown | / | 29.14 |
+| tau2_bench_airline | a39421 | pass^1 | gen | 10 | 46.00 |
+| tau2_bench_airline | a39421 | pass^2 | gen | 10 | 37.00 |
+| tau2_bench_airline | a39421 | pass^3 | gen | 10 | 34.00 |
+| tau2_bench_airline | a39421 | pass^4 | gen | 10 | 32.00 |
+| tau2_bench_airline | a39421 | pass^5 | gen | 10 | 30.00 |
+| tau2_bench_retail | a39421 | pass^1 | gen | 23 | 32.17 |
+| tau2_bench_retail | a39421 | pass^2 | gen | 23 | 19.13 |
+| tau2_bench_retail | a39421 | pass^3 | gen | 23 | 13.48 |
+| tau2_bench_retail | a39421 | pass^4 | gen | 23 | 8.70 |
+| tau2_bench_retail | a39421 | pass^5 | gen | 23 | 4.35 |
+| tau2_bench_telecom | a39421 | pass^1 | gen | 23 | 62.61 |
+| tau2_bench_telecom | a39421 | pass^2 | gen | 23 | 44.78 |
+| tau2_bench_telecom | a39421 | pass^3 | gen | 23 | 36.52 |
+| tau2_bench_telecom | a39421 | pass^4 | gen | 23 | 32.17 |
+| tau2_bench_telecom | a39421 | pass^5 | gen | 23 | 30.43 |
+| tau2_bench_pass^5_avg | - | naive_average | gen | / | 21.59 |
+| tau2_bench_pass^5_avg-weighted | - | weighted_average | gen | / | 19.64 |
 ```

--- a/docs/source_en/extended_benchmark/agent/tau2_bench.md
+++ b/docs/source_en/extended_benchmark/agent/tau2_bench.md
@@ -213,7 +213,7 @@ for task in sub_tasks:
             abbr=f'tau2_bench_{task}',
             args = dict(
                 domain = task,                      # -d, simulation domain to run, optional values: "airline", "retail", "telecom"
-                num_trials = 3,                     # Number of runs per task, default is 1
+                num_trials = 5,                     # Number of runs per task, default is 1
                 # ......
             ),
         )

--- a/docs/source_zh_cn/extended_benchmark/agent/tau2_bench.md
+++ b/docs/source_zh_cn/extended_benchmark/agent/tau2_bench.md
@@ -140,8 +140,8 @@ Press Up/Down arrow to page, 'P' to PAUSE/RESUME screen refresh, 'Ctrl + C' to e
 | tau2_bench_airline | / | pass^1 | unknown | 50 | 38.00 |
 | tau2_bench_retail | / | pass^1 | unknown | 114 | 21.05 |
 | tau2_bench_telecom | / | pass^1 | unknown | 114 | 33.33 |
-| tau2_bench_avg | - | naive_average | unknown | / | 30.80 |
-| tau2_bench_avg-weighted | - | weighted_average | unknown | / | 29.14 |
+| tau2_bench_pass^1_avg | - | naive_average | unknown | / | 30.80 |
+| tau2_bench_pass^1_avg-weighted | - | weighted_average | unknown | / | 29.14 |
 ```
 - `tau2_bench_avg` 表示三大领域的简单平均得分。
 - `tau2_bench_avg-weighted` 表示三大领域的加权平均得分（权重为各领域的任务数），权重为每个领域的任务数。
@@ -213,7 +213,7 @@ for task in sub_tasks:
             abbr=f'tau2_bench_{task}',
             args = dict(
                 domain = task,                      # -d, 要运行的模拟域，可选值为 "airline", "retail", "telecom"
-                num_trials = 3,                     # 每个任务运行的次数，默认为 1
+                num_trials = 5,                     # 每个任务运行的次数，默认为 1
                 # ......
             ),
         )
@@ -226,11 +226,11 @@ for task in sub_tasks:
 +-----------------------------------+-----------+------------------------------------------------------------+-------------+----------+-------------------------------------------------+---------------------+
 | Task Name                         |   Process | Progress                                                   | Time Cost   | Status   | Log Path                                        | Extend Parameters   |
 +===================================+===========+============================================================+=============+==========+=================================================+=====================+
-| openai-v1-chat/tau2_bench_airline |   1856223 | [######                        ] 30/150 Running TAU2 Bench | 0:07:13     | running  | logs/eval/openai-v1-chat/tau2_bench_airline.out | None                |
+| openai-v1-chat/tau2_bench_airline |   1856223 | [######                        ] 30/250 Running TAU2 Bench | 0:07:13     | running  | logs/eval/openai-v1-chat/tau2_bench_airline.out | None                |
 +-----------------------------------+-----------+------------------------------------------------------------+-------------+----------+-------------------------------------------------+---------------------+
-| openai-v1-chat/tau2_bench_retail  |   1856224 | [######                        ] 75/342 Running TAU2 Bench | 0:11:56     | running  | logs/eval/openai-v1-chat/tau2_bench_retail.out  | None                |
+| openai-v1-chat/tau2_bench_retail  |   1856224 | [######                        ] 75/568 Running TAU2 Bench | 0:11:56     | running  | logs/eval/openai-v1-chat/tau2_bench_retail.out  | None                |
 +-----------------------------------+-----------+------------------------------------------------------------+-------------+----------+-------------------------------------------------+---------------------+
-| openai-v1-chat/tau2_bench_telecom |   1856222 | [######                        ] 76/342 Running TAU2 Bench | 1:09:51     | running  | logs/eval/openai-v1-chat/tau2_bench_telecom.out | None                |
+| openai-v1-chat/tau2_bench_telecom |   1856222 | [######                        ] 76/568 Running TAU2 Bench | 1:09:51     | running  | logs/eval/openai-v1-chat/tau2_bench_telecom.out | None                |
 +-----------------------------------+-----------+------------------------------------------------------------+-------------+----------+-------------------------------------------------+---------------------+
 ```
 
@@ -238,9 +238,21 @@ for task in sub_tasks:
 ```shell
 | dataset | version | metric | mode | total_count | openai-v1-chat |
 |----- | ----- | ----- | ----- | ----- | -----|
-| tau2_bench_airline | / | pass^3 | unknown | 50 | 38.00 |
-| tau2_bench_retail | / | pass^3 | unknown | 114 | 21.05 |
-| tau2_bench_telecom | / | pass^3 | unknown | 114 | 33.33 |
-| tau2_bench_avg | - | naive_average | unknown | / | 30.80 |
-| tau2_bench_avg-weighted | - | weighted_average | unknown | / | 29.14 |
+| tau2_bench_airline | a39421 | pass^1 | gen | 10 | 46.00 |
+| tau2_bench_airline | a39421 | pass^2 | gen | 10 | 37.00 |
+| tau2_bench_airline | a39421 | pass^3 | gen | 10 | 34.00 |
+| tau2_bench_airline | a39421 | pass^4 | gen | 10 | 32.00 |
+| tau2_bench_airline | a39421 | pass^5 | gen | 10 | 30.00 |
+| tau2_bench_retail | a39421 | pass^1 | gen | 23 | 32.17 |
+| tau2_bench_retail | a39421 | pass^2 | gen | 23 | 19.13 |
+| tau2_bench_retail | a39421 | pass^3 | gen | 23 | 13.48 |
+| tau2_bench_retail | a39421 | pass^4 | gen | 23 | 8.70 |
+| tau2_bench_retail | a39421 | pass^5 | gen | 23 | 4.35 |
+| tau2_bench_telecom | a39421 | pass^1 | gen | 23 | 62.61 |
+| tau2_bench_telecom | a39421 | pass^2 | gen | 23 | 44.78 |
+| tau2_bench_telecom | a39421 | pass^3 | gen | 23 | 36.52 |
+| tau2_bench_telecom | a39421 | pass^4 | gen | 23 | 32.17 |
+| tau2_bench_telecom | a39421 | pass^5 | gen | 23 | 30.43 |
+| tau2_bench_pass^5_avg | - | naive_average | gen | / | 21.59 |
+| tau2_bench_pass^5_avg-weighted | - | weighted_average | gen | / | 19.64 |
 ```

--- a/tests/UT/tasks/custom_tasks/test_tau2_bench_task.py
+++ b/tests/UT/tasks/custom_tasks/test_tau2_bench_task.py
@@ -201,6 +201,7 @@ class TestTAU2BenchTask(unittest.TestCase):
         # 模拟 compute_metrics 返回值
         mock_metrics = mock.MagicMock()
         mock_metrics.avg_reward = 0.8
+        mock_metrics.pass_hat_ks = {1: 0.8, 2: 0.64}
         mock_compute_metrics.return_value = mock_metrics
 
         # 模拟 get_tasks 返回 3 个任务
@@ -284,6 +285,7 @@ class TestTAU2BenchTask(unittest.TestCase):
 
         mock_metrics = mock.MagicMock()
         mock_metrics.avg_reward = 0.7
+        mock_metrics.pass_hat_ks = {1: 0.7, 2: 0.49}
         mock_compute_metrics.return_value = mock_metrics
 
         # 模拟 tqdm

--- a/tests/UT/tasks/custom_tasks/test_tau2_bench_task.py
+++ b/tests/UT/tasks/custom_tasks/test_tau2_bench_task.py
@@ -223,7 +223,8 @@ class TestTAU2BenchTask(unittest.TestCase):
         # 验证结果文件内容
         with open(expected_out_json, 'r') as f:
             results = json.load(f)
-        self.assertEqual(results.get("pass^2"), 80.0)  # 0.8 * 100
+        self.assertEqual(results.get("pass^1"), 80.0)  # 0.8 * 100
+        self.assertEqual(results.get("pass^2"), 64.0)  # 0.64 * 100
         self.assertEqual(results.get("total_count"), 3)  # 因为 get_tasks 被 mock 为返回 3 个任务
 
     @mock.patch('ais_bench.benchmark.tasks.custom_tasks.tau2_bench_task.get_tasks')


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [x] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)

## 🔍 Motivation / 变更动机

Please describe the motivation of this PR and the goal you want to achieve through this PR.
请描述您的拉取请求的动机和您希望通过此拉取请求实现的目标。
Fix the tau2 bench  metrics display in pass^k situation

## 📝 Modification / 修改内容

Please briefly describe what modification is made in this PR.
请简要描述此拉取请求中进行的修改。
Fix the tau2 bench  metrics display in pass^k situation

## 📐 Associated Test Results / 关联测试结果

Please provide links to the related test results, such as CI pipelines, test reports, etc.
请提供相关测试结果的链接，例如 CI 管道、测试报告等。

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
