### PR TITLE
fix: ensure custom URL has trailing slash to prevent urljoin from dropping last path segment

### DIFF
--- a/ais_bench/benchmark/models/api_models/base_api.py
+++ b/ais_bench/benchmark/models/api_models/base_api.py
@@ -1,5 +1,6 @@
 import sys
 import json
+import urllib.parse
 import warnings
 import asyncio
 import os.path as osp
@@ -118,17 +119,22 @@ class BaseAPIModel(BaseModel):
 
     def _get_base_url(self) -> str:
         protocol = "https" if self.enable_ssl else "http"
-        if self.url:
+        clean_url = self.url.strip() if isinstance(self.url, str) else ""
+        if clean_url:
             self.logger.info(
-                f"Using custom URL: [{self.url}], [host_ip: {self.host_ip}] and [host_port: {self.host_port}] will be ignored"
+                f"Using custom URL: [{clean_url}], [host_ip: {self.host_ip}] and [host_port: {self.host_port}] will be ignored"
             )
             # Check if URL already contains protocol
-            if self.url.startswith("http://") or self.url.startswith("https://"):
-                url = self.url
+            if clean_url.startswith("http://") or clean_url.startswith("https://"):
+                url = clean_url
             else:
-                url = f"{protocol}://{self.url}"
-            # Ensure trailing slash to avoid urljoin dropping the last path segment
-            return url if url.endswith("/") else url + "/"
+                url = f"{protocol}://{clean_url}"
+            # Ensure trailing slash on path to avoid urljoin dropping the last path segment.
+            # Use urlparse/urlunparse to safely handle URLs with query strings or fragments.
+            parsed = urllib.parse.urlparse(url)
+            if not parsed.path or parsed.path.endswith("/"):
+                return url
+            return urllib.parse.urlunparse(parsed._replace(path=parsed.path + "/"))
 
         # For IPv6 literals, wrap in brackets when constructing the URL.
         host = self.host_ip

--- a/ais_bench/benchmark/models/api_models/base_api.py
+++ b/ais_bench/benchmark/models/api_models/base_api.py
@@ -14,12 +14,19 @@ import aiohttp
 from ais_bench.benchmark.utils.logging.logger import AISLogger
 from ais_bench.benchmark.utils.logging.error_codes import MODEL_CODES
 from ais_bench.benchmark.utils.logging.exceptions import (
-    AISBenchNotImplementedError, AISBenchValueError, AISBenchKeyError,
-    AISBenchTypeError, AISBenchRuntimeError, AISBenchImplementationError)
+    AISBenchNotImplementedError,
+    AISBenchValueError,
+    AISBenchKeyError,
+    AISBenchTypeError,
+    AISBenchRuntimeError,
+    AISBenchImplementationError,
+)
 from ais_bench.benchmark.utils.prompt import PromptList
 from ais_bench.benchmark.models import BaseModel
 from ais_bench.benchmark.models.output import Output
-from ais_bench.benchmark.openicl.icl_inferencer.output_handler.ppl_inferencer_output_handler import PPLRequestOutput
+from ais_bench.benchmark.openicl.icl_inferencer.output_handler.ppl_inferencer_output_handler import (
+    PPLRequestOutput,
+)
 from ais_bench.benchmark.utils.logging.error_codes import ICLI_CODES
 from ais_bench.benchmark.global_consts import REQUEST_TIME_OUT
 
@@ -28,10 +35,12 @@ AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=REQUEST_TIME_OUT)
 
 PromptType = Union[PromptList, str]
 
+
 class MockAISLogger(AISLogger):
     """Mock logger for API model. Because model will init in task for warmup and init in infer process,
     so we mock the logger to avoid the print each log in init process twice
     """
+
     def info(self, msg, *args, **kwargs):
         pass
 
@@ -40,6 +49,7 @@ class MockAISLogger(AISLogger):
 
     def warning(self, msg, *args, **kwargs):
         pass
