### PR TITLE
feat(UT): add oneig ut test- dataset & summary & stub

### DIFF
--- a/tests/UT/datasets/test_oneig.py
+++ b/tests/UT/datasets/test_oneig.py
@@ -1,0 +1,366 @@
+"""Unit tests for OneIGDataset - focus on public API."""
+import atexit
+import importlib
+import importlib.util
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def _mock_mod(name, **attrs):
+    """Create a mock module with proper __spec__ and optional attributes."""
+    mod = types.ModuleType(name)
+    mod.__spec__ = importlib.util.spec_from_loader(name, loader=None)
+    mod.__path__ = []
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+def _setup_file_mocks():
+    """Set up mock modules needed by this test file's import chain."""
+    mocks = {}
+
+    # datasets
+    mocks['datasets'] = _mock_mod('datasets',
+        Dataset=MagicMock(), DatasetDict=MagicMock(),
+        load_dataset=MagicMock(), load_from_disk=MagicMock(),
+        concatenate_datasets=MagicMock())
+    mocks['datasets'].Dataset.from_list = MagicMock(return_value=MagicMock())
+    mocks['datasets.utils'] = _mock_mod('datasets.utils')
+    mocks['datasets.utils.logging'] = _mock_mod('datasets.utils.logging',
+        disable_progress_bar=MagicMock())
+    mocks['datasets'].utils = mocks['datasets.utils']
+    mocks['datasets'].utils.logging = mocks['datasets.utils.logging']
+
+    # torch and submodules
+    torch = _mock_mod('torch',
+        Tensor=MagicMock, nn=MagicMock(), optim=MagicMock(),
+        utils=MagicMock(), cuda=MagicMock(), device=MagicMock(),
+        no_grad=MagicMock(), manual_seed=MagicMock(), load=MagicMock(),
+        float=MagicMock(), float16=MagicMock(), float32=MagicMock(),
+        bfloat16=MagicMock(), tensor=MagicMock(), cat=MagicMock(),
+        zeros=MagicMock(), ones=MagicMock(), max=MagicMock(),
+        amp=MagicMock(), _utils=MagicMock(), _C=MagicMock(),
+        jit=MagicMock(), onnx=MagicMock(), overrides=MagicMock(),
+        library=MagicMock(), compile=MagicMock(return_value=lambda f: f),
+        backends=MagicMock())
+    torch.cuda.is_available = MagicMock(return_value=False)
+    torch.cuda.manual_seed_all = MagicMock()
+    torch.utils.data = MagicMock()
+    torch.utils.data.DataLoader = MagicMock
+    torch.utils.data.Dataset = MagicMock
+    torch.amp.autocast = MagicMock()
+    torch.backends.mps = MagicMock()
+    torch.backends.mps.is_available = MagicMock(return_value=False)
+    torch.backends.cuda = MagicMock()
+    torch.backends.cuda.is_available = MagicMock(return_value=False)
+    torch.backends.cudnn = MagicMock()
+    torch.backends.cudnn.enabled = False
+    mocks['torch'] = torch
+    for sub in ['nn', 'cuda', 'amp', 'distributed', 'utils', 'utils.data',
+                'optim', 'autograd', 'profiler', '_utils', '_C', 'jit',
+                'onnx', 'overrides', 'library']:
+        mocks.setdefault('torch.' + sub, _mock_mod('torch.' + sub))
+
+    # mmengine
+    mocks['mmengine.dist'] = _mock_mod('mmengine.dist',
+        is_initialized=MagicMock(return_value=False),
+        is_main_process=MagicMock(return_value=True),
+        ProcessGroup=MagicMock)
+    mocks['mmengine.device'] = _mock_mod('mmengine.device',
+        is_npu_available=MagicMock(return_value=False),
+        get_device=MagicMock(return_value='cpu'))
+
+    # transformers
+    mocks['transformers'] = _mock_mod('transformers',
+        AutoTokenizer=MagicMock(), AutoModel=MagicMock(),
+        AutoModelForCausalLM=MagicMock(), AutoConfig=MagicMock(),
+        StoppingCriteria=type('StoppingCriteria', (), {}))
+    mocks['transformers.generation'] = _mock_mod('transformers.generation')
+    mocks['transformers.generation.stopping_criteria'] = _mock_mod(
+        'transformers.generation.stopping_criteria',
+        StoppingCriteria=type('StoppingCriteria', (), {}))
+
+    # other dependencies
+    mocks['evaluate'] = _mock_mod('evaluate',
+        load=MagicMock(return_value=MagicMock()),
+        combine=MagicMock(return_value=MagicMock()))
+    mocks['orjson'] = _mock_mod('orjson',
+        loads=MagicMock(return_value={}), dumps=MagicMock(return_value=b'{}'))
+    mocks['fcntl'] = _mock_mod('fcntl',
+        flock=MagicMock(), LOCK_EX=1, LOCK_UN=2, LOCK_SH=4, LOCK_NB=8)
+    mocks['resource'] = _mock_mod('resource',
+        getrlimit=MagicMock(return_value=(1000, 1000)),
+        setrlimit=MagicMock(), RLIMIT_AS=1, RLIMIT_CPU=2, RLIMIT_NOFILE=3)
+    for name in ['termios', 'pwd', 'grp']:
+        mocks[name] = _mock_mod(name)
+
+    return mocks
+
+
+_FILE_MOCKS = _setup_file_mocks()
+_file_originals = {k: sys.modules.get(k) for k in _FILE_MOCKS}
+for _mod_name, _mock_obj in _FILE_MOCKS.items():
+    if _mod_name in sys.modules:
+        continue
+    try:
+        importlib.import_module(_mod_name)
+    except Exception:
+        sys.modules[_mod_name] = _mock_obj
+
+
+def _restore_file_mocks():
+    for mod_name, original in _file_originals.items():
+        if original is not None:
+            sys.modules[mod_name] = original
+        else:
+            sys.modules.pop(mod_name, None)
+
+
+atexit.register(_restore_file_mocks)
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+from ais_bench.benchmark.datasets.oneig import OneIGDataset
+
+
+def _make_dataset(**attrs):
+    """Create a OneIGDataset instance bypassing BaseDataset.__init__."""
+    ds = OneIGDataset.__new__(OneIGDataset)
+    ds.logger = MagicMock()
+    for k, v in attrs.items():
+        setattr(ds, k, v)
+    return ds
+
+
+class TestOneIGDataset(unittest.TestCase):
+    """OneIGDataset 对外API测试"""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_oneig_load_model_names_length_mismatch_raises_error(self):
+        """model_names长度不匹配时应抛出ValueError"""
+        ds = _make_dataset()
+        with patch.object(ds, '_load_aux_data', return_value={}), \
+             patch.object(ds, '_load_image_data', return_value=[]), \
+             patch.object(ds, '_preprocess_data', return_value=[]), \
+             patch('ais_bench.benchmark.datasets.oneig.Dataset.from_list'):
+            with self.assertRaises(ValueError) as ctx:
+                ds.load(path='/tmp/imgs', task_type='alignment',
+                        model_names=['m1', 'm2'], image_grids=['2,2'])
+            self.assertIn('model_names length', str(ctx.exception))
+
+    def test_oneig_load_default_params(self):
+        """默认参数应正确设置"""
+        ds = _make_dataset()
+        with patch.object(ds, '_load_aux_data', return_value={}), \
+             patch.object(ds, '_load_image_data', return_value=[]), \
+             patch.object(ds, '_preprocess_data', return_value=[]), \
+             patch('ais_bench.benchmark.datasets.oneig.Dataset.from_list') as mock_from_list:
+            mock_from_list.return_value = MagicMock()
+            ds.load(path='/tmp/imgs')
+            self.assertEqual(ds.model_names, ['default'])
+            self.assertEqual(ds.image_grids, ['2,2'])
+            self.assertEqual(ds.task_type, 'alignment')
+            self.assertEqual(ds.mode, 'EN')
+
+    def test_oneig_load_returns_dataset(self):
+        """load应返回Dataset对象"""
+        ds = _make_dataset()
+        fake_dataset = MagicMock()
+        with patch.object(ds, '_load_aux_data', return_value={}), \
+             patch.object(ds, '_load_image_data', return_value=[]), \
+             patch.object(ds, '_preprocess_data', return_value=[]), \
+             patch('ais_bench.benchmark.datasets.oneig.Dataset.from_list',
+                   return_value=fake_dataset):
+            result = ds.load(path='/tmp/imgs')
+            self.assertIs(result, fake_dataset)
+
+    def test_oneig_load_aux_data_alignment(self):
+        """alignment任务应正确加载question_dependency数据"""
+        qd_dir = os.path.join(self.tmp, 'qd')
+        os.makedirs(qd_dir)
+        anime_data = {'s1': {'question': 'Q1', 'dependency': 'D1'}}
+        with open(os.path.join(qd_dir, 'anime.json'), 'w', encoding='utf-8') as f:
+            json.dump(anime_data, f)
+        ds = _make_dataset(
+            task_type='alignment', mode='EN',
+            aux_data_paths={'question_dependency_dir': qd_dir})
+        result = ds._load_aux_data()
+        self.assertIn('alignment_data', result)
+        self.assertEqual(result['alignment_data']['anime'], anime_data)
+
+    def test_oneig_load_aux_data_reasoning(self):
+        """reasoning任务应正确加载gt_answers数据"""
+        gt_path = os.path.join(self.tmp, 'gt.json')
+        gt_data = {'s1': '42', 's2': 'hello'}
+        with open(gt_path, 'w', encoding='utf-8') as f:
+            json.dump(gt_data, f)
+        ds = _make_dataset(
+            task_type='reasoning', mode='EN',
+            aux_data_paths={'gt_answer_path': gt_path})
+        result = ds._load_aux_data()
+        self.assertEqual(result['gt_answers'], gt_data)
+
+    def test_oneig_load_aux_data_text_valid(self):
+        """text任务应正确加载text_contents数据"""
+        csv_path = os.path.join(self.tmp, 'text.csv')
+        df = pd.DataFrame({'id': ['s1', 's2'], 'text_content': ['hello', 'world']})
+        df.to_csv(csv_path, index=False)
+        ds = _make_dataset(
+            task_type='text', mode='EN',
+            aux_data_paths={'text_content_csv_path': csv_path})
+        result = ds._load_aux_data()
+        self.assertEqual(result['text_contents']['s1'], 'hello')
+        self.assertEqual(result['text_contents']['s2'], 'world')
+
+    def test_oneig_load_aux_data_style_valid(self):
+        """style任务应正确加载并归一化style_labels数据"""
+        csv_path = os.path.join(self.tmp, 'style.csv')
+        df = pd.DataFrame({'id': ['s1', 's2'], 'class': ['Anime Style', 'Portrait']})
+        df.to_csv(csv_path, index=False)
+        ds = _make_dataset(
+            task_type='style', mode='EN',
+            aux_data_paths={'style_csv_path': csv_path})
+        result = ds._load_aux_data()
+        self.assertEqual(result['style_labels']['s1'], 'anime_style')
+        self.assertEqual(result['style_labels']['s2'], 'portrait')
+
+    def test_oneig_load_image_data_finds_images(self):
+        """应正确找到并加载图片数据"""
+        img_dir = os.path.join(self.tmp, 'text', 'm1')
+        os.makedirs(img_dir, exist_ok=True)
+        with open(os.path.join(img_dir, 'abc.png'), 'wb') as f:
+            f.write(b'')
+        ds = _make_dataset(
+            task_type='text', mode='EN',
+            model_names=['m1'], image_grids=['2,2'])
+        result = ds._load_image_data(self.tmp, {})
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['model_name'], 'm1')
+        self.assertEqual(result[0]['id'], 'abc')
+
+    def test_oneig_load_image_data_dir_not_found(self):
+        """目录不存在时应返回空列表"""
+        ds = _make_dataset(
+            task_type='text', mode='EN',
+            model_names=['m1'], image_grids=['2,2'])
+        result = ds._load_image_data('/nonexistent/path', {})
+        self.assertEqual(result, [])
+
+    def test_oneig_preprocess_strips_whitespace(self):
+        """_preprocess_data应去除字符串字段的首尾空白"""
+        ds = _make_dataset()
+        data = [
+            {'gt_answer': '  42  '},
+            {'expected_text': '  hello  '},
+            {'style_label': '  anime  '},
+        ]
+        result = ds._preprocess_data(data)
+        self.assertEqual(result[0]['gt_answer'], '42')
+        self.assertEqual(result[1]['expected_text'], 'hello')
+        self.assertEqual(result[2]['style_label'], 'anime')
+
+    def test_oneig_preprocess_preserves_non_string(self):
+        """_preprocess_data应保留非字符串字段"""
+        ds = _make_dataset()
+        data = [{'gt_answer': 42, 'other': None}]
+        result = ds._preprocess_data(data)
+        self.assertEqual(result[0]['gt_answer'], 42)
+        self.assertIsNone(result[0]['other'])
+
+    def test_oneig_get_task_class_iter_zh_alignment(self):
+        """ZH模式alignment应包含multilingualism"""
+        ds = _make_dataset(task_type='alignment', mode='ZH')
+        result = ds._get_task_class_iter()
+        class_names = [c[0] for c in result]
+        self.assertIn('Multilingualism', class_names)
+
+    def test_oneig_get_task_class_iter_en_alignment(self):
+        """EN模式alignment不应包含multilingualism"""
+        ds = _make_dataset(task_type='alignment', mode='EN')
+        result = ds._get_task_class_iter()
+        class_names = [c[0] for c in result]
+        self.assertNotIn('Multilingualism', class_names)
+
+    def test_oneig_load_alignment_task_fields(self):
+        """alignment任务应正确设置question和dependency字段"""
+        qd_dir = os.path.join(self.tmp, 'qd')
+        os.makedirs(qd_dir)
+        anime_data = {'abc': {'question': '{"1":"Q1"}', 'dependency': '{"1":[0]}'}}
+        with open(os.path.join(qd_dir, 'anime.json'), 'w', encoding='utf-8') as f:
+            json.dump(anime_data, f)
+        img_dir = os.path.join(self.tmp, 'anime', 'm1')
+        os.makedirs(img_dir)
+        with open(os.path.join(img_dir, 'abc.png'), 'wb') as f:
+            f.write(b'')
+        ds = _make_dataset(task_type='alignment', mode='EN')
+        with patch('ais_bench.benchmark.datasets.oneig.Dataset.from_list',
+                   side_effect=lambda x: x):
+            result = ds.load(path=self.tmp, task_type='alignment',
+                            model_names=['m1'], image_grids=['2,2'],
+                            aux_data_paths={'question_dependency_dir': qd_dir})
+        item = result[0]
+        self.assertEqual(item['question'], '{"1":"Q1"}')
+        self.assertEqual(item['dependency'], '{"1":[0]}')
+
+    def test_oneig_load_reasoning_task_fields(self):
+        """reasoning任务应正确设置gt_answer字段"""
+        gt_path = os.path.join(self.tmp, 'gt.json')
+        with open(gt_path, 'w', encoding='utf-8') as f:
+            json.dump({'abc': '42'}, f)
+        img_dir = os.path.join(self.tmp, 'reasoning', 'm1')
+        os.makedirs(img_dir)
+        with open(os.path.join(img_dir, 'abc.png'), 'wb') as f:
+            f.write(b'')
+        ds = _make_dataset(task_type='reasoning', mode='EN')
+        with patch('ais_bench.benchmark.datasets.oneig.Dataset.from_list',
+                   side_effect=lambda x: x):
+            result = ds.load(path=self.tmp, task_type='reasoning',
+                            model_names=['m1'], image_grids=['2,2'],
+                            aux_data_paths={'gt_answer_path': gt_path})
+        self.assertEqual(result[0]['gt_answer'], '42')
+
+    def test_oneig_load_reasoning_empty_gt_skipped(self):
+        """reasoning任务空gt_answer应被跳过"""
+        gt_path = os.path.join(self.tmp, 'gt.json')
+        with open(gt_path, 'w', encoding='utf-8') as f:
+            json.dump({'abc': ''}, f)
+        img_dir = os.path.join(self.tmp, 'reasoning', 'm1')
+        os.makedirs(img_dir)
+        with open(os.path.join(img_dir, 'abc.png'), 'wb') as f:
+            f.write(b'')
+        ds = _make_dataset(task_type='reasoning', mode='EN')
+        with patch('ais_bench.benchmark.datasets.oneig.Dataset.from_list',
+                   side_effect=lambda x: x):
+            result = ds.load(path=self.tmp, task_type='reasoning',
+                            model_names=['m1'], image_grids=['2,2'],
+                            aux_data_paths={'gt_answer_path': gt_path})
+        self.assertEqual(len(result), 0)
+
+    def test_oneig_is_valid_style_label(self):
+        """测试_is_valid_style_label各种输入"""
+        ds = _make_dataset(task_type='style')
+        import pandas as pd
+        self.assertFalse(ds._is_valid_style_label(pd.NA))
+        self.assertFalse(ds._is_valid_style_label(''))
+        self.assertFalse(ds._is_valid_style_label('nan'))
+        self.assertFalse(ds._is_valid_style_label('  '))
+        self.assertTrue(ds._is_valid_style_label('impressionism'))
+        self.assertTrue(ds._is_valid_style_label('Pop Art'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/summarizers/test_oneig.py
+++ b/tests/UT/summarizers/test_oneig.py
@@ -1,0 +1,274 @@
+"""Unit tests for OneIGSummarizer - focus on public API."""
+import atexit
+import importlib
+import importlib.util
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def _mock_mod(name, **attrs):
+    """Create a mock module with proper __spec__ and optional attributes."""
+    mod = types.ModuleType(name)
+    mod.__spec__ = importlib.util.spec_from_loader(name, loader=None)
+    mod.__path__ = []
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+def _setup_file_mocks():
+    """Set up mock modules needed by this test file's import chain."""
+    mocks = {}
+
+    # torch and submodules
+    torch = _mock_mod('torch',
+        Tensor=MagicMock, nn=MagicMock(), optim=MagicMock(),
+        utils=MagicMock(), cuda=MagicMock(), device=MagicMock(),
+        no_grad=MagicMock(), manual_seed=MagicMock(), load=MagicMock(),
+        float=MagicMock(), float16=MagicMock(), float32=MagicMock(),
+        bfloat16=MagicMock(), tensor=MagicMock(), cat=MagicMock(),
+        zeros=MagicMock(), ones=MagicMock(), max=MagicMock(),
+        amp=MagicMock(), _utils=MagicMock(), _C=MagicMock(),
+        jit=MagicMock(), onnx=MagicMock(), overrides=MagicMock(),
+        library=MagicMock(), compile=MagicMock(return_value=lambda f: f),
+        backends=MagicMock())
+    torch.cuda.is_available = MagicMock(return_value=False)
+    torch.cuda.manual_seed_all = MagicMock()
+    torch.utils.data = MagicMock()
+    torch.utils.data.DataLoader = MagicMock
+    torch.utils.data.Dataset = MagicMock
+    torch.amp.autocast = MagicMock()
+    torch.backends.mps = MagicMock()
+    torch.backends.mps.is_available = MagicMock(return_value=False)
+    torch.backends.cuda = MagicMock()
+    torch.backends.cuda.is_available = MagicMock(return_value=False)
+    torch.backends.cudnn = MagicMock()
+    torch.backends.cudnn.enabled = False
+    mocks['torch'] = torch
+    for sub in ['nn', 'cuda', 'amp', 'distributed', 'utils', 'utils.data',
+                'optim', 'autograd', 'profiler', '_utils', '_C', 'jit',
+                'onnx', 'overrides', 'library']:
+        mocks.setdefault('torch.' + sub, _mock_mod('torch.' + sub))
+
+    # mmengine
+    mocks['mmengine.dist'] = _mock_mod('mmengine.dist',
+        is_initialized=MagicMock(return_value=False),
+        is_main_process=MagicMock(return_value=True),
+        ProcessGroup=MagicMock)
+    mocks['mmengine.device'] = _mock_mod('mmengine.device',
+        is_npu_available=MagicMock(return_value=False),
+        get_device=MagicMock(return_value='cpu'))
+
+    # transformers
+    mocks['transformers'] = _mock_mod('transformers',
+        AutoTokenizer=MagicMock(), AutoModel=MagicMock(),
+        AutoModelForCausalLM=MagicMock(), AutoConfig=MagicMock(),
+        StoppingCriteria=type('StoppingCriteria', (), {}))
+    mocks['transformers.generation'] = _mock_mod('transformers.generation')
+    mocks['transformers.generation.stopping_criteria'] = _mock_mod(
+        'transformers.generation.stopping_criteria',
+        StoppingCriteria=type('StoppingCriteria', (), {}))
+
+    # other dependencies
+    mocks['evaluate'] = _mock_mod('evaluate',
+        load=MagicMock(return_value=MagicMock()),
+        combine=MagicMock(return_value=MagicMock()))
+    mocks['orjson'] = _mock_mod('orjson',
+        loads=MagicMock(return_value={}), dumps=MagicMock(return_value=b'{}'))
+    mocks['fcntl'] = _mock_mod('fcntl',
+        flock=MagicMock(), LOCK_EX=1, LOCK_UN=2, LOCK_SH=4, LOCK_NB=8)
+    mocks['resource'] = _mock_mod('resource',
+        getrlimit=MagicMock(return_value=(1000, 1000)),
+        setrlimit=MagicMock(), RLIMIT_AS=1, RLIMIT_CPU=2, RLIMIT_NOFILE=3)
+    for name in ['termios', 'pwd', 'grp']:
+        mocks[name] = _mock_mod(name)
+
+    return mocks
+
+
+_FILE_MOCKS = _setup_file_mocks()
+_file_originals = {k: sys.modules.get(k) for k in _FILE_MOCKS}
+for _mod_name, _mock_obj in _FILE_MOCKS.items():
+    if _mod_name in sys.modules:
+        continue
+    try:
+        importlib.import_module(_mod_name)
+    except Exception:
+        sys.modules[_mod_name] = _mock_obj
+
+
+def _restore_file_mocks():
+    for mod_name, original in _file_originals.items():
+        if original is not None:
+            sys.modules[mod_name] = original
+        else:
+            sys.modules.pop(mod_name, None)
+
+
+atexit.register(_restore_file_mocks)
+
+import unittest
+from unittest.mock import patch
+
+from mmengine.config import ConfigDict
+
+from ais_bench.benchmark.summarizers.default import DefaultSummarizer
+from ais_bench.benchmark.summarizers.oneig import OneIGSummarizer
+
+
+class TestOneIGSummarizer(unittest.TestCase):
+    """OneIGSummarizer 对外API测试"""
+
+    def test_oneig_register_metric_new_metric(self):
+        """注册新metric时应正确更新所有字典"""
+        raw_results = {}
+        parsed_results = {}
+        dataset_metrics = {}
+        dataset_eval_mode = {}
+        OneIGSummarizer._register_metric(
+            'oneig_diversity_anime', 85.0, 'model_a',
+            raw_results, parsed_results, dataset_metrics, dataset_eval_mode)
+        self.assertEqual(
+            raw_results['model_a']['oneig_diversity_anime']['accuracy'], 85.0)
+        self.assertEqual(
+            parsed_results['model_a']['oneig_diversity_anime']['accuracy'], 85.0)
+        self.assertEqual(dataset_metrics['oneig_diversity_anime'], ['accuracy'])
+        self.assertEqual(dataset_eval_mode['oneig_diversity_anime'], 'gen')
+
+    def test_oneig_register_metric_existing_metric(self):
+        """已存在metric时不应覆盖dataset_metrics"""
+        raw_results = {}
+        parsed_results = {}
+        dataset_metrics = {'oneig_diversity_anime': ['custom_metric']}
+        dataset_eval_mode = {}
+        OneIGSummarizer._register_metric(
+            'oneig_diversity_anime', 85.0, 'model_a',
+            raw_results, parsed_results, dataset_metrics, dataset_eval_mode)
+        self.assertEqual(
+            dataset_metrics['oneig_diversity_anime'], ['custom_metric'])
+        self.assertEqual(
+            raw_results['model_a']['oneig_diversity_anime']['accuracy'], 85.0)
+
+    def test_oneig_aggregate_diversity_with_class_scores(self):
+        """class_scores应正确聚合细粒度指标"""
+        summ = OneIGSummarizer.__new__(OneIGSummarizer)
+        raw_results = {'model_a': {
+            'oneig_diversity': {
+                'class_scores': {
+                    'anime': [0.8, 0.9],
+                    'human': [0.7, 0.6],
+                },
+            }
+        }}
+        parsed_results = {}
+        dataset_metrics = {}
+        dataset_eval_mode = {}
+        summ._aggregate_diversity_finegrain(
+            'model_a', raw_results, parsed_results,
+            dataset_metrics, dataset_eval_mode, raw_results['model_a'])
+        # anime: avg = 0.85, *100 = 85.0
+        self.assertAlmostEqual(
+            raw_results['model_a']['oneig_diversity_anime']['accuracy'], 85.0)
+        # human: avg = 0.65, *100 = 65.0
+        self.assertAlmostEqual(
+            raw_results['model_a']['oneig_diversity_human']['accuracy'], 65.0)
+        self.assertIn('oneig_diversity_anime', dataset_metrics)
+        self.assertIn('oneig_diversity_human', dataset_metrics)
+
+    def test_oneig_aggregate_diversity_class_scores_with_none(self):
+        """class_scores含None时应过滤后计算"""
+        summ = OneIGSummarizer.__new__(OneIGSummarizer)
+        raw_results = {'model_a': {
+            'oneig_diversity': {
+                'class_scores': {'anime': [0.8, None, 0.9]},
+            }
+        }}
+        parsed_results = {}
+        dataset_metrics = {}
+        dataset_eval_mode = {}
+        summ._aggregate_diversity_finegrain(
+            'model_a', raw_results, parsed_results,
+            dataset_metrics, dataset_eval_mode, raw_results['model_a'])
+        # valid = [0.8, 0.9], avg = 0.85, *100 = 85.0
+        self.assertAlmostEqual(
+            raw_results['model_a']['oneig_diversity_anime']['accuracy'], 85.0)
+
+    def test_oneig_aggregate_diversity_fallback_details(self):
+        """无class_scores时应回退到details聚合"""
+        summ = OneIGSummarizer.__new__(OneIGSummarizer)
+        raw_results = {'model_a': {
+            'oneig_diversity': {
+                'details': [
+                    {'class_item': 'anime', 'score': 0.8},
+                    {'class_item': 'anime', 'score': 0.9},
+                    {'class_item': 'human', 'score': 0.7},
+                ],
+            }
+        }}
+        parsed_results = {}
+        dataset_metrics = {}
+        dataset_eval_mode = {}
+        summ._aggregate_diversity_finegrain(
+            'model_a', raw_results, parsed_results,
+            dataset_metrics, dataset_eval_mode, raw_results['model_a'])
+        # anime: avg = 0.85, *100 = 85.0
+        self.assertAlmostEqual(
+            raw_results['model_a']['oneig_diversity_anime']['accuracy'], 85.0)
+        # human: avg = 0.7, *100 = 70.0
+        self.assertAlmostEqual(
+            raw_results['model_a']['oneig_diversity_human']['accuracy'], 70.0)
+
+    @patch('ais_bench.benchmark.summarizers.default.AISLogger')
+    @patch.object(DefaultSummarizer, '_calculate_group_metrics')
+    def test_oneig_summarizer_full_flow(self, mock_super, _log):
+        """端到端测试：full flow应正确聚合细粒度指标"""
+        cfg = ConfigDict({
+            'models': [{'abbr': 'model_a'}],
+            'datasets': [{'abbr': 'oneig_diversity'}],
+            'work_dir': '/tmp',
+        })
+        summ = OneIGSummarizer(cfg)
+
+        raw_results = {
+            'model_a': {
+                'oneig_diversity': {
+                    'accuracy': 75.0,
+                    'class_scores': {
+                        'anime': [0.8, 0.9, None],
+                        'human': [0.7, 0.6],
+                        'object': [None, None],
+                    },
+                    'details': [],
+                }
+            }
+        }
+        parsed_results = {
+            'model_a': {'oneig_diversity': {'accuracy': 75.0}},
+        }
+        dataset_metrics = {'oneig_diversity': ['accuracy']}
+        dataset_eval_mode = {'oneig_diversity': 'gen'}
+
+        mock_super.side_effect = lambda rr, pr, dm, dem: (rr, pr, dm, dem)
+
+        raw_results, parsed_results, dataset_metrics, dataset_eval_mode = \
+            summ._calculate_group_metrics(
+                raw_results, parsed_results, dataset_metrics,
+                dataset_eval_mode)
+
+        # anime: valid = [0.8, 0.9], avg = 0.85, *100 = 85.0
+        self.assertIn('oneig_diversity_anime', parsed_results['model_a'])
+        self.assertAlmostEqual(
+            parsed_results['model_a']['oneig_diversity_anime']['accuracy'], 85.0)
+        # human: valid = [0.7, 0.6], avg = 0.65, *100 = 65.0
+        self.assertAlmostEqual(
+            parsed_results['model_a']['oneig_diversity_human']['accuracy'], 65.0)
+        # object: valid = [], skipped
+        self.assertNotIn('oneig_diversity_object', parsed_results['model_a'])
+        self.assertIn('oneig_diversity_anime', dataset_metrics)
+        self.assertIn('oneig_diversity_human', dataset_metrics)
+        self.assertEqual(dataset_eval_mode['oneig_diversity_anime'], 'gen')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/tasks/oneig/conftest.py
+++ b/tests/UT/tasks/oneig/conftest.py
@@ -1,0 +1,330 @@
+"""Conftest for OneIG task tests.
+
+Pre-mocks missing heavy dependencies before test collection.
+Mocks are scoped to this directory only and restored after session.
+"""
+import importlib
+import importlib.util
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _mock_mod(name, **attrs):
+    """Create a mock module with __spec__ and optional attributes."""
+    mod = types.ModuleType(name)
+    mod.__spec__ = importlib.util.spec_from_loader(name, loader=None)
+    mod.__path__ = []
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+def _setup_mocks():
+    """Set up mock modules for missing heavy dependencies."""
+    m = {}
+
+    # Helper: MagicMock with return value
+    def _mr(val):
+        return MagicMock(return_value=val)
+
+    # ---- torch ----
+    torch = _mock_mod('torch',
+        Tensor=MagicMock, nn=MagicMock(), optim=MagicMock(),
+        utils=MagicMock(), cuda=MagicMock(), device=_mr(MagicMock()),
+        no_grad=MagicMock(), manual_seed=MagicMock(), load=MagicMock(),
+        float=MagicMock(), float16=MagicMock(name='float16'),
+        float32=MagicMock(name='float32'), bfloat16=MagicMock(name='bfloat16'),
+        tensor=_mr(MagicMock()), cat=MagicMock(), zeros=_mr(MagicMock()),
+        ones=_mr(MagicMock()), max=_mr(MagicMock()), amp=MagicMock(),
+        _utils=MagicMock(), _C=MagicMock(), jit=MagicMock(),
+        onnx=MagicMock(), overrides=MagicMock(), library=MagicMock(),
+        _meta_registrations=MagicMock(), _inductor=MagicMock(),
+        compile=_mr(lambda f: f), backends=MagicMock(),
+        LongTensor=MagicMock, FloatTensor=MagicMock, IntTensor=MagicMock,
+        DoubleTensor=MagicMock, HalfTensor=MagicMock, ByteTensor=MagicMock,
+        CharTensor=MagicMock, ShortTensor=MagicMock, BoolTensor=MagicMock,
+    )
+    torch.cuda.is_available = _mr(False)
+    torch.cuda.manual_seed_all = MagicMock()
+    torch.cuda.empty_cache = MagicMock()
+    torch.amp.autocast = MagicMock()
+    torch.backends.mps = MagicMock()
+    torch.backends.mps.is_available = _mr(False)
+    torch.backends.cuda = MagicMock()
+    torch.backends.cuda.is_available = _mr(False)
+    torch.backends.cudnn = MagicMock()
+    torch.backends.cudnn.enabled = False
+    torch.utils.data = MagicMock()
+    torch.utils.data.DataLoader = MagicMock
+    torch.utils.data.Dataset = MagicMock
+    torch.nn.Module = MagicMock
+    torch.nn.functional = MagicMock()
+    torch._utils._flatten_dense_tensors = MagicMock()
+    torch._utils._take_tensors = MagicMock()
+    torch._utils._unflatten_dense_tensors = MagicMock()
+    m['torch'] = torch
+
+    # torch submodules
+    for sub in ['nn', 'cuda', 'amp', 'distributed', 'utils', 'utils.data',
+                'optim', 'autograd', 'profiler', '_utils', '_C', 'jit',
+                'onnx', 'overrides', 'library']:
+        if f'torch.{sub}' not in m:
+            m[f'torch.{sub}'] = _mock_mod(f'torch.{sub}')
+
+    # torch.utils.data needs DataLoader/Dataset for imports
+    m['torch.utils.data'].DataLoader = MagicMock
+    m['torch.utils.data'].Dataset = MagicMock
+    m['torch.utils.data'].default_collate = MagicMock()
+    torch.utils.data = m['torch.utils.data']
+    # torch.utils needs checkpoint
+    m['torch.utils'].checkpoint = MagicMock()
+    m['torch.utils'].data = m['torch.utils.data']
+    # torch.nn needs Module
+    m['torch.nn'].Module = MagicMock
+    m['torch.nn'].functional = MagicMock()
+    # torch.optim needs optimizer classes
+    m['torch.optim'].AdamW = MagicMock
+    m['torch.optim'].Adam = MagicMock
+    m['torch.optim'].SGD = MagicMock
+    # torch.autograd needs grad/backward
+    m['torch.autograd'].grad = MagicMock()
+    m['torch.autograd'].backward = MagicMock()
+
+    # torch.distributed specific
+    td = m['torch.distributed']
+    td.is_initialized = _mr(False)
+    td.is_available = _mr(False)
+    td.get_rank = _mr(0)
+    td.get_world_size = _mr(1)
+
+    # ---- mmengine ----
+    m['mmengine.dist'] = _mock_mod('mmengine.dist',
+        is_initialized=_mr(False), is_main_process=_mr(True),
+        get_rank=_mr(0), get_world_size=_mr(1), ProcessGroup=MagicMock)
+    m['mmengine.device'] = _mock_mod('mmengine.device',
+        is_npu_available=_mr(False), get_device=_mr('cpu'),
+        get_max_cuda_memory=_mr(0), get_max_musa_memory=_mr(0))
+
+    # ---- transformers ----
+    tf = _mock_mod('transformers',
+        Qwen3VLForConditionalGeneration=MagicMock(),
+        AutoProcessor=MagicMock(), AutoTokenizer=MagicMock(),
+        StoppingCriteria=type('StoppingCriteria', (), {}),
+        StoppingCriteriaList=_mr([]), PreTrainedTokenizer=MagicMock,
+        PreTrainedTokenizerFast=MagicMock, AutoModel=MagicMock(),
+        AutoModelForCausalLM=MagicMock(), AutoConfig=MagicMock(),
+        GenerationConfig=MagicMock(), BitsAndBytesConfig=MagicMock(),
+        pipeline=MagicMock(), Qwen2_5_VLForConditionalGeneration=MagicMock(),
+        Qwen2_5OmniProcessor=MagicMock(), Qwen2VLProcessor=MagicMock(),
+        Qwen2Tokenizer=MagicMock(), BertTokenizer=MagicMock(),
+        BertLMHeadModel=MagicMock(), BertConfig=MagicMock(),
+    )
+    tf_gen = _mock_mod('transformers.generation', GenerationConfig=MagicMock())
+    tf_sc = _mock_mod('transformers.generation.stopping_criteria',
+        StoppingCriteria=type('StoppingCriteria', (), {}))
+    tf_gen.stopping_criteria = tf_sc
+    tf.generation = tf_gen
+    m['transformers'] = tf
+    m['transformers.generation'] = tf_gen
+    m['transformers.generation.stopping_criteria'] = tf_sc
+
+    # ---- torchvision ----
+    tv_t = _mock_mod('torchvision.transforms',
+        Compose=MagicMock(), Resize=MagicMock(), CenterCrop=MagicMock(),
+        ToTensor=MagicMock(), Normalize=MagicMock(), InterpolationMode=MagicMock())
+    m['torchvision'] = _mock_mod('torchvision', transforms=tv_t)
+    m['torchvision.transforms'] = tv_t
+
+    # ---- other ML/NLP deps ----
+    m['qwen_vl_utils'] = _mock_mod('qwen_vl_utils',
+        process_vision_info=_mr((None, None)))
+    m['dreamsim'] = _mock_mod('dreamsim',
+        dreamsim=_mr((MagicMock(), MagicMock())))
+    m['evaluate'] = _mock_mod('evaluate',
+        load=_mr(MagicMock()), combine=_mr(MagicMock()))
+    m['PIL'] = _mock_mod('PIL', Image=_mock_mod('PIL.Image', open=MagicMock()))
+    m['PIL.Image'] = m['PIL'].Image
+
+    # numpy
+    np_attrs = {k: _mr(MagicMock()) for k in
+        ['zeros', 'ones', 'array', 'asarray', 'concatenate',
+         'expand_dims', 'stack', 'squeeze', 'reshape']}
+    np_attrs.update({
+        'ndarray': MagicMock,
+        'float32': MagicMock(name='float32'),
+        'float64': MagicMock(name='float64'),
+        'int32': MagicMock(name='int32'),
+        'int64': MagicMock(name='int64'),
+        'uint8': MagicMock(name='uint8'),
+        'mean': _mr(0.0), 'sum': _mr(0),
+        'max': _mr(0), 'min': _mr(0),
+    })
+    m['numpy'] = _mock_mod('numpy', **np_attrs)
+
+    # scipy
+    m['scipy'] = _mock_mod('scipy',
+        stats=_mock_mod('scipy.stats', hypergeom=MagicMock()),
+        integrate=_mock_mod('scipy.integrate'))
+    m['scipy.stats'] = m['scipy'].stats
+    m['scipy.integrate'] = m['scipy'].integrate
+
+    # nltk
+    nltk_t = _mock_mod('nltk.translate',
+        bleu_score=_mock_mod('nltk.translate.bleu_score', sentence_bleu=_mr(0.5)))
+    nltk_t.tokenize = _mock_mod('nltk.tokenize', word_tokenize=_mr([]))
+    m['nltk'] = _mock_mod('nltk', translate=nltk_t)
+    m['nltk.translate'] = nltk_t
+    m['nltk.translate.bleu_score'] = nltk_t.bleu_score
+    m['nltk.tokenize'] = nltk_t.tokenize
+
+    # simple single-module deps
+    m['jieba'] = _mock_mod('jieba', cut=_mr([]), lcut=_mr([]))
+    m['rouge_chinese'] = _mock_mod('rouge_chinese', Rouge=MagicMock())
+    m['rouge_score'] = _mock_mod('rouge_score',
+        rouge_scorer=_mock_mod('rouge_score.rouge_scorer', RougeScorer=MagicMock))
+    m['rouge_score.rouge_scorer'] = m['rouge_score'].rouge_scorer
+    m['sacrebleu'] = _mock_mod('sacrebleu',
+        corpus_bleu=_mr(MagicMock(score=0)), BLEU=MagicMock)
+    m['bert_score'] = _mock_mod('bert_score', score=_mr(([], [], [])))
+    m['jiwer'] = _mock_mod('jiwer', compute_measures=_mr({}))
+    m['Levenshtein'] = _mock_mod('Levenshtein', distance=_mr(0))
+
+    # rapidfuzz
+    rf_d = _mock_mod('rapidfuzz.distance',
+        Levenshtein=_mock_mod('rapidfuzz.distance.Levenshtein', distance=_mr(0)))
+    m['rapidfuzz'] = _mock_mod('rapidfuzz', distance=rf_d)
+    m['rapidfuzz.distance'] = rf_d
+    m['rapidfuzz.distance.Levenshtein'] = rf_d.Levenshtein
+
+    m['latex2sympy2'] = _mock_mod('latex2sympy2', latex2sympy=_mr(MagicMock()))
+    m['sympy'] = _mock_mod('sympy',
+        sympify=_mr(MagicMock()), Eq=MagicMock, solve=_mr([]))
+    m['lark'] = _mock_mod('lark',
+        Lark=MagicMock, Transformer=type('Transformer', (), {}))
+    m['sentence_transformers'] = _mock_mod('sentence_transformers',
+        SentenceTransformer=MagicMock)
+    m['safetensors'] = _mock_mod('safetensors',
+        torch=_mock_mod('safetensors.torch', load_file=_mr({})))
+    m['safetensors.torch'] = m['safetensors'].torch
+
+    # pycocoevalcap
+    pcec = _mock_mod('pycocoevalcap',
+        bleu=_mock_mod('pycocoevalcap.bleu', bleu=MagicMock()),
+        cider=_mock_mod('pycocoevalcap.cider', cider=MagicMock()),
+        rouge=_mock_mod('pycocoevalcap.rouge', rouge=MagicMock()),
+        meteor=_mock_mod('pycocoevalcap.meteor', meteor=MagicMock()),
+        tokenizer=_mock_mod('pycocoevalcap.tokenizer'))
+    m['pycocoevalcap'] = pcec
+    for sub in ['bleu', 'cider', 'rouge', 'meteor', 'tokenizer']:
+        m[f'pycocoevalcap.{sub}'] = getattr(pcec, sub)
+
+    # pycocotools
+    pct = _mock_mod('pycocotools',
+        coco=_mock_mod('pycocotools.coco', COCO=MagicMock),
+        cocoeval=_mock_mod('pycocotools.cocoeval'))
+    m['pycocotools'] = pct
+    m['pycocotools.coco'] = pct.coco
+    m['pycocotools.cocoeval'] = pct.cocoeval
+
+    # rich
+    rich_subs = {s: _mock_mod(f'rich.{s}') for s in
+                 ['live', 'console', 'table', 'panel', 'text', 'progress']}
+    for s, mod in rich_subs.items():
+        cap = s.capitalize() if s != 'live' else 'Live'
+        setattr(mod, cap, MagicMock)
+    rich = _mock_mod('rich', **rich_subs)
+    m['rich'] = rich
+    for s, mod in rich_subs.items():
+        m[f'rich.{s}'] = mod
+
+    # openai
+    m['openai'] = _mock_mod('openai',
+        OpenAI=MagicMock, AsyncOpenAI=MagicMock,
+        APIError=Exception, APIConnectionError=Exception, RateLimitError=Exception)
+
+    # tiktoken
+    m['tiktoken'] = _mock_mod('tiktoken',
+        Encoding=MagicMock, get_encoding=_mr(MagicMock()),
+        encoding_for_model=_mr(MagicMock()))
+
+    # misc simple modules
+    for name in ['accelerate', 'bitsandbytes', 'einops', 'cpm_kernels',
+                 'cv2', 'chardet', 'charset_normalizer', 'antlr4']:
+        m[name] = _mock_mod(name)
+
+    m['peft'] = _mock_mod('peft', LoraConfig=MagicMock(), get_peft_model=MagicMock())
+    m['trl'] = _mock_mod('trl', SFTConfig=MagicMock(), SFTTrainer=MagicMock())
+    m['func_timeout'] = _mock_mod('func_timeout',
+        func_timeout=MagicMock(), FunctionTimedOut=Exception)
+
+    # fuzzywuzzy
+    fw_f = _mock_mod('fuzzywuzzy.fuzz', ratio=_mr(80))
+    m['fuzzywuzzy'] = _mock_mod('fuzzywuzzy',
+        fuzz=fw_f, process=_mock_mod('fuzzywuzzy.process'))
+    m['fuzzywuzzy.fuzz'] = fw_f
+    m['fuzzywuzzy.process'] = m['fuzzywuzzy'].process
+
+    m['jsonlines'] = _mock_mod('jsonlines', open=MagicMock())
+    m['immutabledict'] = _mock_mod('immutabledict', Immutabledict=dict)
+    m['loguru'] = _mock_mod('loguru', logger=MagicMock())
+    m['gradio_client'] = _mock_mod('gradio_client', Client=MagicMock())
+
+    # absl
+    m['absl'] = _mock_mod('absl',
+        flags=_mock_mod('absl.flags'), logging=_mock_mod('absl.logging'))
+    m['absl.flags'] = m['absl'].flags
+    m['absl.logging'] = m['absl'].logging
+
+    # yaml, toml
+    m['yaml'] = _mock_mod('yaml', safe_load=_mr({}), safe_dump=MagicMock())
+    m['toml'] = _mock_mod('toml', load=_mr({}), dumps=MagicMock())
+
+    # datasets
+    ds = _mock_mod('datasets',
+        Dataset=MagicMock(), DatasetDict=MagicMock(),
+        load_dataset=_mr(MagicMock()), load_from_disk=_mr(MagicMock()),
+        concatenate_datasets=_mr(MagicMock()))
+    ds.Dataset.from_list = _mr(MagicMock())
+    m['datasets'] = ds
+
+    # Unix-only modules
+    m['fcntl'] = _mock_mod('fcntl', flock=MagicMock(),
+        LOCK_EX=1, LOCK_UN=2, LOCK_SH=4, LOCK_NB=8)
+    m['resource'] = _mock_mod('resource',
+        getrlimit=_mr((1000, 1000)), setrlimit=MagicMock(),
+        RLIMIT_AS=1, RLIMIT_CPU=2, RLIMIT_NOFILE=3)
+    for name in ['termios', 'pwd', 'grp']:
+        m[name] = _mock_mod(name)
+
+    # janus
+    m['janus'] = _mock_mod('janus', Queue=type('Queue', (), {
+        'async_q': MagicMock, 'sync_q': MagicMock}))
+
+    return m
+
+
+MOCK_MODULES = _setup_mocks()
+
+_original_modules = {k: sys.modules.get(k) for k in MOCK_MODULES}
+
+for mod_name, mock_obj in MOCK_MODULES.items():
+    if mod_name in sys.modules:
+        continue
+    try:
+        importlib.import_module(mod_name)
+    except Exception:
+        sys.modules[mod_name] = mock_obj
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _restore_modules_after_session():
+    """Restore original sys.modules state after all OneIG tests complete."""
+    yield
+    for mod_name, original in _original_modules.items():
+        if original is not None:
+            sys.modules[mod_name] = original
+        else:
+            sys.modules.pop(mod_name, None)


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [x] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)

## 🔍 Motivation / 变更动机

AISBench支持OneIG数据集接入

## 📝 Modification / 修改内容

AISBench支持OneIG数据集接入
1. 增加统一配置入口，支持5个评测子任务任意组合评测。
2. 增加UT

软件设计：
https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E3%80%91OneIG-%E6%95%B0%E6%8D%AE%E9%9B%86%E6%8E%A5%E5%85%A5-AISBench-%E6%B5%8B%E8%AF%84%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E6%96%87%E6%A1%A3


## 📐 Associated Test Results / 关联测试结果

测试报告：
https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E6%B5%8B%E8%AF%95%E6%8A%A5%E5%91%8A%E3%80%91OneIG%E2%80%90Benchmark-%E6%95%B0%E6%8D%AE%E9%9B%86%E6%8E%A5%E5%85%A5AISBench

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
