### PR TITLE
feat(UT): add swe-bench_pro UT tests

### DIFF
--- a/tests/UT/tasks/swebp_pro/conftest.py
+++ b/tests/UT/tasks/swebp_pro/conftest.py
@@ -437,12 +437,21 @@ def _setup_mocks():
         'charset_normalizer': charset_normalizer,
     }
 
+    return MOCK_MODULES
+
+
+MOCK_MODULES = _setup_mocks()
+
+import pytest
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_system_modules():
+    original_modules = {k: sys.modules[k] for k in MOCK_MODULES if k in sys.modules}
     for mod_name, mock_obj in MOCK_MODULES.items():
-        if mod_name not in sys.modules:
-            sys.modules[mod_name] = mock_obj
-
-    return len(MOCK_MODULES)
-
-
-num_mocked = _setup_mocks()
-print(f"[conftest] Mocked {num_mocked} modules at module load time", flush=True)
+        sys.modules[mod_name] = mock_obj
+    yield
+    for mod_name in MOCK_MODULES:
+        if mod_name in original_modules:
+            sys.modules[mod_name] = original_modules[mod_name]
+        else:
+            sys.modules.pop(mod_name, None)

--- a/tests/UT/tasks/swebp_pro/conftest.py
+++ b/tests/UT/tasks/swebp_pro/conftest.py
@@ -1,0 +1,448 @@
+import sys
+import os
+import json
+from unittest.mock import MagicMock
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+
+def _setup_mocks():
+    minisweagent = type('minisweagent', (), {})()
+    minisweagent.run = type('run', (), {})()
+    minisweagent.run.utils = type('utils', (), {})()
+    minisweagent.run.utils.batch_instances = type('batch_instances', (), {})()
+    minisweagent.run.utils.batch_instances.BatchInstance = MagicMock
+    minisweagent.run.extra = type('extra', (), {})()
+    minisweagent.run.extra.utils = type('utils', (), {})()
+    minisweagent.run.extra.utils.batch_progress = type('batch_progress', (), {})()
+    minisweagent.run.extra.utils.batch_progress.RunBatchProgressManager = MagicMock
+    minisweagent.run.extra.run_batch = type('run_batch', (), {})()
+    minisweagent.run.extra.run_batch.process_instance = MagicMock()
+    minisweagent.run.extra.run_batch.RunBatchConfig = MagicMock()
+    minisweagent.config = type('config', (), {})()
+    minisweagent.config.get_config_path = MagicMock()
+
+    orjson = MagicMock()
+    orjson.loads = MagicMock(return_value={})
+    orjson.dumps = MagicMock(return_value=b'{}')
+
+    docker = MagicMock()
+    docker.errors = type('errors', (), {})()
+    docker.errors.Timeout = Exception
+    docker.errors.ImageNotFound = Exception
+    docker.from_env = MagicMock()
+
+    transformers = MagicMock()
+    transformers.AutoTokenizer = MagicMock()
+    transformers.AutoTokenizer.from_pretrained = MagicMock()
+
+    fcntl = MagicMock()
+    fcntl.flock = MagicMock()
+    fcntl.LOCK_EX = 1
+    fcntl.LOCK_UN = 2
+
+    tqdm = MagicMock()
+    tqdm.auto = MagicMock()
+    tqdm.auto.tqdm = MagicMock()
+
+    datasets = MagicMock()
+    datasets.Dataset = MagicMock()
+    datasets.DatasetDict = MagicMock()
+    datasets.load_dataset = MagicMock()
+    datasets.load_from_disk = MagicMock()
+    datasets.features = MagicMock()
+    datasets.features.Features = MagicMock()
+    datasets.features.Value = MagicMock()
+    datasets.utils = MagicMock()
+    datasets.utils.logging = MagicMock()
+    datasets.utils.logging.disable_progress_bar = MagicMock()
+
+    scipy = MagicMock()
+    scipy.stats = MagicMock()
+    scipy.stats.hypergeom = MagicMock()
+    scipy.integrate = MagicMock()
+
+    jieba = MagicMock()
+    jieba.cut = MagicMock(return_value=[])
+    jieba.lcut = MagicMock(return_value=[])
+
+    rouge_chinese = MagicMock()
+    rouge_chinese.Rouge = MagicMock()
+
+    mmengine = MagicMock()
+    mmengine.registry = MagicMock()
+    mmengine.registry.METRICS = MagicMock()
+    mmengine.registry.Registry = type('Registry', (), {
+        '__init__': lambda *args, **kwargs: None,
+        'register_module': lambda *args, **kwargs: (lambda f: f),
+    })
+    mmengine.config = MagicMock()
+    mmengine.config.ConfigDict = dict
+    mmengine.config.Config = MagicMock
+    mmengine.fileio = MagicMock()
+    mmengine.utils = MagicMock()
+    mmengine.logging = MagicMock()
+    mmengine.logging.MessageHub = MagicMock
+    mmengine.hub = MagicMock()
+    mmengine.dist = MagicMock()
+    mmengine.device = MagicMock()
+    mmengine.visualization = MagicMock()
+    mmengine.optim = MagicMock()
+    mmengine.runner = MagicMock()
+    mmengine.structures = MagicMock()
+    mmengine.structures.InstanceData = MagicMock
+    mmengine.load = MagicMock()
+    mmengine.load.side_effect = lambda path: json.load(open(path))
+    mmengine_lite = MagicMock()
+    mmengine_lite.logging = MagicMock()
+    mmengine_lite.logging.MessageHub = MagicMock
+
+    evaluate = MagicMock()
+    evaluate.load = MagicMock(return_value=MagicMock())
+    evaluate.combine = MagicMock(return_value=MagicMock())
+
+    nltk = MagicMock()
+    nltk.translate = MagicMock()
+    nltk.translate.bleu_score = MagicMock()
+    nltk.translate.bleu_score.sentence_bleu = MagicMock(return_value=0.5)
+    nltk.tokenize = MagicMock()
+    nltk.tokenize.word_tokenize = MagicMock(return_value=[])
+
+    accelerate = MagicMock()
+
+    transformers = MagicMock()
+    transformers.AutoTokenizer = MagicMock()
+    transformers.AutoTokenizer.from_pretrained = MagicMock()
+    transformers.AutoModelForCausalLM = MagicMock()
+    transformers.AutoModelForCausalLM.from_pretrained = MagicMock()
+    transformers.pipeline = MagicMock()
+    transformers.BitsAndBytesConfig = MagicMock()
+    transformers.GenerationConfig = MagicMock()
+    transformers.StopStringCriteria = MagicMock()
+    transformers.StoppingCriteriaList = MagicMock()
+    transformers.generation = MagicMock()
+    transformers.generation.stopping_criteria = MagicMock()
+    transformers.generation.stopping_criteria.StoppingCriteria = type('StoppingCriteria', (), {})
+
+    peft = MagicMock()
+    peft.LoraConfig = MagicMock()
+    peft.get_peft_model = MagicMock()
+
+    bitsandbytes = MagicMock()
+
+    trl = MagicMock()
+    trl.SFTConfig = MagicMock()
+    trl.SFTTrainer = MagicMock()
+
+    einops = MagicMock()
+
+    func_timeout = MagicMock()
+    func_timeout.func_timeout = MagicMock()
+    func_timeout.FunctionTimedOut = Exception
+
+    fuzzywuzzy = MagicMock()
+    fuzzywuzzy.fuzz = MagicMock()
+    fuzzywuzzy.fuzz.ratio = MagicMock(return_value=80)
+    fuzzywuzzy.process = MagicMock()
+
+    jsonlines = MagicMock()
+    jsonlines.open = MagicMock()
+
+    absl = MagicMock()
+    absl.flags = MagicMock()
+    absl.logging = MagicMock()
+
+    cpm_kernels = MagicMock()
+
+    gradio_client = MagicMock()
+    gradio_client.Client = MagicMock()
+
+    immutabledict = MagicMock()
+    immutabledict.Immutabledict = dict
+
+    janus = MagicMock()
+    janus.Queue = type('Queue', (), {
+        'async_q': MagicMock,
+        'sync_q': MagicMock,
+    })
+
+    loguru = MagicMock()
+    loguru.logger = MagicMock()
+
+    rich = MagicMock()
+    rich.live = MagicMock()
+    rich.live.Live = MagicMock
+    rich.console = MagicMock()
+    rich.console.Console = MagicMock
+    rich.table = MagicMock()
+    rich.table.Table = MagicMock
+    rich.panel = MagicMock()
+    rich.panel.Panel = MagicMock
+    rich.text = MagicMock()
+    rich.text.Text = MagicMock
+    rich.progress = MagicMock()
+    rich.progress.Progress = MagicMock
+
+    openai = MagicMock()
+    openai.OpenAI = MagicMock
+    openai.AsyncOpenAI = MagicMock
+    openai.APIError = Exception
+    openai.APIConnectionError = Exception
+    openai.RateLimitError = Exception
+
+    requests = MagicMock()
+    requests.get = MagicMock()
+    requests.post = MagicMock()
+    requests.Session = MagicMock
+
+    yaml = MagicMock()
+    yaml.safe_load = MagicMock(return_value={})
+    yaml.safe_dump = MagicMock()
+
+    toml = MagicMock()
+    toml.load = MagicMock(return_value={})
+    toml.dumps = MagicMock()
+
+    PIL = MagicMock()
+    PIL.Image = MagicMock()
+    PIL.Image.open = MagicMock()
+
+    cv2 = MagicMock()
+
+    torch = MagicMock()
+    torch.Tensor = MagicMock
+    torch.nn = MagicMock()
+    torch.nn.Module = MagicMock
+    torch.optim = MagicMock()
+    torch.utils = MagicMock()
+    torch.utils.data = MagicMock()
+    torch.utils.data.DataLoader = MagicMock
+    torch.utils.data.Dataset = MagicMock
+    torch.cuda = MagicMock()
+    torch.cuda.is_available = MagicMock(return_value=False)
+    torch.device = MagicMock
+    torch.no_grad = MagicMock()
+
+    safetensors = MagicMock()
+    safetensors.torch = MagicMock()
+    safetensors.torch.load_file = MagicMock(return_value={})
+
+    sentence_transformers = MagicMock()
+    sentence_transformers.SentenceTransformer = MagicMock
+
+    rouge_score = MagicMock()
+    rouge_score.rouge_scorer = MagicMock()
+    rouge_score.rouge_scorer.RougeScorer = MagicMock
+
+    prompt_toolkit = MagicMock()
+    prompt_toolkit.shortcuts = MagicMock()
+
+    python_multipart = MagicMock()
+
+    aiohttp = MagicMock()
+    aiohttp.ClientSession = MagicMock
+
+    httpx = MagicMock()
+    httpx.Client = MagicMock
+    httpx.AsyncClient = MagicMock
+
+    tiktoken = MagicMock()
+    tiktoken.Encoding = MagicMock
+    tiktoken.get_encoding = MagicMock(return_value=MagicMock())
+    tiktoken.encoding_for_model = MagicMock(return_value=MagicMock())
+
+    lark = MagicMock()
+    lark.Lark = MagicMock
+    lark.Transformer = type('Transformer', (), {})
+
+    sympy = MagicMock()
+    sympy.sympify = MagicMock(return_value=MagicMock())
+    sympy.Eq = MagicMock
+    sympy.solve = MagicMock(return_value=[])
+
+    Levenshtein = MagicMock()
+    Levenshtein.distance = MagicMock(return_value=0)
+
+    rapidfuzz = MagicMock()
+    rapidfuzz.distance = MagicMock()
+    rapidfuzz.distance.Levenshtein = MagicMock()
+    rapidfuzz.distance.Levenshtein.distance = MagicMock(return_value=0)
+
+    latex2sympy2 = MagicMock()
+    latex2sympy2.latex2sympy = MagicMock(return_value=MagicMock())
+
+    antlr4 = MagicMock()
+
+    pycocoevalcap = MagicMock()
+    pycocoevalcap.bleu = MagicMock()
+    pycocoevalcap.bleu.bleu = MagicMock()
+    pycocoevalcap.cider = MagicMock()
+    pycocoevalcap.cider.cider = MagicMock()
+    pycocoevalcap.rouge = MagicMock()
+    pycocoevalcap.rouge.rouge = MagicMock()
+    pycocoevalcap.meteor = MagicMock()
+    pycocoevalcap.meteor.meteor = MagicMock()
+    pycocoevalcap.tokenizer = MagicMock()
+
+    pycocotools = MagicMock()
+    pycocotools.coco = MagicMock()
+    pycocotools.coco.COCO = MagicMock
+    pycocotools.cocoeval = MagicMock()
+
+    jiwer = MagicMock()
+    jiwer.compute_measures = MagicMock(return_value={})
+
+    sacrebleu = MagicMock()
+    sacrebleu.corpus_bleu = MagicMock(return_value=MagicMock(score=0))
+    sacrebleu.BLEU = MagicMock
+
+    bert_score = MagicMock()
+    bert_score.score = MagicMock(return_value=([], [], []))
+
+    resource = MagicMock()
+    resource.getrlimit = MagicMock(return_value=(1000, 1000))
+    resource.setrlimit = MagicMock()
+    resource.RLIMIT_AS = 1
+    resource.RLIMIT_CPU = 2
+
+    rouge = MagicMock()
+    rouge.Rouge = MagicMock
+
+    chardet = MagicMock()
+
+    charset_normalizer = MagicMock()
+
+    MOCK_MODULES = {
+        'minisweagent': minisweagent,
+        'minisweagent.run': minisweagent.run,
+        'minisweagent.run.utils': minisweagent.run.utils,
+        'minisweagent.run.utils.batch_instances': minisweagent.run.utils.batch_instances,
+        'minisweagent.run.extra': minisweagent.run.extra,
+        'minisweagent.run.extra.utils': minisweagent.run.extra.utils,
+        'minisweagent.run.extra.utils.batch_progress': minisweagent.run.extra.utils.batch_progress,
+        'minisweagent.run.extra.run_batch': minisweagent.run.extra.run_batch,
+        'minisweagent.config': minisweagent.config,
+        'orjson': orjson,
+        'docker': docker,
+        'docker.errors': docker.errors,
+        'transformers': transformers,
+        'transformers.generation': transformers.generation,
+        'transformers.generation.stopping_criteria': transformers.generation.stopping_criteria,
+        'fcntl': fcntl,
+        'tqdm': tqdm,
+        'tqdm.auto': tqdm.auto,
+        'datasets': datasets,
+        'datasets.features': datasets.features,
+        'datasets.utils': datasets.utils,
+        'datasets.utils.logging': datasets.utils.logging,
+        'scipy': scipy,
+        'scipy.stats': scipy.stats,
+        'scipy.integrate': scipy.integrate,
+        'jieba': jieba,
+        'rouge_chinese': rouge_chinese,
+        'mmengine': mmengine,
+        'mmengine.registry': mmengine.registry,
+        'mmengine.config': mmengine.config,
+        'mmengine.fileio': mmengine.fileio,
+        'mmengine.utils': mmengine.utils,
+        'mmengine.logging': mmengine.logging,
+        'mmengine.hub': mmengine.hub,
+        'mmengine.dist': mmengine.dist,
+        'mmengine.device': mmengine.device,
+        'mmengine.visualization': mmengine.visualization,
+        'mmengine.optim': mmengine.optim,
+        'mmengine.runner': mmengine.runner,
+        'mmengine.structures': mmengine.structures,
+        'mmengine_lite': mmengine_lite,
+        'mmengine_lite.logging': mmengine_lite.logging,
+        'evaluate': evaluate,
+        'nltk': nltk,
+        'nltk.translate': nltk.translate,
+        'nltk.translate.bleu_score': nltk.translate.bleu_score,
+        'nltk.tokenize': nltk.tokenize,
+        'accelerate': accelerate,
+        'peft': peft,
+        'bitsandbytes': bitsandbytes,
+        'trl': trl,
+        'einops': einops,
+        'func_timeout': func_timeout,
+        'fuzzywuzzy': fuzzywuzzy,
+        'fuzzywuzzy.fuzz': fuzzywuzzy.fuzz,
+        'fuzzywuzzy.process': fuzzywuzzy.process,
+        'jsonlines': jsonlines,
+        'absl': absl,
+        'absl.flags': absl.flags,
+        'absl.logging': absl.logging,
+        'cpm_kernels': cpm_kernels,
+        'gradio_client': gradio_client,
+        'immutabledict': immutabledict,
+        'janus': janus,
+        'loguru': loguru,
+        'rich': rich,
+        'rich.live': rich.live,
+        'rich.console': rich.console,
+        'rich.table': rich.table,
+        'rich.panel': rich.panel,
+        'rich.text': rich.text,
+        'rich.progress': rich.progress,
+        'openai': openai,
+        'requests': requests,
+        'yaml': yaml,
+        'toml': toml,
+        'PIL': PIL,
+        'PIL.Image': PIL.Image,
+        'cv2': cv2,
+        'torch': torch,
+        'torch.nn': torch.nn,
+        'torch.optim': torch.optim,
+        'torch.utils': torch.utils,
+        'torch.utils.data': torch.utils.data,
+        'torch.cuda': torch.cuda,
+        'safetensors': safetensors,
+        'safetensors.torch': safetensors.torch,
+        'sentence_transformers': sentence_transformers,
+        'rouge_score': rouge_score,
+        'rouge_score.rouge_scorer': rouge_score.rouge_scorer,
+        'prompt_toolkit': prompt_toolkit,
+        'prompt_toolkit.shortcuts': prompt_toolkit.shortcuts,
+        'python_multipart': python_multipart,
+        'aiohttp': aiohttp,
+        'httpx': httpx,
+        'tiktoken': tiktoken,
+        'lark': lark,
+        'sympy': sympy,
+        'Levenshtein': Levenshtein,
+        'rapidfuzz': rapidfuzz,
+        'rapidfuzz.distance': rapidfuzz.distance,
+        'rapidfuzz.distance.Levenshtein': rapidfuzz.distance.Levenshtein,
+        'latex2sympy2': latex2sympy2,
+        'antlr4': antlr4,
+        'pycocoevalcap': pycocoevalcap,
+        'pycocoevalcap.bleu': pycocoevalcap.bleu,
+        'pycocoevalcap.cider': pycocoevalcap.cider,
+        'pycocoevalcap.rouge': pycocoevalcap.rouge,
+        'pycocoevalcap.meteor': pycocoevalcap.meteor,
+        'pycocoevalcap.tokenizer': pycocoevalcap.tokenizer,
+        'pycocotools': pycocotools,
+        'pycocotools.coco': pycocotools.coco,
+        'pycocotools.cocoeval': pycocotools.cocoeval,
+        'jiwer': jiwer,
+        'sacrebleu': sacrebleu,
+        'bert_score': bert_score,
+        'resource': resource,
+        'rouge': rouge,
+        'chardet': chardet,
+        'charset_normalizer': charset_normalizer,
+    }
+
+    for mod_name, mock_obj in MOCK_MODULES.items():
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = mock_obj
+
+    return len(MOCK_MODULES)
+
+
+num_mocked = _setup_mocks()
+print(f"[conftest] Mocked {num_mocked} modules at module load time", flush=True)