+
 
 class BaseAPIModel(BaseModel):
     """Base class for API model wrapper.
@@ -103,17 +113,22 @@ class BaseAPIModel(BaseModel):
         raise AISBenchNotImplementedError(
             MODEL_CODES.UNKNOWN_ERROR,
             f"{self.__class__.__name__} does not supported"
-            " to be called in base classes"
+            " to be called in base classes",
         )
 
     def _get_base_url(self) -> str:
         protocol = "https" if self.enable_ssl else "http"
         if self.url:
-            self.logger.info(f"Using custom URL: [{self.url}], [host_ip: {self.host_ip}] and [host_port: {self.host_port}] will be ignored")
+            self.logger.info(
+                f"Using custom URL: [{self.url}], [host_ip: {self.host_ip}] and [host_port: {self.host_port}] will be ignored"
+            )
             # Check if URL already contains protocol
             if self.url.startswith("http://") or self.url.startswith("https://"):
-                return self.url
-            return f"{protocol}://{self.url}"
+                url = self.url
+            else:
+                url = f"{protocol}://{self.url}"
+            # Ensure trailing slash to avoid urljoin dropping the last path segment
+            return url if url.endswith("/") else url + "/"
 
         # For IPv6 literals, wrap in brackets when constructing the URL.
         host = self.host_ip
@@ -135,7 +150,7 @@ class BaseAPIModel(BaseModel):
 
             if response.status_code == 200:
                 data = response.json()
-                model_id = data['data'][0]['id']
+                model_id = data["data"][0]["id"]
                 self.logger.debug(f"Service Model ID: {model_id}")
                 return model_id
             else:
@@ -144,7 +159,7 @@ class BaseAPIModel(BaseModel):
         except requests.exceptions.RequestException as e:
             raise AISBenchRuntimeError(
                 MODEL_CODES.GET_SERVICE_MODEL_PATH_FAILED,
-                f"Failed to get service model path from {self.base_url}. Error: {e}"
+                f"Failed to get service model path from {self.base_url}. Error: {e}",
             )
 
     async def iter_lines(self, stream):
@@ -190,19 +205,19 @@ class BaseAPIModel(BaseModel):
         raise AISBenchNotImplementedError(
             MODEL_CODES.UNKNOWN_ERROR,
             f"{self.__class__.__name__} does not supported"
-            " to be called in base classes"
+            " to be called in base classes",
         )
 
     async def parse_text_response(self, data, output):
         raise AISBenchNotImplementedError(
             MODEL_CODES.PARSE_TEXT_RSP_NOT_IMPLEMENTED,
-            f"{self.__class__.__name__} should be implemented if stream is False"
+            f"{self.__class__.__name__} should be implemented if stream is False",
         )
 
     async def parse_stream_response(self, data, output):
         raise AISBenchNotImplementedError(
             MODEL_CODES.PARSE_STREAM_RSP_NOT_IMPLEMENTED,
-            f"{self.__class__.__name__} should be implemented if stream is True"
+            f"{self.__class__.__name__} should be implemented if stream is True",
         )
 
     async def generate(
@@ -282,7 +297,7 @@ class BaseAPIModel(BaseModel):
                         output.error_info = f"Unexpected response format: {raw_chunk}. Please check if server is working correctly."
                         raise AISBenchValueError(
                             MODEL_CODES.PARSE_TEXT_RSP_INVALID_FORMAT,
-                            f"Unexpected response format. Please check 'error_info' in ***_failed.jsonl for more information."
+                            f"Unexpected response format. Please check 'error_info' in ***_failed.jsonl for more information.",
                         )
                     await self.parse_stream_response(data, output)
                 output.success = True
@@ -305,7 +320,7 @@ class BaseAPIModel(BaseModel):
                     output.error_info = f"Unexpected response format: {raw_data}. Please check if server is working correctly."
                     raise AISBenchValueError(
                         MODEL_CODES.PARSE_TEXT_RSP_INVALID_FORMAT,
-                        f"Unexpected response format. Please check ***_details.jsonl for more information."
+                        f"Unexpected response format. Please check ***_details.jsonl for more information.",
                     )
                 await self.parse_text_response(data, output)
                 output.success = True
@@ -313,13 +328,14 @@ class BaseAPIModel(BaseModel):
                 output.error_info = response.reason
                 output.success = False
 
-    async def get_ppl(self,
+    async def get_ppl(
+        self,
         input_data: PromptType,
         max_out_len: int,
         output: PPLRequestOutput,
         session: aiohttp.ClientSession = None,
-        **args
-        ):
+        **args,
+    ):
         """Compute perplexity for a given prompt via the remote API.
         Args:
             input_data: Prompt text or list structure the backend expects.
