### PR TITLE
feat(UT): add oneig ut test-3 (diversity&style)

### DIFF
--- a/tests/UT/tasks/oneig/test_oneig_diversity_eval.py
+++ b/tests/UT/tasks/oneig/test_oneig_diversity_eval.py
@@ -1,0 +1,133 @@
+"""OneIGDiversityEvaluator 单元测试 - 聚焦对外API"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ais_bench.benchmark.tasks.oneig.oneig_diversity_eval import (
+    OneIGDiversityEvaluator,
+)
+
+
+DIVERSITY_MODULE = 'ais_bench.benchmark.tasks.oneig.oneig_diversity_eval'
+DIVERSITY_CLASS = DIVERSITY_MODULE + '.OneIGDiversityEvaluator'
+
+
+class TestOneIGDiversityEvaluator(unittest.TestCase):
+    """OneIGDiversityEvaluator 对外API测试"""
+
+    def setUp(self):
+        with patch(DIVERSITY_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            self.evaluator = OneIGDiversityEvaluator.__new__(OneIGDiversityEvaluator)
+            self.evaluator.logger = MagicMock()
+            self.evaluator.device = 'cuda'
+            self.evaluator.oneig_root = ''
+            self.evaluator.dreamsim_path = None
+            self.evaluator.dreamsim = MagicMock()
+            self.evaluator.preprocess = MagicMock()
+            processed = MagicMock()
+            self.evaluator.preprocess.return_value = processed
+            processed.to.return_value = processed
+            dist = MagicMock()
+            dist.item.return_value = 0.5
+            self.evaluator.dreamsim.return_value = dist
+
+    def _setup_score_patches(self, split_images=None, exists=True):
+        """Set up common patches for score() tests."""
+        if split_images is None:
+            split_images = ['/a.jpg', '/b.jpg']
+        patches = [
+            patch(DIVERSITY_CLASS + '._ensure_model'),
+            patch(DIVERSITY_MODULE + '.tempfile.mkdtemp', return_value='/cache'),
+            patch(DIVERSITY_MODULE + '.shutil.rmtree'),
+            patch(DIVERSITY_MODULE + '.split_image_grid', return_value=split_images),
+            patch(DIVERSITY_MODULE + '.os.path.exists', return_value=exists),
+            patch('PIL.Image.open'),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+    def test_diversity_init_defaults(self):
+        """测试默认参数初始化"""
+        with patch(DIVERSITY_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            evaluator = OneIGDiversityEvaluator()
+        self.assertEqual(evaluator.device, 'cuda')
+        self.assertEqual(evaluator.oneig_root, '')
+        self.assertIsNone(evaluator.dreamsim_path)
+        self.assertIsNone(evaluator.dreamsim)
+
+    def test_diversity_init_custom_params(self):
+        """测试自定义参数初始化"""
+        with patch(DIVERSITY_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            evaluator = OneIGDiversityEvaluator(
+                device='cpu', oneig_root='/oneig/root', dreamsim_path='/ds/cache')
+        self.assertEqual(evaluator.device, 'cpu')
+        self.assertEqual(evaluator.oneig_root, '/oneig/root')
+        self.assertEqual(evaluator.dreamsim_path, '/ds/cache')
+
+    def test_diversity_score_none_test_set(self):
+        """测试test_set为None时返回默认值"""
+        result = self.evaluator.score(predictions=[], references=[], test_set=None)
+        self.assertEqual(result, {'accuracy': 0.0, 'details': []})
+        self.evaluator.logger.error.assert_called()
+
+    def test_diversity_score_valid_sample(self):
+        """测试有效样本正确计算两两距离"""
+        test_set = [{'id': 's1', 'class_item': 'cat', 'image_path': '/img.png'}]
+        # 3 张切分图 -> 3 对 (0,1),(0,2),(1,2), 距离 0.1/0.2/0.3 -> avg 0.2
+        dist = MagicMock()
+        dist.item.side_effect = [0.1, 0.2, 0.3]
+        self.evaluator.dreamsim.return_value = dist
+        self._setup_score_patches(split_images=['/a.jpg', '/b.jpg', '/c.jpg'])
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        # avg = (0.1+0.2+0.3)/3 = 0.2, overall = 20.0
+        self.assertAlmostEqual(result['accuracy'], 20.0)
+        self.assertAlmostEqual(result['details'][0]['score'], 0.2)
+        self.assertEqual(self.evaluator.dreamsim.call_count, 3)
+
+    def test_diversity_score_image_not_found(self):
+        """测试图片不存在时跳过"""
+        test_set = [{'id': 's1', 'class_item': 'cat', 'image_path': '/missing.png'}]
+        self._setup_score_patches(exists=False)
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertEqual(result['accuracy'], 0.0)
+        self.assertEqual(result['details'], [])
+        self.evaluator.dreamsim.assert_not_called()
+
+    def test_diversity_score_exception_handling(self):
+        """测试单样本异常时score=None"""
+        test_set = [{'id': 's1', 'class_item': 'cat', 'image_path': '/img.png'}]
+        patches = [
+            patch(DIVERSITY_CLASS + '._ensure_model'),
+            patch(DIVERSITY_MODULE + '.tempfile.mkdtemp', return_value='/cache'),
+            patch(DIVERSITY_MODULE + '.shutil.rmtree'),
+            patch(DIVERSITY_MODULE + '.split_image_grid',
+                  side_effect=RuntimeError("split failed")),
+            patch(DIVERSITY_MODULE + '.os.path.exists', return_value=True),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertEqual(result['accuracy'], 0.0)
+        self.evaluator.logger.error.assert_called()
+
+    def test_diversity_score_class_scores_aggregation(self):
+        """测试class_scores正确聚合同类样本"""
+        test_set = [
+            {'id': 's1', 'class_item': 'cat', 'image_path': '/img1.png'},
+            {'id': 's2', 'class_item': 'cat', 'image_path': '/img2.png'},
+        ]
+        dist = MagicMock()
+        dist.item.side_effect = [0.4, 0.6]
+        self.evaluator.dreamsim.return_value = dist
+        self._setup_score_patches()
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        class_scores = result['class_scores']
+        self.assertIn('cat', class_scores)
+        self.assertEqual(len(class_scores['cat']), 2)
+        # overall = (0.4 + 0.6) / 2 * 100 = 50.0
+        self.assertAlmostEqual(result['accuracy'], 50.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/tasks/oneig/test_oneig_eval.py
+++ b/tests/UT/tasks/oneig/test_oneig_eval.py
@@ -1,0 +1,195 @@
+"""Unit tests for OneIGEvalTask (no real model/dataset inference)."""
+import os.path as osp
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from mmengine.config import ConfigDict
+
+from ais_bench.benchmark.tasks.oneig.oneig_eval import OneIGEvalTask
+
+
+class TestOneIGEvalTask(unittest.TestCase):
+    """Tests for OneIGEvalTask public API."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.cfg = ConfigDict({
+            'work_dir': self.tmp,
+            'models': [{'abbr': 'm_ab', 'type': 'stub'}],
+            'datasets': [[
+                {'abbr': 'ds1', 'type': 'stub', 'eval_cfg': {'num_gpus': 2}},
+                {'abbr': 'ds2', 'type': 'stub', 'eval_cfg': {'num_gpus': 4}},
+            ]],
+            'cli_args': {},
+        })
+        self.out_path = osp.join(self.tmp, 'results', 'm1', 'ds1.json')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_oneig_eval_init_num_gpus(self, _log):
+        """num_gpus should be the max across dataset_cfgs."""
+        task = OneIGEvalTask(self.cfg)
+        self.assertEqual(task.num_gpus, 4)
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_oneig_eval_init_class_attributes(self, _log):
+        """Class attributes should be set correctly."""
+        self.assertEqual(OneIGEvalTask.name_prefix, 'OneIGEval')
+        self.assertEqual(OneIGEvalTask.log_subdir, 'logs/eval')
+        self.assertEqual(OneIGEvalTask.output_subdir, 'results')
+
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_oneig_eval_get_command_format(self, _log):
+        """get_command should return command with python, script, cfg_path."""
+        cfg = ConfigDict({
+            'work_dir': self.tmp,
+            'models': [{'abbr': 'm_ab', 'type': 'stub'}],
+            'datasets': [[{'abbr': 'ds1', 'type': 'stub', 'eval_cfg': {}}]],
+            'cli_args': {},
+        })
+        task = OneIGEvalTask(cfg)
+        cmd = task.get_command('/tmp/config.py', 'run {task_cmd}')
+        self.assertIn(sys.executable, cmd)
+        self.assertIn('/tmp/config.py', cmd)
+        self.assertIn('oneig_eval.py', cmd)
+        self.assertTrue(cmd.startswith('run '))
+
+    def _setup_run_mocks(self, mock_build_ds, mock_icl, mock_out_path,
+                         result=None):
+        """Set up common mocks for run() tests."""
+        mock_ds = MagicMock()
+        mock_ds.test = [{'q': 'a'}]
+        mock_build_ds.return_value = mock_ds
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.score.return_value = result or {
+            'accuracy': 0.9, 'details': []}
+        mock_icl.build.return_value = mock_evaluator
+        mock_out_path.return_value = self.out_path
+        return mock_ds, mock_evaluator
+
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.mkdir_or_exist')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.mmengine')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.task_abbr_from_cfg',
+           return_value='m1/ds1')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.dataset_abbr_from_cfg',
+           return_value='ds1')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.get_infer_output_path')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.ICL_EVALUATORS')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.build_dataset_from_cfg')
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_oneig_eval_run_single_dataset(
+            self, _log, mock_build_ds, mock_icl, mock_out_path,
+            _mock_ds_abbr, _mock_task_abbr, mock_mmengine, _mock_mkdir):
+        """run() should build dataset, run evaluator, and dump results."""
+        cfg = ConfigDict({
+            'work_dir': self.tmp,
+            'models': [{'abbr': 'm1', 'type': 'stub'}],
+            'datasets': [[
+                {'abbr': 'ds1', 'type': 'stub', 'task_type': 'alignment',
+                 'eval_cfg': {'evaluator': {'type': 'OneIGAlignmentEvaluator'}}},
+            ]],
+            'cli_args': {},
+        })
+        mock_ds, mock_evaluator = self._setup_run_mocks(
+            mock_build_ds, mock_icl, mock_out_path)
+
+        task = OneIGEvalTask(cfg)
+        task.run(None)
+
+        mock_build_ds.assert_called_once()
+        mock_icl.build.assert_called_once_with(
+            {'type': 'OneIGAlignmentEvaluator'})
+        mock_evaluator.score.assert_called_once_with(
+            predictions=[], references=[], test_set=mock_ds.test)
+        mock_mmengine.dump.assert_called_once()
+
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.mkdir_or_exist')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.mmengine')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.task_abbr_from_cfg',
+           return_value='m1/ds1')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.dataset_abbr_from_cfg',
+           return_value='ds1')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.get_infer_output_path')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.ICL_EVALUATORS')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.build_dataset_from_cfg')
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_oneig_eval_run_multiple_datasets(
+            self, _log, mock_build_ds, mock_icl, mock_out_path,
+            _mock_ds_abbr, _mock_task_abbr, mock_mmengine, _mock_mkdir):
+        """run() should handle multiple datasets."""
+        cfg = ConfigDict({
+            'work_dir': self.tmp,
+            'models': [{'abbr': 'm1', 'type': 'stub'}],
+            'datasets': [[
+                {'abbr': 'ds1', 'type': 'stub', 'task_type': 'alignment',
+                 'eval_cfg': {'evaluator': {'type': 'OneIGAlignmentEvaluator'}}},
+                {'abbr': 'ds2', 'type': 'stub', 'task_type': 'diversity',
+                 'eval_cfg': {'evaluator': {'type': 'OneIGDiversityEvaluator'}}},
+            ]],
+            'cli_args': {},
+        })
+        mock_ds = MagicMock()
+        mock_ds.test = [{'q': 'a'}]
+        mock_build_ds.return_value = mock_ds
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.score.side_effect = [
+            {'accuracy': 0.9, 'details': []},
+            {'accuracy': 0.8, 'details': []},
+        ]
+        mock_icl.build.return_value = mock_evaluator
+
+        out_path1 = osp.join(self.tmp, 'results', 'm1', 'ds1.json')
+        out_path2 = osp.join(self.tmp, 'results', 'm1', 'ds2.json')
+        mock_out_path.side_effect = [out_path1, out_path2]
+
+        task = OneIGEvalTask(cfg)
+        task.run(None)
+
+        self.assertEqual(mock_build_ds.call_count, 2)
+        self.assertEqual(mock_icl.build.call_count, 2)
+        self.assertEqual(mock_evaluator.score.call_count, 2)
+        self.assertEqual(mock_mmengine.dump.call_count, 2)
+
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.mkdir_or_exist')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.mmengine')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.task_abbr_from_cfg',
+           return_value='m1/ds1')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.dataset_abbr_from_cfg',
+           return_value='ds1')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.get_infer_output_path')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.ICL_EVALUATORS')
+    @patch('ais_bench.benchmark.tasks.oneig.oneig_eval.build_dataset_from_cfg')
+    @patch('ais_bench.benchmark.tasks.base.AISLogger')
+    def test_oneig_eval_run_saves_results(
+            self, _log, mock_build_ds, mock_icl, mock_out_path,
+            _mock_ds_abbr, _mock_task_abbr, mock_mmengine, _mock_mkdir):
+        """run() should save results with correct format."""
+        cfg = ConfigDict({
+            'work_dir': self.tmp,
+            'models': [{'abbr': 'm1', 'type': 'stub'}],
+            'datasets': [[
+                {'abbr': 'ds1', 'type': 'stub', 'task_type': 'alignment',
+                 'eval_cfg': {'evaluator': {'type': 'OneIGAlignmentEvaluator'}}},
+            ]],
+            'cli_args': {},
+        })
+        result = {'accuracy': 0.9, 'details': [{'score': 1.0}]}
+        self._setup_run_mocks(
+            mock_build_ds, mock_icl, mock_out_path, result=result)
+
+        task = OneIGEvalTask(cfg)
+        task.run(None)
+
+        mock_mmengine.dump.assert_called_once_with(
+            result, self.out_path, ensure_ascii=False, indent=4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/UT/tasks/oneig/test_oneig_style_eval.py
+++ b/tests/UT/tasks/oneig/test_oneig_style_eval.py
@@ -1,0 +1,199 @@
+"""OneIGStyleEvaluator 单元测试 - 聚焦对外API"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ais_bench.benchmark.tasks.oneig.oneig_style_eval import OneIGStyleEvaluator
+
+
+STYLE_MODULE = 'ais_bench.benchmark.tasks.oneig.oneig_style_eval'
+STYLE_CLASS = STYLE_MODULE + '.OneIGStyleEvaluator'
+
+
+class TestOneIGStyleEvaluator(unittest.TestCase):
+    """OneIGStyleEvaluator 对外API测试"""
+
+    def setUp(self):
+        with patch(STYLE_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            self.evaluator = OneIGStyleEvaluator.__new__(OneIGStyleEvaluator)
+            self.evaluator.logger = MagicMock()
+            self.evaluator.oneig_root = ''
+            self.evaluator.device = 'cuda'
+            self.evaluator.csd_embed_path = None
+            self.evaluator.se_embed_path = None
+            self.evaluator.encoder_cfg = {}
+            self.evaluator.csd_encoder = MagicMock()
+            self.evaluator.se_encoder = MagicMock()
+            self.evaluator.csd_ref_embeds = None
+            self.evaluator.se_ref_embeds = None
+
+    def _setup_score_patches(self, split_images=None, exists=True):
+        """Set up common patches for score() tests."""
+        if split_images is None:
+            split_images = ['/split.jpg']
+        patches = [
+            patch(STYLE_CLASS + '._ensure_models'),
+            patch(STYLE_MODULE + '.tempfile.mkdtemp', return_value='/cache'),
+            patch(STYLE_MODULE + '.shutil.rmtree'),
+            patch(STYLE_MODULE + '.split_image_grid', return_value=split_images),
+            patch(STYLE_MODULE + '.os.path.exists', return_value=exists),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+    def test_style_init_defaults(self):
+        """测试默认参数初始化"""
+        with patch(STYLE_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            evaluator = OneIGStyleEvaluator()
+        self.assertEqual(evaluator.oneig_root, '')
+        self.assertEqual(evaluator.device, 'cuda')
+        self.assertIsNone(evaluator.csd_embed_path)
+        self.assertIsNone(evaluator.se_embed_path)
+        self.assertEqual(evaluator.encoder_cfg, {})
+        self.assertIsNone(evaluator.csd_encoder)
+        self.assertIsNone(evaluator.se_encoder)
+
+    def test_style_init_custom_params(self):
+        """测试自定义参数初始化"""
+        cfg = {'csd_model_path': '/csd', 'clip_model_path': '/clip', 'se_model_path': '/se'}
+        with patch(STYLE_MODULE + '.BaseEvaluator.__init__', return_value=None):
+            evaluator = OneIGStyleEvaluator(
+                oneig_root='/oneig/root', device='cpu',
+                csd_embed_path='/csd_emb.pt', se_embed_path='/se_emb.pt',
+                encoder_cfg=cfg,
+            )
+        self.assertEqual(evaluator.oneig_root, '/oneig/root')
+        self.assertEqual(evaluator.device, 'cpu')
+        self.assertEqual(evaluator.csd_embed_path, '/csd_emb.pt')
+        self.assertEqual(evaluator.se_embed_path, '/se_emb.pt')
+        self.assertEqual(evaluator.encoder_cfg, cfg)
+
+    def test_style_score_none_test_set(self):
+        """测试test_set为None时返回默认值"""
+        result = self.evaluator.score(predictions=[], references=[], test_set=None)
+        self.assertEqual(result, {'accuracy': 0.0, 'details': []})
+        self.evaluator.logger.error.assert_called()
+
+    def test_style_score_valid_sample(self):
+        """测试有效样本正确计算"""
+        self.evaluator.csd_encoder = MagicMock()
+        self.evaluator.se_encoder = MagicMock()
+        test_set = [{'id': 's1', 'image_path': '/img.png', 'style_label': 'impressionism'}]
+        self._setup_score_patches()
+        with patch.object(self.evaluator, '_compute_similarity', side_effect=[0.8, 0.6]):
+            result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        # max_style_score = (0.8 + 0.6) / 2 = 0.7, overall = 70.0
+        self.assertAlmostEqual(result['accuracy'], 70.0)
+        self.assertAlmostEqual(result['details'][0]['score'], 0.7)
+
+    def test_style_score_empty_style_label(self):
+        """测试style_label为空时跳过"""
+        test_set = [{'id': 's1', 'image_path': '/img.png', 'style_label': ''}]
+        self._setup_score_patches()
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertEqual(result['accuracy'], 0.0)
+        self.assertEqual(result['details'], [])
+        self.evaluator.csd_encoder.get_style_embedding.assert_not_called()
+
+    def test_style_score_image_not_found(self):
+        """测试image_path不存在时跳过"""
+        test_set = [{'id': 's1', 'image_path': '/missing.png', 'style_label': 'impressionism'}]
+        self._setup_score_patches(exists=False)
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertEqual(result['accuracy'], 0.0)
+
+    def test_style_score_exception_handling(self):
+        """测试单样本异常时score=None"""
+        test_set = [{'id': 's1', 'image_path': '/img.png', 'style_label': 'impressionism'}]
+        patches = [
+            patch(STYLE_CLASS + '._ensure_models'),
+            patch(STYLE_MODULE + '.tempfile.mkdtemp', return_value='/cache'),
+            patch(STYLE_MODULE + '.shutil.rmtree'),
+            patch(STYLE_MODULE + '.split_image_grid',
+                  side_effect=RuntimeError("split failed")),
+            patch(STYLE_MODULE + '.os.path.exists', return_value=True),
+        ]
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+        result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertEqual(result['accuracy'], 0.0)
+        self.evaluator.logger.error.assert_called()
+
+    def test_style_score_style_dict_aggregation(self):
+        """测试style_dict正确聚合多个相同样本的分数"""
+        self.evaluator.csd_encoder = MagicMock()
+        self.evaluator.se_encoder = MagicMock()
+        test_set = [
+            {'id': 's1', 'image_path': '/img1.png', 'style_label': 'impressionism'},
+            {'id': 's2', 'image_path': '/img2.png', 'style_label': 'impressionism'},
+        ]
+        self._setup_score_patches()
+        with patch.object(self.evaluator, '_compute_similarity',
+                          side_effect=[0.8, 0.6, 0.4, 0.6]):
+            result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        # s1: (0.8+0.6)/2 = 0.7; s2: (0.4+0.6)/2 = 0.5
+        style_scores = result['style_scores']
+        self.assertIn('impressionism', style_scores)
+        self.assertEqual(len(style_scores['impressionism']), 2)
+        # overall = (0.7 + 0.5) / 2 * 100 = 60.0
+        self.assertAlmostEqual(result['accuracy'], 60.0)
+
+    def test_style_score_style_label_normalization(self):
+        """测试style_label做lower().replace(' ','_')归一化"""
+        self.evaluator.csd_encoder = MagicMock()
+        self.evaluator.se_encoder = MagicMock()
+        test_set = [{'id': 's1', 'image_path': '/img.png', 'style_label': 'Pop Art'}]
+        self._setup_score_patches()
+        with patch.object(self.evaluator, '_compute_similarity', side_effect=[0.8, 0.8]):
+            result = self.evaluator.score(predictions=[], references=[], test_set=test_set)
+        self.assertIn('pop_art', result['style_scores'])
+
+    def test_style_ensure_models_already_loaded(self):
+        """测试编码器已加载时直接返回"""
+        self.evaluator.csd_encoder = MagicMock()
+        self.evaluator.se_encoder = MagicMock()
+        self.evaluator._ensure_models()
+        self.evaluator.logger.info.assert_not_called()
+
+    def test_style_ensure_models_import_error(self):
+        """测试导入失败时抛出ImportError"""
+        self.evaluator.csd_encoder = None
+        self.evaluator.se_encoder = None
+        with patch(STYLE_MODULE + '.ensure_oneig_path'), \
+             patch('builtins.__import__', side_effect=ImportError("no module")):
+            with self.assertRaises(ImportError):
+                self.evaluator._ensure_models()
+        self.evaluator.logger.error.assert_called()
+
+    def test_style_compute_similarity_valid_tensor(self):
+        """测试_compute_similarity使用有效tensor计算"""
+        import torch
+        embed = MagicMock(spec=torch.Tensor)
+        embed.dim.return_value = 1
+        embed.unsqueeze.return_value = embed
+        ref_embed = MagicMock(spec=torch.Tensor)
+        self.evaluator.csd_ref_embeds = {'impressionism': ref_embed}
+        with patch('torch.max',
+                   return_value=MagicMock(item=lambda: 0.85)):
+            result = self.evaluator._compute_similarity(embed, 'impressionism', 'csd')
+        self.assertEqual(result, 0.85)
+
+    def test_style_compute_similarity_none_ref(self):
+        """测试ref_embeds为None时返回0.0"""
+        self.evaluator.csd_ref_embeds = None
+        result = self.evaluator._compute_similarity(
+            MagicMock(), 'impressionism', 'csd')
+        self.assertEqual(result, 0.0)
+
+    def test_style_compute_similarity_style_not_found(self):
+        """测试style_label不在ref_embeds中时返回0.0"""
+        self.evaluator.csd_ref_embeds = {'other_style': MagicMock()}
+        result = self.evaluator._compute_similarity(
+            MagicMock(), 'impressionism', 'csd')
+        self.assertEqual(result, 0.0)
+        self.evaluator.logger.warning.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [x] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)

## 🔍 Motivation / 变更动机

AISBench支持OneIG数据集接入

## 📝 Modification / 修改内容

AISBench支持OneIG数据集接入
1. 增加统一配置入口，支持5个评测子任务任意组合评测。
2. 增加UT

软件设计：
https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E3%80%91OneIG-%E6%95%B0%E6%8D%AE%E9%9B%86%E6%8E%A5%E5%85%A5-AISBench-%E6%B5%8B%E8%AF%84%E8%BD%AF%E4%BB%B6%E8%AE%BE%E8%AE%A1%E6%96%87%E6%A1%A3


## 📐 Associated Test Results / 关联测试结果

测试报告：
https://github.com/ivanbao9783/benchmark/wiki/%E3%80%90%E6%B5%8B%E8%AF%95%E6%8A%A5%E5%91%8A%E3%80%91OneIG%E2%80%90Benchmark-%E6%95%B0%E6%8D%AE%E9%9B%86%E6%8E%A5%E5%85%A5AISBench

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
