### PR TITLE
【Feature】【Part1】AISBench support  the VBench 1.0 Video Quality Evaluation Pipeline.

### DIFF
--- a/ais_bench/benchmark/configs/summarizers/vbench.py
+++ b/ais_bench/benchmark/configs/summarizers/vbench.py
@@ -1,0 +1,7 @@
+from ais_bench.benchmark.summarizers import VBenchSummarizer
+
+summarizer = dict(
+    attr='accuracy',
+    type=VBenchSummarizer,
+    summary_groups=[],
+)

--- a/ais_bench/benchmark/datasets/__init__.py
+++ b/ais_bench/benchmark/datasets/__init__.py
@@ -26,6 +26,7 @@ from ais_bench.benchmark.datasets.bbh import * # noqa: F401, F403
 from ais_bench.benchmark.datasets.race import *
 from ais_bench.benchmark.datasets.textvqa import *
 from ais_bench.benchmark.datasets.videobench import *
+from ais_bench.benchmark.datasets.vbench import *
 from ais_bench.benchmark.datasets.vocalsound import *
 from ais_bench.benchmark.datasets.lambada import * # noqa: F401, F403
 from ais_bench.benchmark.datasets.lcsts import * # noqa: F401, F403

--- a/ais_bench/benchmark/datasets/vbench.py
+++ b/ais_bench/benchmark/datasets/vbench.py
@@ -1,0 +1,21 @@
+"""VBench 1.0 dataset config type for video/image quality evaluation (eval-only, no loader)."""
+from datasets import Dataset
+
+from ais_bench.benchmark.registry import LOAD_DATASET
+from ais_bench.benchmark.datasets.base import BaseDataset
+
+
+@LOAD_DATASET.register_module()
+class VBenchDataset(BaseDataset):
+    """Placeholder dataset for VBench evaluation.
+
+    VBench evaluation uses only dataset config (path/videos_path, dimension_list,
+    full_json_dir, eval_cfg). This class provides a minimal load() so that
+    LOAD_DATASET.build(dataset_cfg) does not fail if ever called; the actual
+    evaluation is done in VBenchEvalTask which reads the config directly.
+    """
+
+    @staticmethod
+    def load(path: str, **kwargs):
+        """Return a minimal placeholder dataset. VBench eval uses config only."""
+        return Dataset.from_list([{"dummy": 0}])

--- a/ais_bench/benchmark/partitioners/base.py
+++ b/ais_bench/benchmark/partitioners/base.py
@@ -25,6 +25,7 @@ class BasePartitioner:
 
             - eval.runner.task.judge_cfg
             - eval.runner.task.dump_details