@@ -334,12 +350,16 @@ class BaseAPIModel(BaseModel):
             • Respect session lifecycle: only close if they created it.
         """
         if session is None:
-            self.session = aiohttp.ClientSession(trust_env=True, timeout=AIOHTTP_TIMEOUT)
+            self.session = aiohttp.ClientSession(
+                trust_env=True, timeout=AIOHTTP_TIMEOUT
+            )
             close_session = True
         else:
             self.session = session
             close_session = False
-        request_body = await self.get_ppl_request_body(input_data, max_out_len, output, **args)
+        request_body = await self.get_ppl_request_body(
+            input_data, max_out_len, output, **args
+        )
         retry_count = 0
         for _ in range(self.retry):
             try:
@@ -382,22 +402,37 @@ class BaseAPIModel(BaseModel):
         if close_session:
             await self.session.close()
 
-    async def get_ppl_request_body(self, input_data:PromptType, max_out_len: int, output: PPLRequestOutput, **args):
-        raise AISBenchNotImplementedError(ICLI_CODES.IMPLEMENTATION_ERROR_PPL_METHOD_NOT_IMPLEMENTED, f"PPL is not supported for this model.")
+    async def get_ppl_request_body(
+        self, input_data: PromptType, max_out_len: int, output: PPLRequestOutput, **args
+    ):
+        raise AISBenchNotImplementedError(
+            ICLI_CODES.IMPLEMENTATION_ERROR_PPL_METHOD_NOT_IMPLEMENTED,
+            f"PPL is not supported for this model.",
+        )
 
     def get_prompt_logprobs(self, data: dict):
-        raise AISBenchNotImplementedError(ICLI_CODES.IMPLEMENTATION_ERROR_PPL_METHOD_NOT_IMPLEMENTED, f"PPL is not supported for this model.")
+        raise AISBenchNotImplementedError(
+            ICLI_CODES.IMPLEMENTATION_ERROR_PPL_METHOD_NOT_IMPLEMENTED,
+            f"PPL is not supported for this model.",
+        )
 
     def _calc_ppl(self, prompt_logprobs: list):
-        logprobs = [list(item.values())[0]['logprob'] for item in prompt_logprobs if item is not None]
-        tokenids = [list(item.keys())[0] for item in prompt_logprobs if item is not None]
+        logprobs = [
+            list(item.values())[0]["logprob"]
+            for item in prompt_logprobs
+            if item is not None
+        ]
+        tokenids = [
+            list(item.keys())[0] for item in prompt_logprobs if item is not None
+        ]
         if len(tokenids) == 0:
             raise AISBenchImplementationError(
                 ICLI_CODES.PPL_COMPUTE_ERROR_NO_VALID_TOKENS,
-                "No valid tokens with log probabilities found for PPL computation."
+                "No valid tokens with log probabilities found for PPL computation.",
             )
         loss = -sum(logprobs) / len(tokenids)
         return loss
+
 
 class APITemplateParser:
     """Intermidate prompt template parser, specifically for API models.
@@ -414,12 +449,12 @@ class APITemplateParser:
             if "round" not in meta_template:
                 raise AISBenchTypeError(
                     MODEL_CODES.MISS_REQUIRED_PARAM_IN_META_TEMPLATE,
-                    "round is required in meta template"
+                    "round is required in meta template",
                 )
             if not isinstance(meta_template["round"], list):
                 raise AISBenchTypeError(
                     MODEL_CODES.INVALID_TYPE_OF_PARAM_IN_META_TEMPLATE,
-                    "round must be a list in meta template"
+                    "round must be a list in meta template",
                 )
             keys_to_check = ["round"]
 
@@ -427,7 +462,7 @@ class APITemplateParser:
                 if not isinstance(meta_template["reserved_roles"], list):
                     raise AISBenchTypeError(
                         MODEL_CODES.INVALID_TYPE_OF_PARAM_IN_META_TEMPLATE,
-                        "reserved_roles must be a list in meta template"
+                        "reserved_roles must be a list in meta template",
                     )
                 keys_to_check.append("reserved_roles")
 
@@ -437,13 +472,13 @@ class APITemplateParser:
                     if not isinstance(item, (str, dict)):
                         raise AISBenchTypeError(
                             MODEL_CODES.INVALID_TYPE_OF_PARAM_IN_META_TEMPLATE,
-                            f"each item in {meta_key} must be a string or a dict in meta template"
+                            f"each item in {meta_key} must be a string or a dict in meta template",
                         )
                     if isinstance(item, dict):
                         if item["role"] in self.roles:
                             raise AISBenchTypeError(
                                 MODEL_CODES.ROLE_IN_META_TEMPLATE_IS_NOT_UNIQUE,
-                                f"role {item['role']} in meta prompt must be unique!"
+                                f"role {item['role']} in meta prompt must be unique!",
                             )
                         self.roles[item["role"]] = item.copy()
 