--- a/tests/UT/tasks/swebp_pro/test_dataset_swebench_pro.py
+++ b/tests/UT/tasks/swebp_pro/test_dataset_swebench_pro.py
@@ -1,0 +1,179 @@
+"""Unit tests for ais_bench.benchmark.datasets.swebench_pro"""
+import unittest
+import tempfile
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from ais_bench.benchmark.datasets import swebench_pro as dataset_module
+
+
+class TestParquetShardsForSplit(unittest.TestCase):
+    """Test _parquet_shards_for_split function."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset_module = dataset_module
+
+    def test_finds_shards_for_split(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "test-00000-of-00002.parquet").write_text("")
+            (root / "test-00001-of-00002.parquet").write_text("")
+            result = self.dataset_module._parquet_shards_for_split(root, "test")
+            self.assertIsNotNone(result)
+            self.assertEqual(len(result), 2)
+
+    def test_returns_none_for_missing_split(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            result = self.dataset_module._parquet_shards_for_split(root, "nonexistent")
+            self.assertIsNone(result)
+
+    def test_finds_shards_in_data_subdir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "data").mkdir()
+            (root / "data" / "test-00000-of-00002.parquet").write_text("")
+            result = self.dataset_module._parquet_shards_for_split(root, "test")
+            self.assertIsNotNone(result)
+            self.assertEqual(len(result), 1)
+
+
+class TestParquetDataFilesForRoot(unittest.TestCase):
+    """Test _parquet_data_files_for_root function."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset_module = dataset_module
+
+    @patch.object(Path, 'is_file', return_value=True)
+    def test_returns_file_dict_for_file_path(self, mock_is_file):
+        test_path = Path("/data/test.parquet")
+        result = self.dataset_module._parquet_data_files_for_root(test_path, "test")
+        self.assertEqual(result, {"test": str(test_path)})
+
+    @patch.object(Path, 'is_file', return_value=False)
+    def test_returns_none_when_no_shards(self, mock_is_file):
+        with patch.object(self.dataset_module, '_parquet_shards_for_split', return_value=None):
+            result = self.dataset_module._parquet_data_files_for_root(Path("/data"), "test")
+            self.assertIsNone(result)
+
+    @patch.object(Path, 'is_file', return_value=False)
+    def test_returns_shards_when_found(self, mock_is_file):
+        with patch.object(self.dataset_module, '_parquet_shards_for_split', return_value=["shard1.parquet", "shard2.parquet"]):
+            result = self.dataset_module._parquet_data_files_for_root(Path("/data"), "test")
+            self.assertEqual(result["test"], ["shard1.parquet", "shard2.parquet"])
+
+
+class TestFilterInstancesMethod(unittest.TestCase):
+    """Test SWEBenchProDataset.filter_instances method."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset_module = dataset_module
+
+    def test_filters_by_instance_id_pattern(self):
+        dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
+        dataset.logger = MagicMock()
+        instances = [
+            {"instance_id": "id1"},
+            {"instance_id": "id2"},
+            {"instance_id": "other"},
+        ]
+        result = dataset.filter_instances(instances, filter_spec="^id")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["instance_id"], "id1")
+        self.assertEqual(result[1]["instance_id"], "id2")
+
+    def test_returns_all_when_no_filter(self):
+        dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
+        dataset.logger = MagicMock()
+        instances = [
+            {"instance_id": "id1"},
+            {"instance_id": "id2"},
+        ]
+        result = dataset.filter_instances(instances, filter_spec="")
+        self.assertEqual(len(result), 2)
+
+    def test_shuffles_when_enabled(self):
+        dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
+        dataset.logger = MagicMock()
+        instances = [
+            {"instance_id": "id1"},
+            {"instance_id": "id2"},
+            {"instance_id": "id3"},
+        ]
+        result = dataset.filter_instances(instances, filter_spec="", shuffle=True)
+        self.assertEqual(len(result), 3)
+
+
+class TestDatasetLoad(unittest.TestCase):
+    """Test SWEBenchProDataset.load method."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset_module = dataset_module
+
+    def test_raises_for_invalid_dataset_name(self):
+        dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
+        dataset.logger = MagicMock()
+
+        with self.assertRaises(Exception):
+            dataset.load("invalid_name", "test", "", False)
+
+    @patch('ais_bench.benchmark.datasets.swebench_pro.load_dataset')
+    def test_raises_when_hf_load_fails(self, mock_load_dataset):
+        dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
+        dataset.logger = MagicMock()
+
+        mock_load_dataset.side_effect = Exception("HF Error")
+
+        with self.assertRaises(Exception):
+            dataset.load("mini", path="", split="test", filter_spec="", shuffle=False)
+
+    @patch('ais_bench.benchmark.datasets.swebench_pro.get_data_path')
+    @patch('ais_bench.benchmark.datasets.swebench_pro.load_dataset')
+    def test_raises_when_local_path_resolve_fails(self, mock_load_dataset, mock_get_data):
+        dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
+        dataset.logger = MagicMock()
+
+        mock_get_data.side_effect = Exception("Path Error")
+
+        with self.assertRaises(Exception):
+            dataset.load("mini", "test", "/local/path", False)
+
+    @patch('ais_bench.benchmark.datasets.swebench_pro.get_data_path')
+    def test_raises_when_no_parquet_found(self, mock_get_data):
+        dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
+        dataset.logger = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_get_data.return_value = tmpdir
+
+            with self.assertRaises(Exception):
+                dataset.load("mini", "test", tmpdir, False)
+
+    @patch('ais_bench.benchmark.datasets.swebench_pro.get_data_path')
+    @patch('ais_bench.benchmark.datasets.swebench_pro.load_dataset')
+    def test_raises_when_local_parquet_load_fails(self, mock_load_dataset, mock_get_data):
+        dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
+        dataset.logger = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_get_data.return_value = tmpdir
+            Path(tmpdir) / "test-00000-of-00001.parquet"
+            (Path(tmpdir) / "test-00000-of-00001.parquet").write_text("")
+            mock_load_dataset.side_effect = Exception("Load Error")
+
+            with self.assertRaises(Exception):
+                dataset.load("mini", "test", tmpdir, False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/tasks/swebp_pro/test_dataset_swebench_pro.py
+++ b/tests/UT/tasks/swebp_pro/test_dataset_swebench_pro.py
@@ -124,7 +124,8 @@ class TestDatasetLoad(unittest.TestCase):
         dataset = self.dataset_module.SWEBenchProDataset.__new__(self.dataset_module.SWEBenchProDataset)
         dataset.logger = MagicMock()
 
-        with self.assertRaises(Exception):
+        from ais_bench.benchmark.utils.logging.exceptions import ParameterValueError
+        with self.assertRaises(ParameterValueError):
             dataset.load("invalid_name", "test", "", False)
 
     @patch('ais_bench.benchmark.datasets.swebench_pro.load_dataset')
@@ -167,7 +168,6 @@ class TestDatasetLoad(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             mock_get_data.return_value = tmpdir
-            Path(tmpdir) / "test-00000-of-00001.parquet"
             (Path(tmpdir) / "test-00000-of-00001.parquet").write_text("")
             mock_load_dataset.side_effect = Exception("Load Error")
 

--- a/tests/UT/tasks/swebp_pro/test_swebench_pro_summarizer.py
+++ b/tests/UT/tasks/swebp_pro/test_swebench_pro_summarizer.py
@@ -1,0 +1,214 @@
+"""Unit tests for ais_bench.benchmark.summarizers.swebench_pro"""
+import unittest
+import tempfile
+import os
+import sys
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from ais_bench.benchmark.summarizers import swebench_pro as summarizer_module
+
+
+class TestSWEBenchProSummarizer(unittest.TestCase):
+    """Test SWEBenchProSummarizer class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.summarizer_module = summarizer_module
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.work_dir = os.path.join(self.temp_dir, "work_dir")
+        os.makedirs(self.work_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _create_mock_cfg(self, model_abbr, dataset_abbr):
+        model_cfg = {
+            "type": "MockModel",
+            "model_abbr": model_abbr,
+            "abbr": model_abbr,
+        }
+
+        dataset_cfg = {
+            "type": "MockDataset",
+            "dataset_abbr": dataset_abbr,
+            "path": f"dataset/path/{dataset_abbr}",
+            "dataset_name": dataset_abbr,
+            "abbr": dataset_abbr,
+        }
+
+        return model_cfg, dataset_cfg
+
+    def test_pick_up_results_success(self):
+        results_dir = os.path.join(self.work_dir, "results")
+        os.makedirs(results_dir, exist_ok=True)
+
+        report_data = {
+            "total_instances_num": 100,
+            "eval_resolved_instances_num": 50,
+            "accuracy": 50.0,
+        }
+        report_path = os.path.join(results_dir, "model1_dataset1_report.json")
+        with open(report_path, "w") as f:
+            json.dump(report_data, f)
+
+        model_cfg, dataset_cfg = self._create_mock_cfg("model1", "dataset1")
+
+        summarizer = self.summarizer_module.SWEBenchProSummarizer.__new__(
+            self.summarizer_module.SWEBenchProSummarizer
+        )
+        summarizer.work_dir = self.work_dir
+        summarizer.model_cfgs = [model_cfg]
+        summarizer.dataset_cfgs = [dataset_cfg]
+        summarizer.logger = MagicMock()
+
+        raw_results, parsed_results, dataset_metrics, dataset_eval_mode = summarizer._pick_up_results()
+
+        self.assertEqual(raw_results["model1"]["dataset1"]["accuracy"], 50.0)
+        self.assertEqual(raw_results["model1"]["dataset1"]["correct_count"], 50)
+        self.assertEqual(raw_results["model1"]["dataset1"]["total_count"], 100)
+        self.assertEqual(parsed_results["model1"]["dataset1"]["accuracy"], 50.0)
+        self.assertEqual(dataset_metrics["dataset1"], ["accuracy"])
+        self.assertEqual(dataset_eval_mode["dataset1"], "agent")
+
+    def test_pick_up_results_missing_report(self):
+        model_cfg, dataset_cfg = self._create_mock_cfg("model1", "dataset1")
+
+        summarizer = self.summarizer_module.SWEBenchProSummarizer.__new__(
+            self.summarizer_module.SWEBenchProSummarizer
+        )
+        summarizer.work_dir = self.work_dir
+        summarizer.model_cfgs = [model_cfg]
+        summarizer.dataset_cfgs = [dataset_cfg]
+        summarizer.logger = MagicMock()
+
+        raw_results, parsed_results, dataset_metrics, dataset_eval_mode = summarizer._pick_up_results()
+
+        self.assertEqual(raw_results["model1"], {})
+        self.assertEqual(parsed_results["model1"], {})
+        self.assertEqual(dataset_eval_mode["dataset1"], "agent")
+
+    def test_pick_up_results_invalid_json(self):
+        results_dir = os.path.join(self.work_dir, "results")
+        os.makedirs(results_dir, exist_ok=True)
+
+        report_path = os.path.join(results_dir, "model1_dataset1_report.json")
+        with open(report_path, "w") as f:
+            f.write("invalid json {")
+
+        model_cfg, dataset_cfg = self._create_mock_cfg("model1", "dataset1")
+
+        summarizer = self.summarizer_module.SWEBenchProSummarizer.__new__(
+            self.summarizer_module.SWEBenchProSummarizer
+        )
+        summarizer.work_dir = self.work_dir
+        summarizer.model_cfgs = [model_cfg]
+        summarizer.dataset_cfgs = [dataset_cfg]
+        summarizer.logger = MagicMock()
+
+        raw_results, parsed_results, dataset_metrics, dataset_eval_mode = summarizer._pick_up_results()
+
+        self.assertEqual(raw_results["model1"], {})
+        self.assertEqual(dataset_eval_mode["dataset1"], "agent")
+
+    def test_pick_up_results_non_dict_report(self):
+        results_dir = os.path.join(self.work_dir, "results")
+        os.makedirs(results_dir, exist_ok=True)
+
+        report_path = os.path.join(results_dir, "model1_dataset1_report.json")
+        with open(report_path, "w") as f:
+            json.dump(["not", "a", "dict"], f)
+
+        model_cfg, dataset_cfg = self._create_mock_cfg("model1", "dataset1")
+
+        summarizer = self.summarizer_module.SWEBenchProSummarizer.__new__(
+            self.summarizer_module.SWEBenchProSummarizer
+        )
+        summarizer.work_dir = self.work_dir
+        summarizer.model_cfgs = [model_cfg]
+        summarizer.dataset_cfgs = [dataset_cfg]
+        summarizer.logger = MagicMock()
+
+        raw_results, parsed_results, dataset_metrics, dataset_eval_mode = summarizer._pick_up_results()
+
+        self.assertEqual(raw_results["model1"], {})
+        self.assertEqual(dataset_eval_mode["dataset1"], "agent")
+
+    def test_pick_up_results_multiple_models_and_datasets(self):
+        results_dir = os.path.join(self.work_dir, "results")
+        os.makedirs(results_dir, exist_ok=True)
+
+        for model_idx in [1, 2]:
+            for dataset_idx in [1, 2]:
+                report_data = {
+                    "total_instances_num": 100 + model_idx * 10 + dataset_idx,
+                    "eval_resolved_instances_num": 50 + model_idx * 5 + dataset_idx,
+                    "accuracy": 50.0 + model_idx * 5 + dataset_idx,
+                }
+                report_path = os.path.join(
+                    results_dir, f"model{model_idx}_dataset{dataset_idx}_report.json"
+                )
+                with open(report_path, "w") as f:
+                    json.dump(report_data, f)
+
+        model_cfg1, dataset_cfg1 = self._create_mock_cfg("model1", "dataset1")
+        model_cfg2, dataset_cfg2 = self._create_mock_cfg("model2", "dataset2")
+
+        summarizer = self.summarizer_module.SWEBenchProSummarizer.__new__(
+            self.summarizer_module.SWEBenchProSummarizer
+        )
+        summarizer.work_dir = self.work_dir
+        summarizer.model_cfgs = [model_cfg1, model_cfg2]
+        summarizer.dataset_cfgs = [dataset_cfg1, dataset_cfg2]
+        summarizer.logger = MagicMock()
+
+        raw_results, parsed_results, dataset_metrics, dataset_eval_mode = summarizer._pick_up_results()
+
+        self.assertIn("model1", raw_results)
+        self.assertIn("model2", raw_results)
+        self.assertIn("dataset1", raw_results["model1"])
+        self.assertIn("dataset2", raw_results["model1"])
+        self.assertEqual(dataset_metrics["dataset1"], ["accuracy"])
+        self.assertEqual(dataset_metrics["dataset2"], ["accuracy"])
+        self.assertEqual(dataset_eval_mode["dataset1"], "agent")
+        self.assertEqual(dataset_eval_mode["dataset2"], "agent")
+
+    def test_pick_up_results_rounds_accuracy(self):
+        results_dir = os.path.join(self.work_dir, "results")
+        os.makedirs(results_dir, exist_ok=True)
+
+        report_data = {
+            "total_instances_num": 100,
+            "eval_resolved_instances_num": 53,
+            "accuracy": 53.3333333,
+        }
+        report_path = os.path.join(results_dir, "model1_dataset1_report.json")
+        with open(report_path, "w") as f:
+            json.dump(report_data, f)
+
+        model_cfg, dataset_cfg = self._create_mock_cfg("model1", "dataset1")
+
+        summarizer = self.summarizer_module.SWEBenchProSummarizer.__new__(
+            self.summarizer_module.SWEBenchProSummarizer
+        )
+        summarizer.work_dir = self.work_dir
+        summarizer.model_cfgs = [model_cfg]
+        summarizer.dataset_cfgs = [dataset_cfg]
+        summarizer.logger = MagicMock()
+
+        raw_results, parsed_results, _, _ = summarizer._pick_up_results()
+
+        self.assertEqual(raw_results["model1"]["dataset1"]["accuracy"], 53.33)
+        self.assertEqual(parsed_results["model1"]["dataset1"]["accuracy"], 53.33)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [x] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号) 

## 🔍 Motivation / 变更动机

swe-bench-pro 数据集接入 AISBench

## 📝 Modification / 修改内容

新增swe-bench-pro数据集

**软件设计文档：**https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E3%80%91SWE%E2%80%90Bench_Pro-%E6%8E%A5%E5%85%A5-AISBench-%E6%B5%8B%E8%AF%84%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E6%96%87%E6%A1%A3


## 📐 Associated Test Results / 关联测试结果

**自验证报告：**
https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E6%B5%8B%E8%AF%95%E6%8A%A5%E5%91%8A%E3%80%91SWE%E2%80%90bench-Pro-%E6%95%B0%E6%8D%AE%E9%9B%86%E6%8E%A5%E5%85%A5%E4%B8%8E%E6%B5%8B%E8%AF%84%E8%83%BD%E5%8A%9B%E5%BB%BA%E8%AE%BE

**UT执行截图：**
ais_bench/benchmark/tasks/swebench_pro/__init__.py               100.00%
ais_bench/benchmark/tasks/swebench_pro/swebench_pro_eval.py       85.62%
ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py      73.65% 
ais_bench/benchmark/datasets/swebench_pro.py                      80.43%
ais_bench/benchmark/summarizers/swebench_pro.py                  100.00%

<img width="1131" height="786" alt="image" src="https://github.com/user-attachments/assets/d6ff352c-5e33-4af0-8c4e-6287c8277ce8" />


## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [x] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [x] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