+            - VBENCH_CACHE_DIR, vbench_cache_dir (for VBenchEvalTask subprocess)
     """
 
     def __init__(self, out_dir: str, keep_keys: Optional[List[str]] = None):
@@ -36,6 +37,10 @@ class BasePartitioner:
                 'eval.runner.task.dump_details',
                 'eval.given_pred',
                 'eval.runner.task.cal_extract_rate',
+                # Top-level experiment keys copied into each task cfg for subprocess
+                # (LocalRunner dumps task cfg; vbench reads VBENCH_CACHE_DIR before import).
+                'VBENCH_CACHE_DIR',
+                'vbench_cache_dir',
             ]
         else:
             self.keep_keys = keep_keys

--- a/ais_bench/benchmark/summarizers/__init__.py
+++ b/ais_bench/benchmark/summarizers/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F401, E501
 from ais_bench.benchmark.summarizers.default import DefaultSummarizer  # noqa: F401
 from ais_bench.benchmark.summarizers.default_subjective import DefaultSubjectiveSummarizer  # noqa: F401
-from ais_bench.benchmark.summarizers.default_perf import DefaultPerfSummarizer # noqa: F401
+from ais_bench.benchmark.summarizers.default_perf import DefaultPerfSummarizer  # noqa: F401
+from ais_bench.benchmark.summarizers.vbench import VBenchSummarizer  # noqa: F401
 from ais_bench.benchmark.summarizers.swebench import SWEBenchSummarizer  # noqa: F401

--- a/ais_bench/benchmark/summarizers/vbench.py
+++ b/ais_bench/benchmark/summarizers/vbench.py
@@ -1,0 +1,168 @@
+# flake8: noqa
+# yapf: disable
+"""VBench summarizer with official normalization and aggregation logic."""
+import re
+from typing import Dict
+
+from ais_bench.benchmark.summarizers.default import DefaultSummarizer
+
+# VBench official constants from scripts/constant.py
+NORMALIZE_DIC = {
+    "subject consistency": {"Min": 0.1462, "Max": 1.0},
+    "background consistency": {"Min": 0.2615, "Max": 1.0},
+    "temporal flickering": {"Min": 0.6293, "Max": 1.0},
+    "motion smoothness": {"Min": 0.706, "Max": 0.9975},
+    "dynamic degree": {"Min": 0.0, "Max": 1.0},
+    "aesthetic quality": {"Min": 0.0, "Max": 1.0},
+    "imaging quality": {"Min": 0.0, "Max": 1.0},
+    "object class": {"Min": 0.0, "Max": 1.0},
+    "multiple objects": {"Min": 0.0, "Max": 1.0},
+    "human action": {"Min": 0.0, "Max": 1.0},
+    "color": {"Min": 0.0, "Max": 1.0},
+    "spatial relationship": {"Min": 0.0, "Max": 1.0},
+    "scene": {"Min": 0.0, "Max": 0.8222},
+    "appearance style": {"Min": 0.0009, "Max": 0.2855},
+    "temporal style": {"Min": 0.0, "Max": 0.364},
+    "overall consistency": {"Min": 0.0, "Max": 0.364},
+}
+DIM_WEIGHT = {
+    "subject consistency": 1,
+    "background consistency": 1,
+    "temporal flickering": 1,
+    "motion smoothness": 1,
+    "aesthetic quality": 1,
+    "imaging quality": 1,
+    "dynamic degree": 0.5,
+    "object class": 1,
+    "multiple objects": 1,
+    "human action": 1,
+    "color": 1,
+    "spatial relationship": 1,
+    "scene": 1,
+    "appearance style": 1,
+    "temporal style": 1,
+    "overall consistency": 1,
+}
+QUALITY_LIST = [
+    "subject consistency",
+    "background consistency",
+    "temporal flickering",
+    "motion smoothness",
+    "aesthetic quality",
+    "imaging quality",
+    "dynamic degree",
+]
+SEMANTIC_LIST = [
+    "object class",
+    "multiple objects",
+    "human action",
+    "color",
+    "spatial relationship",
+    "scene",
+    "appearance style",
+    "temporal style",
+    "overall consistency",
+]
+QUALITY_WEIGHT = 4
+SEMANTIC_WEIGHT = 1
+
+# Known dimension names (underscore form) for regex extraction from abbr
+_DIM_PATTERN = re.compile(
+    r'(subject_consistency|background_consistency|temporal_flickering|'
+    r'motion_smoothness|dynamic_degree|aesthetic_quality|imaging_quality|'
+    r'object_class|multiple_objects|human_action|color|spatial_relationship|'
+    r'scene|appearance_style|temporal_style|overall_consistency)$'
+)
+
+
+def _abbr_to_const_key(abbr: str) -> str:
+    """Extract dimension from abbr, e.g. vbench_custom_subject_consistency -> subject consistency."""
+    m = _DIM_PATTERN.search(abbr)
+    if m:
+        return m.group(1).replace('_', ' ')
+    if abbr.startswith('vbench_'):
+        return abbr[7:].replace('_', ' ')
+    return abbr.replace('_', ' ')
+
+
+def _get_normalized_score(raw_score: float, const_key: str) -> float:
+    """Normalize and apply DIM_WEIGHT per cal_final_score.py."""
+    if const_key not in NORMALIZE_DIC or const_key not in DIM_WEIGHT:
+        return 0.0
+    raw = raw_score / 100.0 if raw_score > 1 else raw_score
+    min_val = NORMALIZE_DIC[const_key]['Min']
+    max_val = NORMALIZE_DIC[const_key]['Max']
+    span = max_val - min_val
+    if span <= 0:
+        norm = 1.0 if raw >= max_val else 0.0
+    else:
+        norm = (raw - min_val) / span
+    return norm * DIM_WEIGHT[const_key]
+
+
+class VBenchSummarizer(DefaultSummarizer):
+    """VBench summarizer using official cal_final_score.py logic.
+
+    Computes Quality Score, Semantic Score, Total Score with:
+    - Per-dimension normalization: (score - Min) / (Max - Min) * DIM_WEIGHT
+    - Quality = weighted avg of QUALITY_LIST dims
+    - Semantic = weighted avg of SEMANTIC_LIST dims
+    - Total = (Quality * 4 + Semantic * 1) / 5
+    """
+
+    def _calculate_group_metrics(
+        self,
+        raw_results: Dict,
+        parsed_results: Dict,
+        dataset_metrics: Dict,
+        dataset_eval_mode: Dict,
+    ):
+        """Compute vbench Quality, Semantic, Total using official formula."""
+        for model_abbr in self.model_abbrs:
+            model_results = parsed_results.get(model_abbr, {})
+            vbench_scores = {}
+            for abbr, data in model_results.items():
+                if not abbr.startswith('vbench_'):
+                    continue
+                acc = data.get('accuracy')
+                if acc is None or not isinstance(acc, (int, float)):
+                    continue
+                const_key = _abbr_to_const_key(abbr)
+                vbench_scores[const_key] = acc
+
+            if not vbench_scores:
+                continue
+
+            normalized = {
+                k: _get_normalized_score(v, k)
+                for k, v in vbench_scores.items()
+            }
+
+            quality_num = sum(normalized.get(k, 0) for k in QUALITY_LIST)
+            quality_denom = sum(DIM_WEIGHT.get(k, 0) for k in QUALITY_LIST)
+            quality_score = (
+                quality_num / quality_denom if quality_denom else 0.0
+            )
+
+            semantic_num = sum(normalized.get(k, 0) for k in SEMANTIC_LIST)
+            semantic_denom = sum(DIM_WEIGHT.get(k, 0) for k in SEMANTIC_LIST)
+            semantic_score = (
+                semantic_num / semantic_denom if semantic_denom else 0.0
+            )
+
+            total_score = (
+                quality_score * QUALITY_WEIGHT + semantic_score * SEMANTIC_WEIGHT
+            ) / (QUALITY_WEIGHT + SEMANTIC_WEIGHT)
+
+            for name, score in [
+                ('vbench_quality', quality_score * 100),
+                ('vbench_semantic', semantic_score * 100),
+                ('vbench_total', total_score * 100),
+            ]:
+                raw_results[model_abbr].setdefault(name, {})['accuracy'] = score
+                parsed_results[model_abbr].setdefault(name, {})['accuracy'] = score
+                if name not in dataset_metrics:
+                    dataset_metrics[name] = ['accuracy']
+                dataset_eval_mode[name] = 'gen'
+
+        return raw_results, parsed_results, dataset_metrics, dataset_eval_mode

--- a/ais_bench/benchmark/tasks/__init__.py
+++ b/ais_bench/benchmark/tasks/__init__.py
@@ -3,4 +3,4 @@ from ais_bench.benchmark.tasks.openicl_infer import *  # noqa: F401, F403
 from ais_bench.benchmark.tasks.openicl_api_infer import OpenICLApiInferTask
 from ais_bench.benchmark.tasks.swebench.swebench_infer import SWEBenchInferTask
 from ais_bench.benchmark.tasks.swebench.swebench_eval import SWEBenchEvalTask
-
+from ais_bench.benchmark.tasks.vbench_eval import VBenchEvalTask  # noqa: F401

--- a/ais_bench/benchmark/tasks/vbench_eval.py
+++ b/ais_bench/benchmark/tasks/vbench_eval.py
@@ -1,0 +1,264 @@
+"""VBench 1.0 evaluation task for video/image quality metrics on GPU or NPU."""
+import argparse
+import json
+import os
+import os.path as osp
+import statistics
+import sys
+import threading
+import time
+
+from mmengine.config import Config, ConfigDict
+
+from ais_bench.benchmark.registry import TASKS
+from ais_bench.benchmark.tasks.base import BaseTask, TaskStateManager
+from ais_bench.benchmark.utils.core.abbr import (
+    dataset_abbr_from_cfg,
+    get_infer_output_path,
+    model_abbr_from_cfg,
+    task_abbr_from_cfg,
+)
+from ais_bench.benchmark.utils.logging import AISLogger
+from typing import List
+
+
+@TASKS.register_module()
+class VBenchEvalTask(BaseTask):
+    """VBench 1.0 evaluation task. Runs VBench metrics on a folder of videos."""
+
+    name_prefix = 'VBenchEval'
+    log_subdir = 'logs/eval'
+    output_subdir = 'results'
+
+    def __init__(self, cfg: ConfigDict):
+        super().__init__(cfg)
+        self.num_gpus = 1
+
+    def get_command(self, cfg_path, template):
+        sys.path.insert(0, os.getcwd())
+        script_path = __file__
+        python = sys.executable
+        command = f'{python} {script_path} {cfg_path}'
+        return template.format(task_cmd=command)
+
+    def _ensure_vbench_in_path(self):
+        """Prepend third_party and third_party/detectron2 to sys.path so vbench and detectron2 resolve to ais_bench copy."""
+        # __file__ = ais_bench/benchmark/tasks/vbench_eval.py -> pkg_root = ais_bench
+        pkg_root = osp.abspath(osp.join(osp.dirname(__file__), '..', '..'))
+        third_party = osp.join(pkg_root, 'third_party')
+        detectron2_parent = osp.join(third_party, 'detectron2')
+        for path in (third_party, detectron2_parent):
+            if path not in sys.path:
+                sys.path.insert(0, path)
+
+    def _apply_vbench_cache_dir_from_cfg(self) -> None:
+        """Set os.environ['VBENCH_CACHE_DIR'] before importing vbench (vbench reads it at import time)."""
+        raw = self.cfg.get('VBENCH_CACHE_DIR') or self.cfg.get('vbench_cache_dir')
+        if raw is None or (isinstance(raw, str) and not raw.strip()):
+            return
+        path = os.path.expandvars(os.path.expanduser(str(raw).strip()))
+        os.environ['VBENCH_CACHE_DIR'] = path
+
+    def _infer_mode(self, dataset_cfg: ConfigDict, eval_cfg: ConfigDict) -> str:
+        """Infer VBench mode when not explicitly provided in eval_cfg."""
+        mode = eval_cfg.get('mode')
+        if mode:
+            return mode
+        if eval_cfg.get('category'):
+            return 'vbench_category'
+        has_prompt = bool(
+            eval_cfg.get('prompt_file')
+            or eval_cfg.get('prompt_list')
+            or dataset_cfg.get('prompt_list')
+        )
+        if has_prompt:
+            return 'custom_input'
+        return 'vbench_standard'
+
+    def _wrap_results(self, raw_results: dict) -> dict:
+        """Convert raw VBench per-dimension results to {accuracy, details} schema."""
+        details = {}
+        scores = []
+        for dim, value in raw_results.items():
+            dim_detail = {}
+            if isinstance(value, dict):
+                dim_detail = value
+                score = value.get('score') or value.get('mean_score')
+            elif isinstance(value, (list, tuple)) and len(value) == 2:
+                score, video_results = value
+                dim_detail = {'score': score, 'video_results': video_results}
+            else:
+                dim_detail = {'value': value}
+                score = None
+            if isinstance(score, (int, float)):
+                scores.append(score)
+            details[dim] = dim_detail
+        accuracy = statistics.mean(scores) if scores else 0.0
+        return {'accuracy': accuracy * 100, 'details': details}
+
+    def run(self, task_state_manager: TaskStateManager | None = None):
+        self._ensure_vbench_in_path()
+        self._apply_vbench_cache_dir_from_cfg()
+        from vbench import VBench, set_progress_callback
+        from vbench.distributed import dist_init, get_rank, get_device, dist_destroy
+
+        for dataset_cfg in self.dataset_cfgs:
+            eval_cfg = dataset_cfg.get('eval_cfg') or {}
+            # videos_path: required, from path or videos_path
+            videos_path = dataset_cfg.get('videos_path') or dataset_cfg.get('path')
+            if not videos_path or not osp.isdir(videos_path):
+                raise ValueError(
+                    f"VBench dataset must have 'path' or 'videos_path' pointing to a video directory, got: {videos_path}"
+                )
+            # device: cuda | npu | None (auto-detect)
+            device_str = eval_cfg.get('device')
+            if device_str is not None and device_str not in ('cuda', 'npu'):
+                device_str = None
+            dist_init(device=device_str)
+            device_str = get_device()
+            # full_json_dir: VBench full info json
+            full_json_dir = dataset_cfg.get('full_json_dir') or eval_cfg.get('full_json_dir')
+            if not full_json_dir or not osp.isfile(full_json_dir):
+                # default under third_party/vbench
+                pkg_root = osp.abspath(osp.join(osp.dirname(__file__), '..', '..'))
+                default_full = osp.join(pkg_root, 'third_party', 'vbench', 'VBench_full_info.json')
+                if osp.isfile(default_full):
+                    full_json_dir = default_full
+                else:
+                    raise FileNotFoundError(
+                        f"VBench full_info json not found. Set dataset full_json_dir or place VBench_full_info.json at {default_full}"
+                    )
+            # dimension_list
+            dimension_list = dataset_cfg.get('dimension_list') or eval_cfg.get('dimension_list')
+            if not dimension_list:
+                dimension_list = [
+                    'subject_consistency', 'background_consistency', 'aesthetic_quality',
+                    'imaging_quality', 'object_class', 'multiple_objects', 'color',
+                    'spatial_relationship', 'scene', 'temporal_style', 'overall_consistency',
+                    'human_action', 'temporal_flickering', 'motion_smoothness', 'dynamic_degree',
+                    'appearance_style',
+                ]
+            # output dir: work_dir/results/<model_abbr>/
+            model_abbr = model_abbr_from_cfg(self.model_cfg)
+            dataset_abbr = dataset_abbr_from_cfg(dataset_cfg)
+            output_dir = osp.join(self.work_dir, self.output_subdir, model_abbr)
+            os.makedirs(output_dir, exist_ok=True)
+
+            if get_rank() == 0:
+                self.logger.info(
+                    f"VBench eval: videos_path={videos_path}, device={device_str}, "
+                    f"dimensions={len(dimension_list)}, output_dir={output_dir}"
+                )
+
+            import torch
+            device = torch.device(device_str)
+            vbench = VBench(device, full_json_dir, output_dir)
+
+            # 注册进度回调，将 VBench 内部的维度进度映射到 TaskStateManager
+            if task_state_manager is not None:
+                def _on_progress(dimension: str, finished: int, total: int, video_path: str | None = None, **_):
+                    # 仅在 rank0 上上报，避免多卡重复
+                    if get_rank() != 0:
+                        return
+                    state = {
+                        "status": "evaluating",
+                        "total_count": total,
+                        "finish_count": finished,
+                        "other_kwargs": {
+                            "dimension": dimension,
+                        },
+                    }
+                    task_state_manager.update_task_state(state)
+
+                set_progress_callback(_on_progress)
+
+            # Infer mode if not explicitly provided
+            mode = self._infer_mode(dataset_cfg, eval_cfg)
+
+            prompt_list = dataset_cfg.get('prompt_list') or eval_cfg.get('prompt_list') or []
+            prompt_file = eval_cfg.get('prompt_file')
+            if prompt_file and osp.isfile(prompt_file):
+                with open(prompt_file, 'r') as f:
+                    prompt_list = json.load(f)
+                assert isinstance(prompt_list, dict), "prompt_file must be JSON dict {video_path: prompt}"
+
+            kwargs = {}
+            if eval_cfg.get('category'):
+                kwargs['category'] = eval_cfg['category']
+            if eval_cfg.get('imaging_quality_preprocessing_mode'):
+                kwargs['imaging_quality_preprocessing_mode'] = eval_cfg['imaging_quality_preprocessing_mode']
+
+            try:
+                raw_results = vbench.evaluate(
+                    videos_path=videos_path,
+                    name=dataset_abbr,
+                    prompt_list=prompt_list,
+                    dimension_list=dimension_list,
+                    local=eval_cfg.get('load_ckpt_from_local', False),
+                    read_frame=eval_cfg.get('read_frame', False),
+                    mode=mode,
+                    **kwargs,
+                )
+
+                if get_rank() == 0:
+                    # Wrap raw VBench results to {accuracy, details} schema and save.
+                    wrapped = self._wrap_results(raw_results)
+                    final_out = get_infer_output_path(
+                        self.model_cfg,
+                        dataset_cfg,
+                        osp.join(self.work_dir, self.output_subdir),
+                    )
+                    os.makedirs(osp.dirname(final_out), exist_ok=True)
+                    with open(final_out, 'w', encoding='utf-8') as f:
+                        json.dump(wrapped, f, ensure_ascii=False, indent=4)
+                    self.logger.info(f"VBench wrapped results saved to {final_out}")
+            finally:
+                dist_destroy()
+
+    def get_output_paths(self, file_extension: str = "json") -> List[str]:
+        """Paths to wrapped VBench result files: results/<model_abbr>/<dataset_abbr>.json."""
+        paths = []
+        for dataset_cfg in self.dataset_cfgs:
+            paths.append(
+                get_infer_output_path(
+                    self.model_cfg,
+                    dataset_cfg,
+                    osp.join(self.work_dir, self.output_subdir),
+                    file_extension,
+                )
+            )
+        return paths
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='VBench evaluation task')
+    parser.add_argument('config', help='Config file path')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    logger = AISLogger()
+    args = parse_args()
+    cfg = Config.fromfile(args.config)
+    task_state_manager = TaskStateManager(
+        tmp_path=osp.join(cfg['work_dir'], 'status_tmp'),
+        task_name=task_abbr_from_cfg(cfg),
+        is_debug=cfg['cli_args']['debug'],
+    )
+    manager_t = threading.Thread(target=task_state_manager.launch, args=())
+    manager_t.start()
+    task_state_manager.update_task_state({
+        'status': 'start',
+        'task_log_path': osp.join('logs/eval', f'{task_abbr_from_cfg(cfg)}.out'),
+    })
+    start_time = time.perf_counter()
+    try:
+        task = VBenchEvalTask(cfg)
+        task.run(task_state_manager)
+    except Exception as e:
+        task_state_manager.update_task_state({'status': 'error'})
+        raise e
+    end_time = time.perf_counter()
+    logger.info(f'VBench evaluation task time elapsed: {end_time - start_time:.2f}s')
+    task_state_manager.update_task_state({'status': 'finish'})
+    manager_t.join()

--- a/ais_bench/benchmark/tasks/vbench_eval.py
+++ b/ais_bench/benchmark/tasks/vbench_eval.py
@@ -128,31 +128,26 @@ class VBenchEvalTask(BaseTask):
                     raise FileNotFoundError(
                         f"VBench full_info json not found. Set dataset full_json_dir or place VBench_full_info.json at {default_full}"
                     )
-            # dimension_list
-            dimension_list = dataset_cfg.get('dimension_list') or eval_cfg.get('dimension_list')
-            if not dimension_list:
-                dimension_list = [
-                    'subject_consistency', 'background_consistency', 'aesthetic_quality',
-                    'imaging_quality', 'object_class', 'multiple_objects', 'color',
-                    'spatial_relationship', 'scene', 'temporal_style', 'overall_consistency',
-                    'human_action', 'temporal_flickering', 'motion_smoothness', 'dynamic_degree',
-                    'appearance_style',
-                ]
             # output dir: work_dir/results/<model_abbr>/
             model_abbr = model_abbr_from_cfg(self.model_cfg)
             dataset_abbr = dataset_abbr_from_cfg(dataset_cfg)
             output_dir = osp.join(self.work_dir, self.output_subdir, model_abbr)
             os.makedirs(output_dir, exist_ok=True)
 
+            import torch
+            device = torch.device(device_str)
+            vbench = VBench(device, full_json_dir, output_dir)
+
+            # dimension_list: prefer config override; otherwise use vbench's built-in full list
+            dimension_list = dataset_cfg.get('dimension_list') or eval_cfg.get('dimension_list')
+            if not dimension_list:
+                dimension_list = vbench.build_full_dimension_list()
+
             if get_rank() == 0:
                 self.logger.info(
                     f"VBench eval: videos_path={videos_path}, device={device_str}, "
                     f"dimensions={len(dimension_list)}, output_dir={output_dir}"
                 )
-
-            import torch
-            device = torch.device(device_str)
-            vbench = VBench(device, full_json_dir, output_dir)
 
             # 注册进度回调，将 VBench 内部的维度进度映射到 TaskStateManager
             if task_state_manager is not None:
@@ -180,7 +175,8 @@ class VBenchEvalTask(BaseTask):
             if prompt_file and osp.isfile(prompt_file):
                 with open(prompt_file, 'r') as f:
                     prompt_list = json.load(f)
-                assert isinstance(prompt_list, dict), "prompt_file must be JSON dict {video_path: prompt}"
+                if not isinstance(prompt_list, dict):
+                    raise ValueError("prompt_file must be JSON dict {video_path: prompt}")
 
             kwargs = {}
             if eval_cfg.get('category'):

--- a/tests/UT/datasets/test_vbench.py
+++ b/tests/UT/datasets/test_vbench.py
@@ -1,0 +1,18 @@
+import unittest
+
+from datasets import Dataset
+
+from ais_bench.benchmark.datasets.vbench import VBenchDataset
+
+
+class TestVBenchDataset(unittest.TestCase):
+
+    def test_load_returns_placeholder(self):
+        ds = VBenchDataset.load(path='/any')
+        self.assertIsInstance(ds, Dataset)
+        self.assertEqual(len(ds), 1)
+        self.assertEqual(ds[0]['dummy'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/partitioners/test_base.py
+++ b/tests/UT/partitioners/test_base.py
@@ -22,6 +22,8 @@ class TestBasePartitioner(unittest.TestCase):
         self.assertIsNotNone(partitioner.keep_keys)
         self.assertIn('eval.runner.task.judge_cfg', partitioner.keep_keys)
         self.assertIn('eval.runner.task.dump_details', partitioner.keep_keys)
+        self.assertIn('VBENCH_CACHE_DIR', partitioner.keep_keys)
+        self.assertIn('vbench_cache_dir', partitioner.keep_keys)
 
     def test_base_partitioner_init_custom_keep_keys(self):
         """Test BasePartitioner initialization with custom keep_keys."""

--- a/tests/UT/summarizers/test_vbench.py
+++ b/tests/UT/summarizers/test_vbench.py
@@ -1,0 +1,107 @@
+"""Unit tests for VBenchSummarizer and helper functions."""
+import unittest
+from unittest.mock import patch
+
+from mmengine.config import ConfigDict
+
+import ais_bench.benchmark.summarizers.vbench as vbench_mod
+from ais_bench.benchmark.summarizers.vbench import (
+    VBenchSummarizer,
+    _abbr_to_const_key,
+    _get_normalized_score,
+)
+
+
+class TestVBenchHelpers(unittest.TestCase):
+
+    def test_abbr_from_regex(self):
+        self.assertEqual(
+            _abbr_to_const_key('vbench_custom_subject_consistency'),
+            'subject consistency',
+        )
+
+    def test_abbr_fallback_strip_prefix(self):
+        self.assertEqual(
+            _abbr_to_const_key('vbench_foo_bar'),
+            'foo bar',
+        )
+
+    def test_abbr_no_prefix(self):
+        self.assertEqual(_abbr_to_const_key('other_key'), 'other key')
+
+    def test_get_normalized_score_divides_when_above_one(self):
+        s = _get_normalized_score(100.0, 'subject consistency')
+        self.assertGreater(s, 0)
+        same_as_one = _get_normalized_score(1.0, 'subject consistency')
+        self.assertAlmostEqual(s, same_as_one, places=8)
+
+    def test_get_normalized_score_unknown_dim(self):
+        self.assertEqual(_get_normalized_score(0.99, 'not a dimension'), 0.0)
+
+    def test_get_normalized_score_zero_span_branch(self):
+        fake_norm = dict(vbench_mod.NORMALIZE_DIC)
+        fake_norm['zero_span_test'] = {'Min': 0.5, 'Max': 0.5}
+        fake_w = dict(vbench_mod.DIM_WEIGHT)
+        fake_w['zero_span_test'] = 2.0
+        with patch.multiple(vbench_mod, NORMALIZE_DIC=fake_norm, DIM_WEIGHT=fake_w):
+            high = _get_normalized_score(0.7, 'zero_span_test')
+            low = _get_normalized_score(0.3, 'zero_span_test')
+            self.assertEqual(high, 2.0)
+            self.assertEqual(low, 0.0)
+
+
+class TestVBenchSummarizer(unittest.TestCase):
+
+    @patch('ais_bench.benchmark.summarizers.default.AISLogger')
+    def test_calculate_group_metrics_writes_aggregate_scores(self, _logger):
+        cfg = ConfigDict({
+            'models': [{'abbr': 'model_a'}],
+            'datasets': [{'abbr': 'd1'}],
+            'work_dir': '/tmp',
+        })
+        summ = VBenchSummarizer(cfg, dataset_abbrs=['d1'], summary_groups=[])
+
+        raw_results = {'model_a': {}}
+        parsed_results = {
+            'model_a': {
+                'vbench_run_subject_consistency': {'accuracy': 100.0},
+                'vbench_run_object_class': {'accuracy': 100.0},
+            },
+        }
+        dataset_metrics = {}
+        dataset_eval_mode = {}
+
+        raw_results, parsed_results, dm, dem = summ._calculate_group_metrics(
+            raw_results, parsed_results, dataset_metrics, dataset_eval_mode,
+        )
+
+        self.assertIn('vbench_quality', parsed_results['model_a'])
+        self.assertIn('vbench_semantic', parsed_results['model_a'])
+        self.assertIn('vbench_total', parsed_results['model_a'])
+        for name in ('vbench_quality', 'vbench_semantic', 'vbench_total'):
+            self.assertAlmostEqual(
+                raw_results['model_a'][name]['accuracy'],
+                parsed_results['model_a'][name]['accuracy'],
+            )
+            self.assertIn(name, dm)
+            self.assertEqual(dm[name], ['accuracy'])
+            self.assertEqual(dem[name], 'gen')
+
+    @patch('ais_bench.benchmark.summarizers.default.AISLogger')
+    def test_calculate_group_metrics_skips_non_vbench_abbr(self, _logger):
+        cfg = ConfigDict({
+            'models': [{'abbr': 'm'}],
+            'datasets': [{'abbr': 'd1'}],
+            'work_dir': '/tmp',
+        })
+        summ = VBenchSummarizer(cfg)
+        parsed_results = {'m': {'plain_ds': {'accuracy': 55.0}}}
+        raw_results = {'m': {}}
+        _, pr, _, __ = summ._calculate_group_metrics(
+            raw_results, parsed_results.copy(), {}, {},
+        )
+        self.assertNotIn('vbench_total', pr['m'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/tasks/test_vbench_eval.py
+++ b/tests/UT/tasks/test_vbench_eval.py
@@ -1,0 +1,245 @@
+"""Unit tests for VBenchEvalTask (no real vbench/torch inference)."""
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from mmengine.config import ConfigDict
+
+from ais_bench.benchmark.tasks.vbench_eval import VBenchEvalTask
+
+
+@contextmanager
+def _fake_vbench_imports(mock_torch_device=None):
+    """Inject mock vbench / vbench.distributed / torch into sys.modules for ``run()``."""
+    mock_vmod = MagicMock()
+    mock_instance = MagicMock()
+    mock_instance.build_full_dimension_list.return_value = [
+        'subject_consistency',
+        'aesthetic_quality',
+    ]
+    mock_instance.evaluate.return_value = {'subject_consistency': {'score': 0.75}}
+    mock_vmod.VBench.return_value = mock_instance
+    mock_vmod.set_progress_callback = MagicMock()
+
+    mock_dist = MagicMock()
+    mock_dist.dist_init = MagicMock()
+    mock_dist.get_rank = MagicMock(return_value=0)
+    mock_dist.get_device = MagicMock(return_value='cpu')
+    mock_dist.dist_destroy = MagicMock()
+
+    mock_torch = MagicMock()
+    dev = MagicMock()
+
+    def _device(_x):
+        return dev
+
+    mock_torch.device = _device if mock_torch_device is None else mock_torch_device
+
+    prev = {}
+    for name in ('vbench', 'vbench.distributed', 'torch'):
+        prev[name] = sys.modules.pop(name, None)
+    sys.modules['vbench'] = mock_vmod
+    sys.modules['vbench.distributed'] = mock_dist
+    sys.modules['torch'] = mock_torch
+    try:
+        yield mock_vmod, mock_dist, mock_torch, mock_instance
+    finally:
+        for name in ('vbench', 'vbench.distributed', 'torch'):
+            sys.modules.pop(name, None)
+        for name, mod in prev.items():
+            if mod is not None:
+                sys.modules[name] = mod
+
+
+class TestVBenchEvalTaskHelpers(unittest.TestCase):
+    """Tests for helpers that need no mocked heavy imports."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.cfg = ConfigDict({
+            'work_dir': self.tmp,
+            'models': [{'abbr': 'm_ab', 'type': 'stub'}],
+            'datasets': [[{
+                'abbr': 'ds_ab',
+                'path': '/tmp/videos_placeholder',
+                'eval_cfg': {},
+            }]],
+            'cli_args': {},
+        })
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_infer_mode_explicit(self, _log):
+        task = VBenchEvalTask(self.cfg)
+        ds = {'path': '/x'}
+        ev = {'mode': 'vbench_standard'}
+        self.assertEqual(task._infer_mode(ds, ev), 'vbench_standard')
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_infer_mode_category(self, _log):
+        task = VBenchEvalTask(self.cfg)
+        ds = {'path': '/x'}
+        ev = {'category': 'motion'}
+        self.assertEqual(task._infer_mode(ds, ev), 'vbench_category')
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_infer_mode_prompt_sources(self, _log):
+        task = VBenchEvalTask(self.cfg)
+        ds = {'path': '/x', 'prompt_list': [{'a': 1}]}
+        self.assertEqual(task._infer_mode(ds, {}), 'custom_input')
+        ds2 = {'path': '/x'}
+        ev2 = {'prompt_list': [{}]}
+        self.assertEqual(task._infer_mode(ds2, ev2), 'custom_input')
+        ev3 = {'prompt_file': '/p.json'}
+        self.assertEqual(task._infer_mode(ds2, ev3), 'custom_input')
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_infer_mode_default_standard(self, _log):
+        task = VBenchEvalTask(self.cfg)
+        self.assertEqual(task._infer_mode({'path': '/x'}, {}), 'vbench_standard')
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_wrap_results_dict_score_and_tuple(self, _log):
+        task = VBenchEvalTask(self.cfg)
+        raw = {
+            'd1': {'score': 0.5},
+            'd2': {'mean_score': 0.5},
+            'd3': (0.4, [{'v': 1}]),
+            'd4': 'no_score',
+        }
+        out = task._wrap_results(raw)
+        self.assertAlmostEqual(out['accuracy'], 46.666666666666664, places=10)
+        self.assertIn('d1', out['details'])
+        self.assertEqual(out['details']['d3']['video_results'], [{'v': 1}])
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_wrap_results_empty_scores_accuracy_zero(self, _log):
+        task = VBenchEvalTask(self.cfg)
+        out = task._wrap_results({'only': {'value': 'x'}})
+        self.assertEqual(out['accuracy'], 0.0)
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    @patch.dict(os.environ, {}, clear=False)
+    def test_apply_cache_dir_priority_and_expand(self, _mock_log):
+        task = VBenchEvalTask(self.cfg)
+        with patch.dict(os.environ, {}, clear=True):
+            task.cfg['VBENCH_CACHE_DIR'] = '/wins_when_both_set'
+            task.cfg['vbench_cache_dir'] = '~/vb_cache'
+            task._apply_vbench_cache_dir_from_cfg()
+            self.assertEqual(os.environ['VBENCH_CACHE_DIR'], '/wins_when_both_set')
+        with patch.dict(os.environ, {}, clear=True):
+            task.cfg.pop('VBENCH_CACHE_DIR', None)
+            task.cfg['vbench_cache_dir'] = '~/vb_cache'
+            with patch.object(os.path, 'expanduser', side_effect=lambda p: p.replace('~/', '/home/me/')):
+                with patch.object(os.path, 'expandvars', side_effect=lambda p: p):
+                    task._apply_vbench_cache_dir_from_cfg()
+            self.assertEqual(os.environ['VBENCH_CACHE_DIR'], '/home/me/vb_cache')
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    @patch.dict(os.environ, {}, clear=False)
+    def test_apply_cache_dir_skips_empty(self, _mock_log):
+        task = VBenchEvalTask(self.cfg)
+        with patch.dict(os.environ, {}, clear=True):
+            task.cfg.pop('VBENCH_CACHE_DIR', None)
+            task.cfg.pop('vbench_cache_dir', None)
+            task._apply_vbench_cache_dir_from_cfg()
+            self.assertNotIn('VBENCH_CACHE_DIR', os.environ)
+        with patch.dict(os.environ, {}, clear=True):
+            task.cfg['VBENCH_CACHE_DIR'] = '   '
+            task._apply_vbench_cache_dir_from_cfg()
+            self.assertNotIn('VBENCH_CACHE_DIR', os.environ)
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    @patch('ais_bench.benchmark.tasks.vbench_eval.get_infer_output_path')
+    def test_get_output_paths(self, mock_path, _log):
+        mock_path.side_effect = lambda m, d, base, ext='json': f'{base}/{m["abbr"]}_{d["abbr"]}.{ext}'
+        task = VBenchEvalTask(self.cfg)
+        paths = task.get_output_paths()
+        self.assertEqual(len(paths), 1)
+        self.assertTrue(paths[0].endswith('m_ab_ds_ab.json'))
+
+
+class TestVBenchEvalTaskRunMocked(unittest.TestCase):
+    """``run()`` with sys.modules mocks."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.videos = os.path.join(self.tmp, 'vids')
+        os.makedirs(self.videos, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _task_cfg(self, **dataset_overrides):
+        ds = {
+            'abbr': 'vb_ds',
+            'path': self.videos,
+            'eval_cfg': {},
+        }
+        ds.update(dataset_overrides)
+        return ConfigDict({
+            'work_dir': self.tmp,
+            'models': [{'abbr': 'm1', 'type': 'stub'}],
+            'datasets': [[ds]],
+            'cli_args': {},
+        })
+
+    @patch('ais_bench.benchmark.tasks.vbench_eval.osp.isfile', return_value=True)
+    @patch('ais_bench.benchmark.tasks.vbench_eval.osp.isdir', return_value=True)
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_run_calls_build_full_dimension_list_when_missing(self, _log, _isdir, _isfile):
+        cfg = self._task_cfg()
+        task = VBenchEvalTask(cfg)
+        with _fake_vbench_imports() as (mock_vmod, mock_dist, _t, mock_inst):
+            task.run(None)
+            mock_inst.build_full_dimension_list.assert_called_once()
+            mock_inst.evaluate.assert_called_once()
+            mock_dist.dist_destroy.assert_called()
+
+        out_json = os.path.join(
+            self.tmp, task.output_subdir, 'm1', 'vb_ds.json',
+        )
+        self.assertTrue(os.path.isfile(out_json))
+        with open(out_json, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        self.assertIn('accuracy', data)
+        self.assertIn('details', data)
+
+    @patch('ais_bench.benchmark.tasks.vbench_eval.osp.isfile', return_value=True)
+    @patch('ais_bench.benchmark.tasks.vbench_eval.osp.isdir', return_value=True)
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_run_prompt_file_not_dict_raises_valueerror(self, _log, _isdir, _isfile):
+        bad_json = os.path.join(self.tmp, 'prompts_bad.json')
+        with open(bad_json, 'w', encoding='utf-8') as f:
+            json.dump([], f)
+
+        cfg = self._task_cfg(
+            eval_cfg={'prompt_file': bad_json},
+        )
+        task = VBenchEvalTask(cfg)
+        with _fake_vbench_imports():
+            with self.assertRaises(ValueError) as ctx:
+                task.run(None)
+            self.assertIn('prompt_file', str(ctx.exception))
+
+    @patch('ais_bench.benchmark.tasks.vbench_eval.osp.isfile', return_value=True)
+    @patch('ais_bench.benchmark.tasks.vbench_eval.osp.isdir', return_value=True)
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_run_registers_progress_callback_with_state_manager(self, _log, _isdir, _isfile):
+        cfg = self._task_cfg()
+        task = VBenchEvalTask(cfg)
+        tsm = MagicMock()
+        with _fake_vbench_imports() as (mock_vmod, *_):
+            task.run(tsm)
+            mock_vmod.set_progress_callback.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [x] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**

（暂无）<!-- Fixes # / Relates to # -->

## 🔍 Motivation / 变更动机

在 ais_bench 中接入 [VBench 1.0](https://github.com/Vchitect/VBench) 类视频/图像质量评测：对给定视频目录跑官方多维指标（质量、语义、风格等），评测结果结构与现有 benchmark 任务输出对齐，并可通过配置控制缓存与运行模式。子进程通过仓库内 `third_party` 与 `detectron2` 路径解析依赖；`VBENCH_CACHE_DIR` / `vbench_cache_dir` 在分区阶段写入任务配置，供子进程在 import vbench 前生效。

## 📝 Modification / 修改内容

- **任务**：新增 `VBenchEvalTask`（`ais_bench/benchmark/tasks/vbench_eval.py`），解析 dataset / eval 配置，推断运行模式（`vbench_standard` / `vbench_category` / `custom_input` 等），调用 VBench 并将各维度原始结果规整为 `{accuracy, details}`。
- **数据集**：新增 `VBenchDataset`（`ais_bench/benchmark/datasets/vbench.py`）及注册，提供最小占位 `load()`；实际评测由任务直接读取 dataset 配置完成。
- **汇总**：新增 `VBenchSummarizer`（`ais_bench/benchmark/summarizers/vbench.py`），使用官方归一化区间与维度权重聚合。
- **配置与注册**：`configs/summarizers/vbench.py`；更新 `tasks/__init__.py`、`datasets/__init__.py`、`summarizers/__init__.py`。
- **分区**：`BasePartitioner` 默认 `keep_keys` 增加 `VBENCH_CACHE_DIR`、`vbench_cache_dir`，保证子进程任务 cfg 可复制上述键。

## 📐 Associated Test Results / 关联测试结果

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

否。本次为新增任务、数据集占位类、汇总器与可选顶层配置键传递，不改变既有任务默认行为。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

未专门评估；VBench 本身依赖 GPU/NPU 与模型推理，开销由评测工作量决定。

## 🌟 Use cases (Optional) / 使用案例（可选）

- 对一批生成视频批量跑 VBench 标准或分类维度，与现有 ais_bench 分区、汇总流程一致。
- 通过自定义 prompt 列表等走 `custom_input` 场景（由 `eval_cfg` / dataset 配置共同决定）。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