@@ -468,7 +503,7 @@ class APITemplateParser:
         if not isinstance(prompt_template, (str, list, PromptList, tuple)):
             raise AISBenchTypeError(
                 MODEL_CODES.PARSE_TEMPLATE_INVALID_TYPE,
-                f"prompt_template must be a string, list of strings, PromptList, or tuple of strings, but got {type(prompt_template)}"
+                f"prompt_template must be a string, list of strings, PromptList, or tuple of strings, but got {type(prompt_template)}",
             )
 
         if not isinstance(prompt_template, (str, PromptList)):
@@ -477,15 +512,13 @@ class APITemplateParser:
         if not mode in ["ppl", "gen"]:
             raise AISBenchTypeError(
                 MODEL_CODES.PARSE_TEMPLATE_INVALID_MODE,
-                f"Parsing mode must be 'ppl' or 'gen', but got {mode}"
+                f"Parsing mode must be 'ppl' or 'gen', but got {mode}",
             )
-
 
         if isinstance(prompt_template, str):
             return prompt_template
 
         if self.meta_template:
-
             prompt = PromptList()
             # Whether to keep generating the prompt
             generate = True
@@ -508,7 +541,7 @@ class APITemplateParser:
                         if not section_name == item["section"]:
                             raise AISBenchValueError(
                                 MODEL_CODES.UNKNOWN_ERROR,
-                                f"section {item['section']} in prompt template must match the last section {section_name}"
+                                f"section {item['section']} in prompt template must match the last section {section_name}",
                             )
                         if section_name in ["round", "ice"]:
                             dialogue = prompt_template[start_idx:i]
@@ -538,13 +571,13 @@ class APITemplateParser:
                             raise AISBenchValueError(
                                 MODEL_CODES.UNKNOWN_ERROR,
                                 f"section {item['section']} in prompt template is not valid, "
-                                "it must be 'begin', 'round', 'end', or 'ice'"
+                                "it must be 'begin', 'round', 'end', or 'ice'",
                             )
                         section_stack.append((item["section"], i + 1))
                     else:
                         raise AISBenchValueError(
                             MODEL_CODES.UNKNOWN_ERROR,
-                            f"Invalid prompt template item pos {item['pos']}, legal item pos are 'begin' or 'end'."
+                            f"Invalid prompt template item pos {item['pos']}, legal item pos are 'begin' or 'end'.",
                         )
                 elif section_stack[-1][0] in ["begin", "end"]:
                     role_dict = self._update_role_dict(item)
@@ -637,7 +670,7 @@ class APITemplateParser:
                     raise AISBenchKeyError(
                         MODEL_CODES.INVALID_ROLE_IN_PROMPT_TEMPLATE,
                         f"prompt template item {template} neither has an appropriate "
-                        "role nor a fallback_role."
+                        "role nor a fallback_role.",
                     )
             if role_idx <= last_role_idx:
                 cutoff_idxs.append(idx)
@@ -677,7 +710,7 @@ class APITemplateParser:
             if isinstance(prompt, str):
                 raise AISBenchTypeError(
                     MODEL_CODES.MIX_STR_WITHOUT_EXPLICIT_ROLE,
-                    "Mixing str without explicit role is not allowed in API models!"
+                    "Mixing str without explicit role is not allowed in API models!",
                 )
             else:
                 api_role, cont = self._role2api_role(prompt, role_dict, for_gen)
@@ -720,6 +753,6 @@ class APITemplateParser:
         else:
             raise AISBenchValueError(
                 MODEL_CODES.INVALID_PROMPT_CONTENT,
-                "Invalid prompt content: without 'prompt' or 'prompt_mm' param!"
+                "Invalid prompt content: without 'prompt' or 'prompt_mm' param!",
             )
         return res, True

--- a/tests/UT/models/api_models/test_base_api.py
+++ b/tests/UT/models/api_models/test_base_api.py
@@ -91,6 +91,47 @@ class TestBaseAPIModel(unittest.TestCase):
         model = self.model_class(**kwargs)
         self.assertEqual(model.base_url, "http://test-api.com/path/")
 
