### PR TITLE
fix(humanevalx): issue 139 - file path join error

### DIFF
--- a/ais_bench/benchmark/datasets/humanevalx/humaneval_x_eval.py
+++ b/ais_bench/benchmark/datasets/humanevalx/humaneval_x_eval.py
@@ -45,7 +45,7 @@ class EvalConfig:
     tmp_dir: str = "./"
     n_workers: int = 32
     timeout: float = 500.0
-    problem_file: str = "./benchmark/ais_bench//datasets/humanevalx/humanevalx_python.jsonl.gz"
+    problem_file: str = "./ais_bench/datasets/humanevalx/humanevalx_python.jsonl.gz"
     out_dir: str = None
     k: Tuple[int, int, int] = (1, 10, 100)
     test_groundtruth: bool = False

--- a/ais_bench/benchmark/datasets/humanevalx/humanevalx.py
+++ b/ais_bench/benchmark/datasets/humanevalx/humanevalx.py
@@ -112,13 +112,12 @@ class HumanevalXEvaluator(BaseEvaluator):
 
     def score(self, predictions, references, test_set):
         prompts = [item['prompt'] for item in test_set]
-        problem_file = f'benchmark/ais_bench/datasets/humanevalx/humanevalx_{self.language}.jsonl.gz'
+        problem_file = f'ais_bench/datasets/humanevalx/humanevalx_{self.language}.jsonl.gz'
         # Get the absolute path
         problem_file = os.path.abspath(problem_file)
         import json
         # 定义文件路径
-        go_dir = f'./benchmark/ais_bench/benchmark/datasets/humanevalx/go/evaluation'
-
+        go_dir = f'./ais_bench/benchmark/datasets/humanevalx/go/evaluation'
         go_dir = os.path.abspath(go_dir)
 
         predictions = [{


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [x] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #139 

## 🔍 Motivation / 变更动机

issue 修复，humaneval_x 数据集评测socre函数路径拼接异常

## 📝 Modification / 修改内容

【问题原因】
humanevalx.py中score函数，硬编码路径时，多写了一个benchmark，导致在benchmark根目录下执行评测时，该问题发生。

假设 CWD = /data/cc/home/xty/benchmark/
path = "benchmark/ais_bench/datasets/humanevalx/humanevalx_js.jsonl.gz"
result = os.path.abspath(path)
print(result)
输出: /data/cc/home/xty/benchmark/benchmark/ais_bench/datasets/humanevalx/humanevalx_js.jsonl.gz

<img width="783" height="202" alt="Image" src="https://github.com/user-attachments/assets/39a94872-a48d-480a-911d-0e00fb4d211d" />

【解决方法】
==修改前==
```python
problem_file = f'benchmark/ais_bench/datasets/humanevalx/humanevalx_{self.language}.jsonl.gz'
problem_file = os.path.abspath(problem_file)
import json
go_dir = f'./benchmark/ais_bench/benchmark/datasets/humanevalx/go/evaluation'
go_dir = os.path.abspath(go_dir)
```

==修改后==
```python
problem_file = f'ais_bench/datasets/humanevalx/humanevalx_{self.language}.jsonl.gz'
problem_file = os.path.abspath(problem_file)
import json
go_dir = f'./ais_bench/benchmark/datasets/humanevalx/go/evaluation'
go_dir = os.path.abspath(go_dir)
```

## 📐 Associated Test Results / 关联测试结果

eval和summary流程正常：
<img width="726" height="569" alt="image" src="https://github.com/user-attachments/assets/a55ebc4c-b2b6-4e27-b98e-83c5a1f21843" />

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
