### PR TITLE
feat(UT): add oneig ut test-2 (alignment&text&reasoning)

### DIFF
--- a/tests/UT/tasks/oneig/test_oneig_alignment_eval.py
+++ b/tests/UT/tasks/oneig/test_oneig_alignment_eval.py
@@ -1,0 +1,177 @@
+"""OneIGAlignmentEvaluator 单元测试 - 聚焦对外API"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ais_bench.benchmark.tasks.oneig.oneig_alignment_eval import (
+    OneIGAlignmentEvaluator,
+)
+
+
+ALIGN_MODULE = 'ais_bench.benchmark.tasks.oneig.oneig_alignment_eval'
+
+
+class TestOneIGAlignmentEvaluator(unittest.TestCase):
+    """OneIGAlignmentEvaluator 对外API测试"""
+
+    def _make_evaluator(self, judge_model_path="", inferencer=None):
+        with patch(ALIGN_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            evaluator = OneIGAlignmentEvaluator.__new__(OneIGAlignmentEvaluator)
+            evaluator.judge_model_path = judge_model_path
+            evaluator.judge_device = "cuda"
+            evaluator.judge_dtype = "bfloat16"
+            evaluator.judge_batch_size = 8
+            evaluator.judge_use_flash_attention = True
+            evaluator.judge_seed = 42
+            evaluator._inferencer = inferencer
+            evaluator.logger = MagicMock()
+        return evaluator
+
+    def _setup_score_mocks(self, split_images=None, exists=True):
+        """Set up common mocks for score() tests."""
+        if split_images is None:
+            split_images = ['/tmp/img1.jpg']
+        patches = [
+            patch(ALIGN_MODULE + '.split_image_grid', return_value=split_images),
+            patch(ALIGN_MODULE + '.rm_error'),
+            patch('os.path.exists', return_value=exists),
+            patch('tempfile.mkdtemp', return_value='/tmp/fake_cache'),
+            patch('shutil.rmtree'),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+    def test_alignment_init_defaults(self):
+        """测试默认参数初始化"""
+        with patch(ALIGN_MODULE + '.BaseEvaluator.__init__'):
+            evaluator = OneIGAlignmentEvaluator()
+        self.assertEqual(evaluator.judge_model_path, "")
+        self.assertEqual(evaluator.judge_device, "cuda")
+        self.assertEqual(evaluator.judge_dtype, "bfloat16")
+        self.assertEqual(evaluator.judge_batch_size, 8)
+        self.assertTrue(evaluator.judge_use_flash_attention)
+        self.assertEqual(evaluator.judge_seed, 42)
+        self.assertIsNone(evaluator._inferencer)
+
+    def test_alignment_init_custom_params(self):
+        """测试自定义参数初始化"""
+        with patch(ALIGN_MODULE + '.BaseEvaluator.__init__'):
+            evaluator = OneIGAlignmentEvaluator(
+                judge_model_path="/path/to/model",
+                judge_device="cpu",
+                judge_dtype="float16",
+                judge_batch_size=4,
+                judge_use_flash_attention=False,
+                judge_seed=123,
+            )
+        self.assertEqual(evaluator.judge_model_path, "/path/to/model")
+        self.assertEqual(evaluator.judge_device, "cpu")
+        self.assertEqual(evaluator.judge_dtype, "float16")
+        self.assertEqual(evaluator.judge_batch_size, 4)
+        self.assertFalse(evaluator.judge_use_flash_attention)
+        self.assertEqual(evaluator.judge_seed, 123)
+
+    def test_alignment_score_none_test_set(self):
+        """测试test_set为None时返回默认值"""
+        evaluator = self._make_evaluator(inferencer=MagicMock())
+        result = evaluator.score([], [], test_set=None)
+        self.assertEqual(result, {'accuracy': 0.0, 'details': []})
+
+    def test_alignment_score_no_inferencer(self):
+        """测试无inferencer时返回默认值"""
+        evaluator = self._make_evaluator(inferencer=None)
+        result = evaluator.score([], [], test_set=[])
+        self.assertEqual(result, {'accuracy': 0.0, 'details': []})
+
+    def test_alignment_score_all_yes(self):
+        """测试全部Yes时accuracy=100.0"""
+        inferencer = MagicMock()
+        inferencer.infer_semantic.return_value = ["Yes"]
+        evaluator = self._make_evaluator(inferencer=inferencer)
+        self._setup_score_mocks()
+        test_set = [{
+            'id': 's1', 'class_item': 'cat', 'image_path': '/tmp/img.jpg',
+            'question': '{"1": "q1"}', 'dependency': '{}',
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        self.assertEqual(result['accuracy'], 100.0)
+        self.assertEqual(len(result['details']), 1)
+        self.assertEqual(result['details'][0]['class_item'], 'cat')
+
+    def test_alignment_score_mixed_answers(self):
+        """测试混合答案时正确计算accuracy"""
+        inferencer = MagicMock()
+        inferencer.infer_semantic.side_effect = [["Yes"], ["No"]]
+        evaluator = self._make_evaluator(inferencer=inferencer)
+        self._setup_score_mocks()
+        test_set = [{
+            'id': 's1', 'class_item': 'cat', 'image_path': '/tmp/img.jpg',
+            'question': '{"1": "q1", "2": "q2"}', 'dependency': '{}',
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        self.assertEqual(result['accuracy'], 50.0)
+
+    def test_alignment_score_dependency_filter(self):
+        """测试依赖过滤：父问题为No时跳过子问题"""
+        inferencer = MagicMock()
+        inferencer.infer_semantic.side_effect = [["No"], ["Yes"]]
+        evaluator = self._make_evaluator(inferencer=inferencer)
+        self._setup_score_mocks()
+        test_set = [{
+            'id': 's1', 'class_item': 'cat', 'image_path': '/tmp/img.jpg',
+            'question': '{"1": "q1", "2": "q2"}', 'dependency': '{"2": [1]}',
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        # q1=No -> q2 skipped, only q1 counted, accuracy=0.0
+        self.assertEqual(result['accuracy'], 0.0)
+
+    def test_alignment_score_image_not_found(self):
+        """测试图片不存在时跳过"""
+        inferencer = MagicMock()
+        evaluator = self._make_evaluator(inferencer=inferencer)
+        self._setup_score_mocks(exists=False)
+        test_set = [{
+            'id': 's1', 'class_item': 'cat', 'image_path': '/tmp/notexist.jpg',
+            'question': '{"1": "q1"}', 'dependency': '{}',
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        inferencer.infer_semantic.assert_not_called()
+        self.assertEqual(result['accuracy'], 0.0)
+        self.assertEqual(result['details'], [])
+
+    def test_alignment_ensure_inferencer_loads(self):
+        """测试_ensure_inferencer正确加载推理器"""
+        evaluator = self._make_evaluator(judge_model_path='/path/to/model')
+        with patch(ALIGN_MODULE + '.OneIGJudgeInferencer') as mock_cls:
+            evaluator._ensure_inferencer()
+            mock_cls.assert_called_once()
+            self.assertIsNotNone(evaluator._inferencer)
+
+    def test_alignment_score_dict_questions(self):
+        """测试question为dict类型时正确解析"""
+        inferencer = MagicMock()
+        inferencer.infer_semantic.return_value = ["Yes"]
+        evaluator = self._make_evaluator(inferencer=inferencer)
+        self._setup_score_mocks()
+        test_set = [{
+            'id': 's1', 'class_item': 'cat', 'image_path': '/tmp/img.jpg',
+            'question': {1: 'q1'}, 'dependency': {},
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        self.assertEqual(result['accuracy'], 100.0)
+
+    def test_alignment_score_invalid_json(self):
+        """测试question为无效JSON时优雅处理"""
+        inferencer = MagicMock()
+        evaluator = self._make_evaluator(inferencer=inferencer)
+        self._setup_score_mocks()
+        test_set = [{
+            'id': 's1', 'class_item': 'cat', 'image_path': '/tmp/img.jpg',
+            'question': 'invalid json', 'dependency': 'invalid json',
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        self.assertEqual(result['accuracy'], 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/tasks/oneig/test_oneig_eval_utils.py
+++ b/tests/UT/tasks/oneig/test_oneig_eval_utils.py
@@ -1,0 +1,258 @@
+"""Unit tests for oneig_eval_utils - focus on OneIGJudgeInferencer public API."""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import torch
+
+
+@contextmanager
+def _fake_oneig_imports():
+    """Inject mock transformers and qwen_vl_utils into sys.modules."""
+    mock_transformers = MagicMock()
+    mock_qwen_vl = MagicMock()
+    prev = {}
+    for name in ('transformers', 'qwen_vl_utils'):
+        prev[name] = sys.modules.pop(name, None)
+    sys.modules['transformers'] = mock_transformers
+    sys.modules['qwen_vl_utils'] = mock_qwen_vl
+    try:
+        yield mock_transformers, mock_qwen_vl
+    finally:
+        for name in ('transformers', 'qwen_vl_utils'):
+            sys.modules.pop(name, None)
+        for name, mod in prev.items():
+            if mod is not None:
+                sys.modules[name] = mod
+
+
+class TestOneIGDTypeMap(unittest.TestCase):
+    """Tests for ONEIG_DTYPE_MAP constant."""
+
+    def test_dtype_map_contains_bfloat16(self):
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            ONEIG_DTYPE_MAP,
+        )
+        self.assertIn('bfloat16', ONEIG_DTYPE_MAP)
+        self.assertEqual(ONEIG_DTYPE_MAP['bfloat16'], torch.bfloat16)
+
+    def test_dtype_map_contains_float16(self):
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            ONEIG_DTYPE_MAP,
+        )
+        self.assertIn('float16', ONEIG_DTYPE_MAP)
+        self.assertEqual(ONEIG_DTYPE_MAP['float16'], torch.float16)
+
+
+class FakeInputs(dict):
+    """A dict-like object that also supports attribute access."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name)
+
+
+class TestOneIGJudgeInferencer(unittest.TestCase):
+    """Tests for OneIGJudgeInferencer public API."""
+
+    @patch('torch.manual_seed')
+    @patch('torch.cuda.manual_seed_all')
+    def test_judge_init_loads_model(self, mock_cuda_seed, mock_seed):
+        """__init__ should load model and processor."""
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            OneIGJudgeInferencer,
+        )
+        with _fake_oneig_imports() as (mock_transformers, _):
+            inferencer = OneIGJudgeInferencer(model_path='test/model', device='cpu')
+            mock_transformers.Qwen3VLForConditionalGeneration.from_pretrained.assert_called_once()
+            mock_transformers.AutoProcessor.from_pretrained.assert_called_once()
+            self.assertIsNotNone(inferencer.model)
+            self.assertIsNotNone(inferencer.processor)
+
+    @patch('torch.manual_seed')
+    @patch('torch.cuda.manual_seed_all')
+    def test_judge_init_sets_seed(self, mock_cuda_seed, mock_seed):
+        """__init__ should set random seeds."""
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            OneIGJudgeInferencer,
+        )
+        with _fake_oneig_imports():
+            OneIGJudgeInferencer(seed=42, device='cpu')
+        mock_seed.assert_called_once_with(42)
+        mock_cuda_seed.assert_called_once_with(42)
+
+    @patch('torch.manual_seed')
+    @patch('torch.cuda.manual_seed_all')
+    def test_judge_batch_inference_single_batch(self, mock_cuda_seed, mock_seed):
+        """batch_inference should process single batch correctly."""
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            OneIGJudgeInferencer,
+        )
+        with _fake_oneig_imports() as (mock_transformers, mock_qwen_vl):
+            inferencer = OneIGJudgeInferencer(batch_size=8, device='cpu')
+
+            fake_inputs = FakeInputs(input_ids=[[1, 2, 3]])
+            inferencer.processor.return_value.to.return_value = fake_inputs
+            inferencer.processor.batch_decode.return_value = ['output1']
+            inferencer.model.generate.return_value = [[1, 2, 3, 4]]
+            mock_qwen_vl.process_vision_info.return_value = (None, None)
+
+            messages = [[{'role': 'user', 'content': 'hi'}]]
+            result = inferencer.batch_inference(messages)
+
+            self.assertEqual(result, ['output1'])
+            inferencer.model.generate.assert_called_once()
+
+    @patch('torch.manual_seed')
+    @patch('torch.cuda.manual_seed_all')
+    def test_judge_batch_inference_multi_batch(self, mock_cuda_seed, mock_seed):
+        """batch_inference should handle multiple batches."""
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            OneIGJudgeInferencer,
+        )
+        with _fake_oneig_imports() as (mock_transformers, mock_qwen_vl):
+            inferencer = OneIGJudgeInferencer(batch_size=2, device='cpu')
+
+            fake_inputs_1 = FakeInputs(input_ids=[[1, 2, 3], [1, 2, 3]])
+            fake_inputs_2 = FakeInputs(input_ids=[[1, 2, 3], [1, 2, 3]])
+            fake_inputs_3 = FakeInputs(input_ids=[[1, 2, 3]])
+            inferencer.processor.return_value.to.side_effect = [
+                fake_inputs_1, fake_inputs_2, fake_inputs_3,
+            ]
+            inferencer.processor.batch_decode.side_effect = [
+                ['out1', 'out2'], ['out3', 'out4'], ['out5'],
+            ]
+            inferencer.model.generate.side_effect = [
+                [[1, 2, 3, 4], [1, 2, 3, 4]],
+                [[1, 2, 3, 4], [1, 2, 3, 4]],
+                [[1, 2, 3, 4]],
+            ]
+            mock_qwen_vl.process_vision_info.return_value = (None, None)
+
+            messages = [[{'role': 'user', 'content': 'hi'}] for _ in range(5)]
+            result = inferencer.batch_inference(messages)
+
+            self.assertEqual(result, ['out1', 'out2', 'out3', 'out4', 'out5'])
+            self.assertEqual(inferencer.model.generate.call_count, 3)
+
+    @patch('torch.manual_seed')
+    @patch('torch.cuda.manual_seed_all')
+    def test_judge_infer_semantic_constructs_messages(self, mock_cuda_seed, mock_seed):
+        """infer_semantic should construct correct messages."""
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            OneIGJudgeInferencer,
+        )
+        with _fake_oneig_imports():
+            inferencer = OneIGJudgeInferencer(device='cpu')
+        with patch.object(inferencer, 'batch_inference', return_value=['Yes']) as mock_batch:
+            result = inferencer.infer_semantic(['/img1.png', '/img2.png'], 'Is this aligned?')
+            self.assertEqual(result, ['Yes'])
+            called_messages = mock_batch.call_args[0][0]
+            self.assertEqual(len(called_messages), 2)
+            content = called_messages[0][0]['content']
+            self.assertEqual(content[0]['type'], 'image')
+            self.assertEqual(content[0]['image'], '/img1.png')
+            self.assertIn('Is this aligned?', content[1]['text'])
+
+    @patch('torch.manual_seed')
+    @patch('torch.cuda.manual_seed_all')
+    def test_judge_infer_ocr_constructs_messages(self, mock_cuda_seed, mock_seed):
+        """infer_ocr should construct correct messages."""
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            OneIGJudgeInferencer,
+        )
+        with _fake_oneig_imports():
+            inferencer = OneIGJudgeInferencer(device='cpu')
+        with patch.object(inferencer, 'batch_inference', return_value=['text']) as mock_batch:
+            result = inferencer.infer_ocr(['/img1.png'])
+            self.assertEqual(result, ['text'])
+            called_messages = mock_batch.call_args[0][0]
+            content = called_messages[0][0]['content']
+            self.assertEqual(content[0]['type'], 'image')
+            self.assertIn('Recognize the text', content[1]['text'])
+
+
+class TestEnsureOneIGPath(unittest.TestCase):
+    """Tests for ensure_oneig_path utility function."""
+
+    def test_ensure_oneig_path_empty_raises(self):
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            ensure_oneig_path,
+        )
+        with self.assertRaises(ImportError):
+            ensure_oneig_path('')
+
+    def test_ensure_oneig_path_not_exist_raises(self):
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            ensure_oneig_path,
+        )
+        with self.assertRaises(ImportError):
+            ensure_oneig_path('/nonexistent/path/12345')
+
+    def test_ensure_oneig_path_valid_adds_to_sys_path(self):
+        """有效路径应被加入sys.path"""
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            ensure_oneig_path,
+        )
+        tmp = tempfile.mkdtemp()
+        try:
+            ensure_oneig_path(tmp)
+            self.assertIn(tmp, sys.path)
+        finally:
+            if tmp in sys.path:
+                sys.path.remove(tmp)
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestSplitImageGrid(unittest.TestCase):
+    """Tests for split_image_grid utility function."""
+
+    def test_split_image_grid_non_black_image(self):
+        """非黑色图片应被切分并保存"""
+        from PIL import Image
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            split_image_grid,
+        )
+        tmp = tempfile.mkdtemp()
+        try:
+            # 创建4x4像素的非黑色图片
+            img = Image.new('RGB', (4, 4), color=(255, 0, 0))
+            img_path = os.path.join(tmp, 'grid.png')
+            img.save(img_path)
+            cache = tempfile.mkdtemp()
+            result = split_image_grid(img_path, (2, 2), cache)
+            self.assertEqual(len(result), 4)
+            for path in result:
+                self.assertTrue(os.path.exists(path))
+            shutil.rmtree(cache, ignore_errors=True)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_split_image_grid_black_image_filtered(self):
+        """黑色子图应被过滤掉"""
+        from PIL import Image
+        from ais_bench.benchmark.tasks.oneig.oneig_eval_utils import (
+            split_image_grid,
+        )
+        tmp = tempfile.mkdtemp()
+        try:
+            # 创建全黑图片
+            img = Image.new('RGB', (4, 4), color=(0, 0, 0))
+            img_path = os.path.join(tmp, 'black.png')
+            img.save(img_path)
+            cache = tempfile.mkdtemp()
+            result = split_image_grid(img_path, (2, 2), cache)
+            self.assertEqual(len(result), 0)
+            shutil.rmtree(cache, ignore_errors=True)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/tasks/oneig/test_oneig_reasoning_eval.py
+++ b/tests/UT/tasks/oneig/test_oneig_reasoning_eval.py
@@ -1,0 +1,117 @@
+"""OneIGReasoningEvaluator 单元测试 - 聚焦对外API"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ais_bench.benchmark.tasks.oneig.oneig_reasoning_eval import (
+    OneIGReasoningEvaluator,
+)
+
+
+REASON_MODULE = 'ais_bench.benchmark.tasks.oneig.oneig_reasoning_eval'
+
+
+class TestOneIGReasoningEvaluator(unittest.TestCase):
+    """OneIGReasoningEvaluator 对外API测试"""
+
+    def setUp(self):
+        with patch(REASON_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            self.evaluator = OneIGReasoningEvaluator.__new__(OneIGReasoningEvaluator)
+            self.evaluator.logger = MagicMock()
+            self.evaluator.oneig_root = ''
+            self.evaluator.llm2clip_cfg = {}
+            self.evaluator.device = 'cuda'
+            self.evaluator.model = MagicMock()
+
+    def _setup_score_patches(self, split_images=None, exists=True):
+        """Set up common patches for score() tests."""
+        if split_images is None:
+            split_images = ['/split.jpg']
+        patches = [
+            patch(REASON_MODULE + '.tempfile.mkdtemp', return_value='/cache'),
+            patch(REASON_MODULE + '.shutil.rmtree'),
+            patch(REASON_MODULE + '.split_image_grid', return_value=split_images),
+            patch(REASON_MODULE + '.os.path.exists', return_value=exists),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+    def test_reasoning_init_defaults(self):
+        """测试默认参数初始化"""
+        with patch(REASON_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            evaluator = OneIGReasoningEvaluator()
+        self.assertEqual(evaluator.oneig_root, '')
+        self.assertEqual(evaluator.llm2clip_cfg, {})
+        self.assertEqual(evaluator.device, 'cuda')
+        self.assertIsNone(evaluator.model)
+
+    def test_reasoning_init_custom_params(self):
+        """测试自定义参数初始化"""
+        cfg = {'processor_model': '/p', 'clip_model': '/c', 'llm_model': '/l'}
+        with patch(REASON_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            evaluator = OneIGReasoningEvaluator(
+                oneig_root='/oneig/root', llm2clip_cfg=cfg, device='cpu')
+        self.assertEqual(evaluator.oneig_root, '/oneig/root')
+        self.assertEqual(evaluator.llm2clip_cfg, cfg)
+        self.assertEqual(evaluator.device, 'cpu')
+
+    def test_reasoning_score_none_test_set(self):
+        """测试test_set为None时返回默认值"""
+        result = self.evaluator.score(predictions=[], references=[], test_set=None)
+        self.assertEqual(result, {'accuracy': 0.0, 'details': []})
+        self.evaluator.logger.error.assert_called()
+
+    def test_reasoning_score_empty_gt_answer(self):
+        """测试gt_answer为空时score=None"""
+        test_set = [{'id': 's1', 'image_path': '/img.png', 'gt_answer': ''}]
+        self._setup_score_patches()
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertIsNone(result['details'][0]['score'])
+        self.evaluator.model.text_img_similarity_score.assert_not_called()
+
+    def test_reasoning_score_model_returns_valid_scores(self):
+        """测试模型返回有效分数时正确计算"""
+        self.evaluator.model.text_img_similarity_score.return_value = [0.8, 0.6]
+        test_set = [{'id': 's1', 'image_path': '/img.png', 'gt_answer': 'answer'}]
+        self._setup_score_patches(split_images=['/a.jpg', '/b.jpg'])
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        # avg = (0.8 + 0.6) / 2 = 0.7, overall = 70.0
+        self.assertAlmostEqual(result['details'][0]['score'], 0.7)
+        self.assertAlmostEqual(result['accuracy'], 70.0)
+
+    def test_reasoning_score_model_returns_none(self):
+        """测试模型返回None时score=None"""
+        self.evaluator.model.text_img_similarity_score.return_value = None
+        test_set = [{'id': 's1', 'image_path': '/img.png', 'gt_answer': 'answer'}]
+        self._setup_score_patches()
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertIsNone(result['details'][0]['score'])
+        self.assertEqual(result['accuracy'], 0.0)
+
+    def test_reasoning_score_model_exception(self):
+        """测试模型推理异常时score=None"""
+        self.evaluator.model.text_img_similarity_score.side_effect = RuntimeError("infer failed")
+        test_set = [{'id': 's1', 'image_path': '/img.png', 'gt_answer': 'answer'}]
+        self._setup_score_patches()
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertIsNone(result['details'][0]['score'])
+        self.assertEqual(result['accuracy'], 0.0)
+        self.evaluator.logger.error.assert_called()
+
+    def test_reasoning_score_partial_valid(self):
+        """测试部分样本有效时正确计算均值"""
+        self.evaluator.model.text_img_similarity_score.return_value = [0.6]
+        test_set = [
+            {'id': 's1', 'image_path': '/img1.png', 'gt_answer': 'answer'},
+            {'id': 's2', 'image_path': '/img2.png', 'gt_answer': ''},
+        ]
+        self._setup_score_patches()
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        # 仅 s1 有效 (0.6), overall = 60.0
+        self.assertAlmostEqual(result['accuracy'], 60.0)
+        self.assertAlmostEqual(result['details'][0]['score'], 0.6)
+        self.assertIsNone(result['details'][1]['score'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/tasks/oneig/test_oneig_text_eval.py
+++ b/tests/UT/tasks/oneig/test_oneig_text_eval.py
@@ -1,0 +1,139 @@
+"""OneIGTextEvaluator 单元测试 - 聚焦对外API"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ais_bench.benchmark.tasks.oneig.oneig_text_eval import (
+    OneIGTextEvaluator,
+)
+
+
+TEXT_MODULE = 'ais_bench.benchmark.tasks.oneig.oneig_text_eval'
+
+
+class TestOneIGTextEvaluator(unittest.TestCase):
+    """OneIGTextEvaluator 对外API测试"""
+
+    def _make_evaluator(self, judge_model_path="", inferencer=None, mode='EN'):
+        with patch(TEXT_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            evaluator = OneIGTextEvaluator.__new__(OneIGTextEvaluator)
+            evaluator.judge_model_path = judge_model_path
+            evaluator.judge_device = "cuda"
+            evaluator.judge_dtype = "bfloat16"
+            evaluator.judge_batch_size = 8
+            evaluator.judge_use_flash_attention = True
+            evaluator.judge_seed = 42
+            evaluator.mode = mode
+            evaluator._inferencer = inferencer
+            evaluator.logger = MagicMock()
+        return evaluator
+
+    def _setup_score_mocks(self, split_images=None, exists=True):
+        """Set up common mocks for score() tests."""
+        if split_images is None:
+            split_images = ['/tmp/img1.jpg']
+        patches = [
+            patch(TEXT_MODULE + '.split_image_grid', return_value=split_images),
+            patch(TEXT_MODULE + '.rm_error'),
+            patch('os.path.exists', return_value=exists),
+            patch('tempfile.mkdtemp', return_value='/tmp/fake_cache'),
+            patch('shutil.rmtree'),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+    def test_text_init_defaults(self):
+        """测试默认参数初始化"""
+        with patch(TEXT_MODULE + '.BaseEvaluator.__init__'):
+            evaluator = OneIGTextEvaluator()
+        self.assertEqual(evaluator.judge_model_path, "")
+        self.assertEqual(evaluator.judge_device, "cuda")
+        self.assertEqual(evaluator.judge_dtype, "bfloat16")
+        self.assertEqual(evaluator.mode, 'EN')
+        self.assertIsNone(evaluator._inferencer)
+
+    def test_text_score_none_test_set(self):
+        """测试test_set为None时返回默认值"""
+        evaluator = self._make_evaluator(inferencer=MagicMock())
+        result = evaluator.score([], [], test_set=None)
+        self.assertEqual(result, {'accuracy': 0.0, 'details': []})
+
+    def test_text_score_no_inferencer(self):
+        """测试无inferencer时返回默认值"""
+        evaluator = self._make_evaluator(inferencer=None)
+        result = evaluator.score([], [], test_set=[])
+        self.assertEqual(result, {'accuracy': 0.0, 'details': []})
+
+    def test_text_score_perfect_match(self):
+        """测试完美匹配时accuracy=100.0"""
+        inferencer = MagicMock()
+        inferencer.infer_ocr.return_value = ["hello world"]
+        evaluator = self._make_evaluator(inferencer=inferencer, mode='EN')
+        self._setup_score_mocks()
+        test_set = [{
+            'id': 's1', 'image_path': '/tmp/img.jpg',
+            'expected_text': 'hello world',
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        self.assertEqual(result['accuracy'], 100.0)
+        self.assertIn('ED', result)
+        self.assertIn('CR', result)
+        self.assertIn('WAC', result)
+
+    def test_text_score_mode_zh_max_edit_distance(self):
+        """测试ZH模式下最大编辑距离限制"""
+        inferencer = MagicMock()
+        inferencer.infer_ocr.return_value = ["b" * 60]
+        evaluator = self._make_evaluator(inferencer=inferencer, mode='ZH')
+        self._setup_score_mocks()
+        test_set = [{
+            'id': 's1', 'image_path': '/tmp/img.jpg',
+            'expected_text': 'a' * 60,
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        self.assertEqual(result['accuracy'], 0.0)
+
+    def test_text_score_mode_en_max_edit_distance(self):
+        """测试EN模式下最大编辑距离限制"""
+        inferencer = MagicMock()
+        inferencer.infer_ocr.return_value = ["b" * 60]
+        evaluator = self._make_evaluator(inferencer=inferencer, mode='EN')
+        self._setup_score_mocks()
+        test_set = [{
+            'id': 's1', 'image_path': '/tmp/img.jpg',
+            'expected_text': 'a' * 60,
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        self.assertEqual(result['accuracy'], 40.0)
+
+    def test_text_score_image_not_found(self):
+        """测试图片不存在时跳过"""
+        inferencer = MagicMock()
+        evaluator = self._make_evaluator(inferencer=inferencer)
+        self._setup_score_mocks(exists=False)
+        test_set = [{
+            'id': 's1', 'image_path': '/tmp/notexist.jpg',
+            'expected_text': 'hello',
+        }]
+        result = evaluator.score([], [], test_set=test_set)
+        inferencer.infer_ocr.assert_not_called()
+        self.assertEqual(result['accuracy'], 0.0)
+        self.assertEqual(result['details'], [])
+
+    def test_text_score_dynamic_max_new_tokens(self):
+        """测试动态max_new_tokens计算"""
+        inferencer = MagicMock()
+        inferencer.infer_ocr.return_value = ["hello"]
+        evaluator = self._make_evaluator(inferencer=inferencer)
+        self._setup_score_mocks()
+        expected_text = ' '.join(['word'] * 61)
+        test_set = [{
+            'id': 's1', 'image_path': '/tmp/img.jpg',
+            'expected_text': expected_text,
+        }]
+        evaluator.score([], [], test_set=test_set)
+        inferencer.infer_ocr.assert_called_once_with(['/tmp/img1.jpg'], 256)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [x] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)

## 🔍 Motivation / 变更动机

AISBench支持OneIG数据集接入

## 📝 Modification / 修改内容

AISBench支持OneIG数据集接入
1. 增加统一配置入口，支持5个评测子任务任意组合评测。
2. 增加UT

软件设计：
https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E3%80%91OneIG-%E6%95%B0%E6%8D%AE%E9%9B%86%E6%8E%A5%E5%85%A5-AISBench-%E6%B5%8B%E8%AF%84%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E6%96%87%E6%A1%A3


## 📐 Associated Test Results / 关联测试结果

测试报告：
https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E6%B5%8B%E8%AF%95%E6%8A%A5%E5%91%8A%E3%80%91OneIG%E2%80%90Benchmark-%E6%95%B0%E6%8D%AE%E9%9B%86%E6%8E%A5%E5%85%A5AISBench

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