+    def test_init_with_url_path_prefix(self):
+        """Test that urljoin preserves the last path segment when URL has a custom prefix."""
+        import urllib.parse
+
+        # Simulate the issue: URL with path prefix (like /member1/deepseek_v4)
+        kwargs = self.default_kwargs.copy()
+        kwargs["url"] = "http://10.5.0.1:8080/member1/deepseek_v4"
+        model = self.model_class(**kwargs)
+        # urljoin should append endpoint to the full path, not drop deepseek_v4
+        full_url = urllib.parse.urljoin(model.base_url, "v1/chat/completions")
+        self.assertEqual(
+            full_url,
+            "http://10.5.0.1:8080/member1/deepseek_v4/v1/chat/completions",
+        )
+
+    def test_init_with_url_query_string(self):
+        """Test that query strings are preserved when appending trailing slash."""
+        kwargs = self.default_kwargs.copy()
+        kwargs["url"] = "http://host.com/path?x=1"
+        model = self.model_class(**kwargs)
+        self.assertEqual(model.base_url, "http://host.com/path/?x=1")
+
+    def test_init_with_url_fragment(self):
+        """Test that fragments are preserved when appending trailing slash."""
+        kwargs = self.default_kwargs.copy()
+        kwargs["url"] = "http://host.com/path#section"
+        model = self.model_class(**kwargs)
+        self.assertEqual(model.base_url, "http://host.com/path/#section")
+
+    def test_init_with_url_whitespace(self):
+        """Test that leading/trailing whitespace is stripped from URL."""
+        kwargs = self.default_kwargs.copy()
+        kwargs["url"] = "  https://test-api.com/v1  "
+        model = self.model_class(**kwargs)
+        self.assertEqual(model.base_url, "https://test-api.com/v1/")
+
+        # Empty/whitespace-only URL should fall through to host_ip:host_port
+        kwargs["url"] = "   "
+        model = self.model_class(**kwargs)
+        self.assertEqual(model.base_url, "http://127.0.0.1:8000/")
+
     def test_init_with_ssl(self):
         kwargs = self.default_kwargs.copy()
         kwargs["enable_ssl"] = True

--- a/tests/UT/models/api_models/test_base_api.py
+++ b/tests/UT/models/api_models/test_base_api.py
@@ -6,14 +6,14 @@ from unittest import mock
 from copy import deepcopy
 import requests
 
-from ais_bench.benchmark.models import (
-    BaseAPIModel, APITemplateParser
-)
+from ais_bench.benchmark.models import BaseAPIModel, APITemplateParser
 from ais_bench.benchmark.utils.prompt import PromptList
 from ais_bench.benchmark.models.output import Output
 from ais_bench.benchmark.utils.logging.exceptions import (
-    AISBenchTypeError, AISBenchValueError,
-    AISBenchRuntimeError, AISBenchKeyError
+    AISBenchTypeError,
+    AISBenchValueError,
+    AISBenchRuntimeError,
+    AISBenchKeyError,
 )
 
 
@@ -36,7 +36,6 @@ class MockResponse:
 
 
 class TestBaseAPIModel(unittest.TestCase):
-
     def setUp(self):
         # 创建一个具体的BaseAPIModel子类用于测试
         class ConcreteAPIModel(BaseAPIModel):
@@ -59,7 +58,7 @@ class TestBaseAPIModel(unittest.TestCase):
             "max_out_len": 100,
             "retry": 1,
             "host_ip": "127.0.0.1",
-            "host_port": 8000
+            "host_port": 8000,
         }
         self.ipv6_kwargs = self.default_kwargs.copy()
         self.ipv6_kwargs["host_ip"] = "::1"
@@ -80,7 +79,17 @@ class TestBaseAPIModel(unittest.TestCase):
         kwargs = self.default_kwargs.copy()
         kwargs["url"] = "https://test-api.com/v1"
         model = self.model_class(**kwargs)
-        self.assertEqual(model.base_url, "https://test-api.com/v1")
+        self.assertEqual(model.base_url, "https://test-api.com/v1/")
+
+        # Test that URL already with trailing slash remains unchanged
+        kwargs["url"] = "https://test-api.com/v1/"
+        model = self.model_class(**kwargs)
+        self.assertEqual(model.base_url, "https://test-api.com/v1/")
+
+        # Test that URL without protocol gets trailing slash
+        kwargs["url"] = "test-api.com/path"
+        model = self.model_class(**kwargs)
+        self.assertEqual(model.base_url, "http://test-api.com/path/")
 
     def test_init_with_ssl(self):
         kwargs = self.default_kwargs.copy()
