### PR TITLE
feat(UT): add swe-bench_pro UT tests - infer

### DIFF
--- a/tests/UT/tasks/swebp_pro/conftest.py
+++ b/tests/UT/tasks/swebp_pro/conftest.py
@@ -22,7 +22,9 @@ def _setup_mocks():
     minisweagent.run.extra.run_batch.process_instance = MagicMock()
     minisweagent.run.extra.run_batch.RunBatchConfig = MagicMock()
     minisweagent.config = type('config', (), {})()
-    minisweagent.config.get_config_path = MagicMock()
+    mock_config_path = MagicMock()
+    mock_config_path.read_text.return_value = '{}'
+    minisweagent.config.get_config_path = MagicMock(return_value=mock_config_path)
 
     orjson = MagicMock()
     orjson.loads = MagicMock(return_value={})

--- a/tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py
+++ b/tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py
@@ -253,14 +253,10 @@ class TestMakeSWEBenchProProgressManager(unittest.TestCase):
 
     def test_handles_import_error(self):
         mock_tsm = MagicMock()
-        original_import = __builtins__['__import__']
 
-        def mock_import(name, *args, **kwargs):
-            if 'minisweagent.run.extra.utils.batch_progress' in name:
-                raise ImportError("module not found")
-            return original_import(name, *args, **kwargs)
-
-        with patch('builtins.__import__', side_effect=mock_import):
+        with patch.dict(sys.modules, {
+            'minisweagent.run.extra.utils.batch_progress': None,
+        }):
             manager, render_group = self.infer_module._make_swebench_pro_progress_manager(mock_tsm, 10, "out_dir")
 
         self.assertIsNotNone(manager)

