### PR TITLE
fix: add trust_env=True to aiohttp sessions to respect HTTP proxy env vars

### DIFF
--- a/ais_bench/benchmark/openicl/icl_inferencer/icl_base_api_inferencer.py
+++ b/ais_bench/benchmark/openicl/icl_inferencer/icl_base_api_inferencer.py
@@ -165,6 +165,7 @@ class BaseApiInferencer(BaseInferencer):
             connector=aiohttp.TCPConnector(limit=concurrency + 1),
             timeout=aiohttp.ClientTimeout(total=get_request_time_out()),
             max_line_size=get_max_chunk_size(),
+            trust_env=True,
         )
         warmup_tasks = []
         async def warmup_limited_request_func(data: dict):
@@ -411,7 +412,8 @@ class BaseApiInferencer(BaseInferencer):
         connector = aiohttp.TCPConnector(limit=num_workers + 1)
         timeout = aiohttp.ClientTimeout(total=get_request_time_out())
         session = aiohttp.ClientSession(
-            connector=connector, timeout=timeout, max_line_size=get_max_chunk_size()
+            connector=connector, timeout=timeout, max_line_size=get_max_chunk_size(),
+            trust_env=True,
         )
         self.logger.debug(f"Create aiohttp session with "
                      f"connector: {connector}, "


### PR DESCRIPTION
## Summary

The `aiohttp.ClientSession` calls in `warmup()` and `consume_async_queue()` in `icl_base_api_inferencer.py` were missing `trust_env=True`, causing HTTP proxy environment variables (`http_proxy`, `https_proxy`) to be **ignored** during benchmark inference.

## Problem

- `curl` respects proxy env vars → manual requests succeed
- AISBench's inference path ignores proxy env vars → requests fail with `ERR99999` / `TINFER-RUNTIME-001` (warmup failed)
- The `trust_env=True` sessions in `base_api.py` are dead code because the inferencer always passes its own session (created without `trust_env=True`)

## Fix

Added `trust_env=True` to both `aiohttp.ClientSession` creation points in `icl_base_api_inferencer.py`:
- `warmup()` method (line ~164)
- `consume_async_queue()` method (line ~413)

## Verification

This ensures that when users have proxy settings configured in their environment (e.g., in Docker containers), AISBench will route requests through the proxy — matching the behavior of `curl` and the `requests` library.

Fixes #246