@@ -102,9 +111,11 @@ class TestBaseAPIModel(unittest.TestCase):
         model = self.model_class(**kwargs)
         self.assertEqual(model._get_base_url(), "http://localhost:8000/")
 
-    @mock.patch('requests.get')
+    @mock.patch("requests.get")
     def test_get_service_model_path_success(self, mock_get):
-        mock_response = MockResponse(200, json_data={"data": [{"id": "test-model-123"}]})
+        mock_response = MockResponse(
+            200, json_data={"data": [{"id": "test-model-123"}]}
+        )
         mock_get.return_value = mock_response
 
         model = self.model_class(**self.default_kwargs)
@@ -114,10 +125,10 @@ class TestBaseAPIModel(unittest.TestCase):
         mock_get.assert_called_once_with(
             "http://127.0.0.1:8000/v1/models",
             headers={"Content-Type": "application/json"},
-            timeout=5
+            timeout=5,
         )
 
-    @mock.patch('requests.get')
+    @mock.patch("requests.get")
     def test_get_service_model_path_failure(self, mock_get):
         # 模拟requests.exceptions.RequestException异常
         mock_get.side_effect = requests.exceptions.RequestException("Connection error")
@@ -157,9 +168,10 @@ class TestBaseAPIModel(unittest.TestCase):
             self.assertEqual(lines[0], b"line1")
             self.assertEqual(lines[1], b"line2")
             self.assertEqual(lines[2], b"line3")
+
         asyncio.run(run())
 
-    @mock.patch('aiohttp.ClientSession.post')
+    @mock.patch("aiohttp.ClientSession.post")
     async def test_text_infer_success(self, mock_post):
         # 设置mock响应
         mock_response = mock.AsyncMock()
@@ -176,7 +188,7 @@ class TestBaseAPIModel(unittest.TestCase):
         self.assertTrue(output.success)
         self.assertEqual(output.text, "test output")
 
-    @mock.patch('aiohttp.ClientSession.post')
+    @mock.patch("aiohttp.ClientSession.post")
     async def test_text_infer_failure(self, mock_post):
         mock_response = mock.AsyncMock()
         mock_response.status = 400
@@ -192,7 +204,7 @@ class TestBaseAPIModel(unittest.TestCase):
         self.assertFalse(output.success)
         self.assertEqual(output.error_info, "Bad Request")
 
-    @mock.patch('aiohttp.ClientSession.post')
+    @mock.patch("aiohttp.ClientSession.post")
     async def test_text_infer_json_decode_error(self, mock_post):
         mock_response = mock.AsyncMock()
         mock_response.status = 200
@@ -206,12 +218,12 @@ class TestBaseAPIModel(unittest.TestCase):
         with self.assertRaises(AISBenchValueError):
             await model.text_infer({"prompt": "test"}, output)
 
-    @mock.patch('aiohttp.ClientSession.post')
+    @mock.patch("aiohttp.ClientSession.post")
     async def test_stream_infer_success(self, mock_post):
         # 创建模拟的流响应
         async def mock_content():
-            yield b"data: {\"chunk\": \"hello\"}\n\n"
-            yield b"data: {\"chunk\": \" world\"}\n\n"
+            yield b'data: {"chunk": "hello"}\n\n'
+            yield b'data: {"chunk": " world"}\n\n'
             yield b"data: [DONE]\n\n"
 
         mock_response = mock.AsyncMock()
@@ -231,7 +243,7 @@ class TestBaseAPIModel(unittest.TestCase):
 
         asyncio.run(run())
 
-    @mock.patch('aiohttp.ClientSession.post')
+    @mock.patch("aiohttp.ClientSession.post")
     async def test_stream_infer_json_decode_error(self, mock_post):
         async def mock_content():
             yield b"data: invalid json\n\n"
@@ -249,23 +261,26 @@ class TestBaseAPIModel(unittest.TestCase):
         async def run():
             with self.assertRaises(AISBenchValueError):
                 await model.stream_infer({"prompt": "test"}, output)
+
         asyncio.run(run())
 
-    @mock.patch('aiohttp.ClientSession')
+    @mock.patch("aiohttp.ClientSession")
     def test_generate_with_session(self, mock_session_class):
         mock_session = mock.AsyncMock()
         mock_session_class.return_value.__aenter__.return_value = mock_session
 
         model = self.model_class(**self.default_kwargs)
         output = Output()
+
         async def run():
             # 使用mock模拟generate方法的关键部分