--- a/tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py
+++ b/tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py
@@ -1,0 +1,466 @@
+"""Unit tests for ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer"""
+import unittest
+import tempfile
+import os
+import sys
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from ais_bench.benchmark.tasks.swebench_pro import swebench_pro_infer as infer_module
+
+
+class TestGetMinisweagentConfig(unittest.TestCase):
+    """Test _get_minisweagent_config function."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    def test_returns_dict_with_model_key(self):
+        cfg = {"model": "test-model", "generation_kwargs": {"temperature": 0.7}}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertIn("model", result)
+        self.assertIn("model_name", result["model"])
+        self.assertIn("model_class", result["model"])
+        self.assertIn("model_kwargs", result["model"])
+
+    def test_handles_empty_config(self):
+        result = self.infer_module._get_minisweagent_config({})
+        self.assertIsInstance(result, dict)
+        self.assertIn("model", result)
+
+    def test_sets_model_name_from_model_key(self):
+        cfg = {"model": "gpt-4"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_name"], "gpt-4")
+
+    def test_sets_model_name_from_model_name_key(self):
+        cfg = {"model_name": "claude-3"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_name"], "claude-3")
+
+    def test_includes_api_key_in_model_kwargs(self):
+        cfg = {"api_key": "sk-test-123"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_kwargs"]["api_key"], "sk-test-123")
+
+    def test_includes_url_as_api_base(self):
+        cfg = {"url": "https://api.example.com/v1"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_kwargs"]["api_base"], "https://api.example.com/v1")
+
+
+class TestAISBenchProgressManager(unittest.TestCase):
+    """Test _AISBenchProgressManager class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    def test_on_instance_start(self):
+        mock_tsm = MagicMock()
+        manager = self.infer_module._AISBenchProgressManager(mock_tsm, 10)
+
+        manager.on_instance_start("instance-1")
+
+        mock_tsm.update_task_state.assert_called_once()
+        call_kwargs = mock_tsm.update_task_state.call_args[0][0]
+        self.assertEqual(call_kwargs["status"], "inferencing")
+        self.assertEqual(call_kwargs["total_count"], 10)
+
+    def test_on_instance_end(self):
+        mock_tsm = MagicMock()
+        manager = self.infer_module._AISBenchProgressManager(mock_tsm, 10)
+
+        manager.on_instance_end("instance-1")
+
+        mock_tsm.update_task_state.assert_called_once()
+        call_kwargs = mock_tsm.update_task_state.call_args[0][0]
+        self.assertEqual(call_kwargs["finish_count"], 1)
+        self.assertEqual(call_kwargs["total_count"], 10)
+
+    def test_finish_count_increments(self):
+        mock_tsm = MagicMock()
+        manager = self.infer_module._AISBenchProgressManager(mock_tsm, 10)
+
+        manager.on_instance_end("id1")
+        manager.on_instance_end("id2")
+        manager.on_instance_end("id3")
+
+        last_call = mock_tsm.update_task_state.call_args_list[-1][0][0]
+        self.assertEqual(last_call["finish_count"], 3)
+
+    def test_update_instance_status(self):
+        mock_tsm = MagicMock()
+        manager = self.infer_module._AISBenchProgressManager(mock_tsm, 10)
+
+        manager.update_instance_status("instance-1", "building image")
+
+        mock_tsm.update_task_state.assert_called_once()
+        call_kwargs = mock_tsm.update_task_state.call_args[0][0]
+        self.assertEqual(call_kwargs["other_kwargs"]["message"], "building image")
+
+
+class TestParseArgs(unittest.TestCase):
+    """Test parse_args function."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    @patch('argparse.ArgumentParser.parse_args')
+    def test_parses_config_argument(self, mock_parse):
+        mock_parse.return_value = MagicMock(config="test_config.py", infer_kwargs="{}")
+
+        args = self.infer_module.parse_args()
+
+        self.assertEqual(args.config, "test_config.py")
+
+    @patch('argparse.ArgumentParser.parse_args')
+    def test_parses_infer_kwargs(self, mock_parse):
+        mock_parse.return_value = MagicMock(
+            config="test_config.py",
+            infer_kwargs='{"key": "value"}'
+        )
+
+        args = self.infer_module.parse_args()
+
+        self.assertEqual(args.infer_kwargs, '{"key": "value"}')
+
+
+class TestAISBenchProgressManagerOnUncaughtException(unittest.TestCase):
+    """Test _AISBenchProgressManager.on_uncaught_exception method."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    def test_on_uncaught_exception(self):
+        mock_tsm = MagicMock()
+        manager = self.infer_module._AISBenchProgressManager(mock_tsm, 10)
+
+        manager.on_uncaught_exception("instance-1", ValueError("test error"))
+
+        self.assertEqual(mock_tsm.update_task_state.call_count, 1)
+        call_kwargs = mock_tsm.update_task_state.call_args[0][0]
+        self.assertEqual(call_kwargs["finish_count"], 1)
+
+
+class TestCompositeProgressManager(unittest.TestCase):
+    """Test _CompositeProgressManager class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    def test_forwards_on_instance_start(self):
+        mock1 = MagicMock()
+        mock2 = MagicMock()
+        manager = self.infer_module._CompositeProgressManager(mock1, mock2)
+
+        manager.on_instance_start("instance-1")
+
+        mock1.on_instance_start.assert_called_once_with("instance-1")
+        mock2.on_instance_start.assert_called_once_with("instance-1")
+
+    def test_forwards_update_instance_status(self):
+        mock1 = MagicMock()
+        mock2 = MagicMock()
+        manager = self.infer_module._CompositeProgressManager(mock1, mock2)
+
+        manager.update_instance_status("instance-1", "message")
+
+        mock1.update_instance_status.assert_called_once_with("instance-1", "message")
+        mock2.update_instance_status.assert_called_once_with("instance-1", "message")
+
+    def test_forwards_on_instance_end(self):
+        mock1 = MagicMock()
+        mock2 = MagicMock()
+        manager = self.infer_module._CompositeProgressManager(mock1, mock2)
+
+        manager.on_instance_end("instance-1", "success")
+
+        mock1.on_instance_end.assert_called_once_with("instance-1", "success")
+        mock2.on_instance_end.assert_called_once_with("instance-1", "success")
+
+    def test_forwards_on_uncaught_exception(self):
+        mock1 = MagicMock()
+        mock2 = MagicMock()
+        manager = self.infer_module._CompositeProgressManager(mock1, mock2)
+        exception = ValueError("test")
+
+        manager.on_uncaught_exception("instance-1", exception)
+
+        mock1.on_uncaught_exception.assert_called_once_with("instance-1", exception)
+        mock2.on_uncaught_exception.assert_called_once_with("instance-1", exception)
+
+    def test_filters_none_delegates(self):
+        mock1 = MagicMock()
+        manager = self.infer_module._CompositeProgressManager(mock1, None)
+
+        manager.on_instance_start("instance-1")
+
+        mock1.on_instance_start.assert_called_once()
+
+    def test_n_completed_property(self):
+        mock1 = MagicMock()
+        mock2 = MagicMock()
+        mock2.n_completed = 5
+        manager = self.infer_module._CompositeProgressManager(mock1, mock2)
+
+        self.assertEqual(manager.n_completed, 5)
+
+
+class TestSWEBenchProInferTask(unittest.TestCase):
+    """Test SWEBenchProInferTask class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    def test_get_command(self):
+        with patch.object(self.infer_module.SWEBenchProInferTask, '__init__', lambda self, cfg: None):
+            task = self.infer_module.SWEBenchProInferTask.__new__(self.infer_module.SWEBenchProInferTask)
+            command = task.get_command("config_path.yaml", "python {task_cmd}")
+            self.assertIn("python", command)
+            self.assertIn("config_path.yaml", command)
+
+
+class TestMakeSWEBenchProProgressManager(unittest.TestCase):
+    """Test _make_swebench_pro_progress_manager function."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    @patch('minisweagent.run.extra.utils.batch_progress.RunBatchProgressManager')
+    def test_returns_composite_manager(self, mock_rbpm_class):
+        mock_tsm = MagicMock()
+        mock_rbpm = MagicMock()
+        mock_rbpm_class.return_value = mock_rbpm
+        mock_rbpm.render_group = "render_group"
+
+        manager, render_group = self.infer_module._make_swebench_pro_progress_manager(mock_tsm, 10, Path("out_dir"))
+
+        self.assertIsNotNone(manager)
+        self.assertEqual(render_group, "render_group")
+
+    def test_handles_import_error(self):
+        mock_tsm = MagicMock()
+        original_import = __builtins__['__import__']
+
+        def mock_import(name, *args, **kwargs):
+            if 'minisweagent.run.extra.utils.batch_progress' in name:
+                raise ImportError("module not found")
+            return original_import(name, *args, **kwargs)
+
+        with patch('builtins.__import__', side_effect=mock_import):
+            manager, render_group = self.infer_module._make_swebench_pro_progress_manager(mock_tsm, 10, "out_dir")
+
+        self.assertIsNotNone(manager)
+        self.assertIsNone(render_group)
+
+
+class TestGetMinisweagentConfigEdgeCases(unittest.TestCase):
+    """Test _get_minisweagent_config function with edge cases."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    def test_sets_openrouter_class(self):
+        cfg = {"type": "OpenRouterModel", "model": "test-model"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_class"], "openrouter")
+
+    def test_sets_litellm_class_by_default(self):
+        cfg = {"model": "test-model"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_class"], "litellm")
+
+    def test_sets_hosted_vllm_prefix(self):
+        cfg = {"url": "http://localhost:8000/v1", "model": "qwen"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_name"], "hosted_vllm/qwen")
+
+    def test_includes_cost_tracking(self):
+        cfg = {"model": "test-model"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["cost_tracking"], "ignore_errors")
+
+    def test_extracts_type_name_from_string(self):
+        cfg = {"type": "ais_bench.benchmark.models.OpenRouter", "model": "test"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_class"], "openrouter")
+
+
+class TestSWEBenchProInferTaskRun(unittest.TestCase):
+    """Test SWEBenchProInferTask.run method."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager')
+    @patch('yaml.safe_load')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg')
+    @patch('concurrent.futures.ThreadPoolExecutor')
+    @patch('concurrent.futures.as_completed')
+    def test_run_all_instances_done(
+        self, mock_as_completed, mock_executor_class, mock_task_abbr, mock_model_abbr,
+        mock_build_dataset, mock_get_output_path, mock_yaml_load,
+        mock_make_progress, mock_ensure_images, mock_cleanup
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = MagicMock()
+            cfg.cli_args = {"debug": False}
+            cfg.work_dir = tmpdir
+
+            task = self.infer_module.SWEBenchProInferTask.__new__(self.infer_module.SWEBenchProInferTask)
+            task.cfg = cfg
+            task.work_dir = tmpdir
+            task.logger = MagicMock()
+            task.model_cfg = {"type": "test", "model": "test-model", "api_key": "test-key", "url": "http://test"}
+            task.dataset_cfgs = [{}]
+
+            mock_model_abbr.return_value = "model1"
+            mock_task_abbr.return_value = "task1"
+
+            mock_dataset = MagicMock()
+            mock_dataset.test = [{"instance_id": "id1"}, {"instance_id": "id2"}]
+            mock_build_dataset.return_value = mock_dataset
+
+            mock_get_output_path.return_value = os.path.join(tmpdir, "preds.json")
+
+            with open(os.path.join(tmpdir, "preds.json"), "w") as f:
+                json.dump({"id1": {}, "id2": {}}, f)
+
+            mock_yaml_load.return_value = {"model": {}}
+
+            mock_make_progress.return_value = (MagicMock(), None)
+
+            task_state_manager = MagicMock()
+
+            task.run(task_state_manager)
+
+            task.logger.info.assert_any_call("All instances already done, nothing to run.")
+
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager')
+    @patch('yaml.safe_load')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg')
+    @patch('concurrent.futures.ThreadPoolExecutor')
+    @patch('concurrent.futures.as_completed')
+    def test_run_no_model_set(
+        self, mock_as_completed, mock_executor_class, mock_task_abbr, mock_model_abbr,
+        mock_build_dataset, mock_get_output_path, mock_yaml_load,
+        mock_make_progress, mock_ensure_images, mock_cleanup
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = MagicMock()
+            cfg.cli_args = {"debug": False}
+            cfg.work_dir = tmpdir
+
+            task = self.infer_module.SWEBenchProInferTask.__new__(self.infer_module.SWEBenchProInferTask)
+            task.cfg = cfg
+            task.work_dir = tmpdir
+            task.logger = MagicMock()
+            task.model_cfg = {"type": "test"}
+            task.dataset_cfgs = [{}]
+
+            mock_model_abbr.return_value = "model1"
+            mock_task_abbr.return_value = "task1"
+
+            mock_dataset = MagicMock()
+            mock_dataset.test = [{"instance_id": "id1"}]
+            mock_build_dataset.return_value = mock_dataset
+
+            mock_get_output_path.return_value = os.path.join(tmpdir, "preds.json")
+
+            mock_yaml_load.return_value = {"model": {}}
+
+            task_state_manager = MagicMock()
+
+            with self.assertRaises(Exception):
+                task.run(task_state_manager)
+
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager')
+    @patch('yaml.safe_load')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg')
+    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg')
+    @patch('concurrent.futures.ThreadPoolExecutor')
+    @patch('concurrent.futures.as_completed')
+    def test_run_with_instances(
+        self, mock_as_completed, mock_executor_class, mock_task_abbr, mock_model_abbr,
+        mock_build_dataset, mock_get_output_path, mock_yaml_load,
+        mock_make_progress, mock_ensure_images, mock_cleanup
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = MagicMock()
+            cfg.cli_args = {"debug": False}
+            cfg.work_dir = tmpdir
+
+            task = self.infer_module.SWEBenchProInferTask.__new__(self.infer_module.SWEBenchProInferTask)
+            task.cfg = cfg
+            task.work_dir = tmpdir
+            task.logger = MagicMock()
+            task.model_cfg = {"type": "test", "model": "test-model", "api_key": "test-key", "batch_size": 1}
+            task.dataset_cfgs = [{}]
+
+            mock_model_abbr.return_value = "model1"
+            mock_task_abbr.return_value = "task1"
+
+            mock_dataset = MagicMock()
+            mock_dataset.test = [{
+                "instance_id": "id1",
+                "problem_statement": "test problem",
+                "repo": "test/repo",
+                "base_commit": "abc123"
+            }]
+            mock_build_dataset.return_value = mock_dataset
+
+            mock_get_output_path.return_value = os.path.join(tmpdir, "preds.json")
+
+            mock_yaml_load.return_value = {"model": {}}
+
+            mock_make_progress.return_value = (MagicMock(), None)
+
+            mock_executor = MagicMock()
+            mock_executor_class.return_value = mock_executor
+            mock_future = MagicMock()
+            mock_future.result.return_value = None
+            mock_executor.submit.return_value = mock_future
+            mock_executor.__enter__ = MagicMock(return_value=mock_executor)
+            mock_executor.__exit__ = MagicMock(return_value=False)
+
+            mock_as_completed.return_value = []
+
+            task_state_manager = MagicMock()
+
+            task.run(task_state_manager)
+
+            mock_ensure_images.assert_called_once()
+            mock_executor_class.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [x] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)

## 🔍 Motivation / 变更动机

swe-bench-pro 数据集接入 AISBench

## 📝 Modification / 修改内容

新增swe-bench-pro数据集

**软件设计文档：**https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E3%80%91SWE%E2%80%90Bench_Pro-%E6%8E%A5%E5%85%A5-AISBench-%E6%B5%8B%E8%AF%84%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E6%96%87%E6%A1%A3


## 📐 Associated Test Results / 关联测试结果

**自验证报告：**
https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E6%B5%8B%E8%AF%95%E6%8A%A5%E5%91%8A%E3%80%91SWE%E2%80%90bench-Pro-%E6%95%B0%E6%8D%AE%E9%9B%86%E6%8E%A5%E5%85%A5%E4%B8%8E%E6%B5%8B%E8%AF%84%E8%83%BD%E5%8A%9B%E5%BB%BA%E8%AE%BE

**UT执行截图：**
ais_bench/benchmark/tasks/swebench_pro/__init__.py               100.00%
ais_bench/benchmark/tasks/swebench_pro/swebench_pro_eval.py       85.62%
ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py      73.65% 
ais_bench/benchmark/datasets/swebench_pro.py                      80.43%
ais_bench/benchmark/summarizers/swebench_pro.py                  100.00%

<img width="1131" height="786" alt="image" src="https://github.com/user-attachments/assets/d6ff352c-5e33-4af0-8c4e-6287c8277ce8" />


## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [x] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [x] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