-            with mock.patch.object(model, 'text_infer') as mock_text_infer:
+            with mock.patch.object(model, "text_infer") as mock_text_infer:
                 await model.generate("test prompt", 100, output, session=mock_session)
                 mock_text_infer.assert_called_once()
+
         asyncio.run(run())
 
-    @mock.patch('aiohttp.ClientSession')
+    @mock.patch("aiohttp.ClientSession")
     def test_generate_with_retry(self, mock_session_class):
 
         mock_session = mock.AsyncMock()
@@ -277,10 +292,12 @@ class TestBaseAPIModel(unittest.TestCase):
 
         # 第一次调用失败，第二次成功
         mock_text_infer = mock.AsyncMock(side_effect=[Exception("First fail"), None])
+
         async def run():
-            with mock.patch.object(model, 'text_infer', mock_text_infer):
+            with mock.patch.object(model, "text_infer", mock_text_infer):
                 await model.generate("test prompt", 100, output, session=mock_session)
                 self.assertEqual(mock_text_infer.call_count, 2)
+
         asyncio.run(run())
 
     def test_abstract_methods(self):
@@ -293,12 +310,11 @@ class TestBaseAPIModel(unittest.TestCase):
 
 
 class TestAPITemplateParser(unittest.TestCase):
-
     def setUp(self):
         self.default_meta_template = {
             "round": [
                 {"role": "user", "api_role": "user"},
-                {"role": "assistant", "api_role": "assistant", "generate": True}
+                {"role": "assistant", "api_role": "assistant", "generate": True},
             ]
         }
 
@@ -321,9 +337,7 @@ class TestAPITemplateParser(unittest.TestCase):
 
     def test_init_with_reserved_roles(self):
         meta_template = deepcopy(self.default_meta_template)
-        meta_template["reserved_roles"] = [
-            {"role": "system", "api_role": "system"}
-        ]
+        meta_template["reserved_roles"] = [{"role": "system", "api_role": "system"}]
         parser = APITemplateParser(meta_template)
         self.assertEqual(len(parser.roles), 3)
         self.assertIn("system", parser.roles)
@@ -332,7 +346,7 @@ class TestAPITemplateParser(unittest.TestCase):
         meta_template = {
             "round": [
                 {"role": "user", "api_role": "user"},
-                {"role": "user", "api_role": "user"}  # 重复的角色
+                {"role": "user", "api_role": "user"},  # 重复的角色
             ]
         }
         with self.assertRaises(AISBenchTypeError):
@@ -356,10 +370,7 @@ class TestAPITemplateParser(unittest.TestCase):
     def test_parse_template_without_meta_template(self):
         parser = APITemplateParser(None)
         # 使用PromptList而不是普通列表
-        prompt_list = PromptList([
-            {"prompt": "Hello"},
-            {"prompt": "World"}
-        ])
+        prompt_list = PromptList([{"prompt": "Hello"}, {"prompt": "World"}])
         result = parser.parse_template(prompt_list, "gen")
         self.assertEqual(result, "Hello\nWorld")
 
@@ -381,18 +392,22 @@ class TestAPITemplateParser(unittest.TestCase):
             {"role": "user", "prompt": "q1"},
             {"role": "assistant", "prompt": "a1"},
             {"role": "user", "prompt": "q2"},
-            {"role": "assistant", "prompt": "a2"}
+            {"role": "assistant", "prompt": "a2"},
         ]
-        result = parser._split_rounds(prompt_template, self.default_meta_template["round"])
+        result = parser._split_rounds(
+            prompt_template, self.default_meta_template["round"]
+        )
         self.assertEqual(result, [0, 2, 4])
 
     def test_split_rounds_with_fallback_role(self):
         parser = APITemplateParser(self.default_meta_template)
         prompt_template = [
             {"role": "unknown", "fallback_role": "user", "prompt": "q1"},
-            {"role": "assistant", "prompt": "a1"}
+            {"role": "assistant", "prompt": "a1"},
         ]
-        result = parser._split_rounds(prompt_template, self.default_meta_template["round"])
+        result = parser._split_rounds(
+            prompt_template, self.default_meta_template["round"]
+        )
         self.assertEqual(result, [0, 2])
 
     def test_split_rounds_invalid_role(self):
@@ -428,7 +443,7 @@ class TestAPITemplateParser(unittest.TestCase):
             "api_role": "user",
             "prompt": "test",
             "begin": "<s>",
-            "end": "</s>"
+            "end": "</s>",
         }
         result, cont = parser._role2api_role({"role": "user"}, parser.roles, False)
         self.assertEqual(result["role"], "user")
@@ -440,7 +455,7 @@ class TestAPITemplateParser(unittest.TestCase):
         parser.roles["assistant"] = {
             "role": "assistant",
             "api_role": "assistant",
-            "generate": True
+            "generate": True,
         }
         result, cont = parser._role2api_role({"role": "assistant"}, parser.roles, True)
         self.assertIsNone(result)
@@ -448,7 +463,10 @@ class TestAPITemplateParser(unittest.TestCase):
 
     def test_role2api_role_invalid_content(self):
         parser = APITemplateParser(self.default_meta_template)
-        parser.roles["user"] = {"role": "user", "api_role": "user"}  # 缺少prompt或prompt_mm
+        parser.roles["user"] = {
+            "role": "user",
+            "api_role": "user",
+        }  # 缺少prompt或prompt_mm
         with self.assertRaises(AISBenchValueError):
             parser._role2api_role({"role": "user"}, parser.roles, False)
 
@@ -457,7 +475,7 @@ class TestAPITemplateParser(unittest.TestCase):
         parser.roles["user"] = {
             "role": "user",
             "api_role": "user",
-            "prompt_mm": [{"type": "text", "content": "test"}]
+            "prompt_mm": [{"type": "text", "content": "test"}],
         }
         result, cont = parser._role2api_role({"role": "user"}, parser.roles, False)
         self.assertEqual(result["prompt"], [{"type": "text", "content": "test"}])
@@ -467,18 +485,20 @@ class TestAPITemplateParser(unittest.TestCase):
             "begin": {"role": "system", "prompt": "System prompt"},
             "round": [
                 {"role": "user", "api_role": "user"},
-                {"role": "assistant", "api_role": "assistant"}
-            ]
+                {"role": "assistant", "api_role": "assistant"},
+            ],
         }
         parser = APITemplateParser(meta_template)
 
         # 模拟一个完整的对话结构
-        prompt_template = PromptList([
-            {"section": "round", "pos": "begin"},
-            {"role": "user", "prompt": "Question 1"},
-            {"role": "assistant", "prompt": "Answer 1"},
-            {"section": "round", "pos": "end"}
-        ])
+        prompt_template = PromptList(
+            [
+                {"section": "round", "pos": "begin"},
+                {"role": "user", "prompt": "Question 1"},
+                {"role": "assistant", "prompt": "Answer 1"},
+                {"section": "round", "pos": "end"},
+            ]
+        )
 
         result = parser.parse_template(prompt_template, "gen")
         self.assertEqual(len(result), 3)  # system + user + assistant


### PR DESCRIPTION
## Problem

When a custom `url` is provided without a trailing `/` (e.g. `http://host/member1/deepseek_v4`), `urllib.parse.urljoin()` treats the last path segment as a file and replaces it with the endpoint, causing the request to go to the wrong URL.

For example:
- URL configured: `http://10.5.x.x:xx/member1/deepseek_v4`
- Actual request goes to: `http://10.5.x.x:xx/member1/v1/chat/completions` ❌
- Expected: `http://10.5.x.x:xx/member1/deepseek_v4/v1/chat/completions` ✅

This results in predictions being empty and output tokens all being 0.

## Root Cause

`_get_base_url()` in `base_api.py` returns the custom URL as-is without ensuring a trailing `/`. All API model subclasses use `urllib.parse.urljoin(self.base_url, endpoint)` to construct the final request URL, which incorrectly drops the last path segment when there's no trailing slash.

Affected classes:
- VLLMCustomAPIChat
- VLLMCustomAPI
- TGIAPI
- TritonAPI
- MindIEStreamAPI
- VitaGenerateAPI

## Fix

`_get_base_url()` now ensures the returned URL always ends with `/` by appending one if missing.

## Tests

Updated `test_init_with_url` to verify the trailing slash behavior, including:
- URL without trailing slash → gets `/` appended
- URL already with trailing slash → remains unchanged  
- URL without protocol → gets protocol added and `/` appended

## e2e test

1. url config with slah  <img width="2121" height="525" alt="image" src="https://github.com/user-attachments/assets/0870fa67-d74e-45a0-86c9-08b456f5aadb" />
2. url config without slash <img width="2262" height="522" alt="image" src="https://github.com/user-attachments/assets/93dc0359-80ad-42b9-a0a5-c9d82833cc5c" />

Closes #311 