### PR TITLE
feat(config): add temperature/top_k/top_p generation_kwargs to SWE-bench examples

### DIFF
--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_full.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_full.py
@@ -15,7 +15,11 @@ models = [
         api_key="EMPTY",
         url="http://127.0.0.1:8000/v1",  #API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
-        generation_kwargs=dict(),
+        generation_kwargs=dict(
+            # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
+            # top_p=1.0,
+            # top_k=-1,
+        ),
     )
 ]
 

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_full.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_full.py
@@ -16,9 +16,12 @@ models = [
         url="http://127.0.0.1:8000/v1",  #API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
         generation_kwargs=dict(
+            # Supports arbitrary generation parameters, consistent with regular model tasks.
+            # Common parameters include temperature, top_p, top_k, timeout, etc.
             # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
             # top_p=1.0,
             # top_k=-1,
+            # timeout=200,       # Inference timeout in seconds
         ),
     )
 ]

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_lite.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_lite.py
@@ -15,7 +15,11 @@ models = [
         api_key="EMPTY",
         url="http://127.0.0.1:8000/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
-        generation_kwargs=dict(),
+        generation_kwargs=dict(
+            # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
+            # top_p=1.0,
+            # top_k=-1,
+        ),
     )
 ]
 

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_lite.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_lite.py
@@ -16,9 +16,12 @@ models = [
         url="http://127.0.0.1:8000/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
         generation_kwargs=dict(
+            # Supports arbitrary generation parameters, consistent with regular model tasks.
+            # Common parameters include temperature, top_p, top_k, timeout, etc.
             # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
             # top_p=1.0,
             # top_k=-1,
+            # timeout=200,       # Inference timeout in seconds
         ),
     )
 ]

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual.py
@@ -15,7 +15,11 @@ models = [
         api_key="EMPTY",
         url="http://127.0.0.1:8000/v1",  # vLLM API base
         batch_size=1,
-        generation_kwargs=dict(),
+        generation_kwargs=dict(
+            # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
+            # top_p=1.0,
+            # top_k=-1,
+        ),
     )
 ]
 

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual.py
@@ -16,9 +16,12 @@ models = [
         url="http://127.0.0.1:8000/v1",  # vLLM API base
         batch_size=1,
         generation_kwargs=dict(
+            # Supports arbitrary generation parameters, consistent with regular model tasks.
+            # Common parameters include temperature, top_p, top_k, timeout, etc.
             # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
             # top_p=1.0,
             # top_k=-1,
+            # timeout=200,       # Inference timeout in seconds
         ),
     )
 ]

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual_mini.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual_mini.py
@@ -28,11 +28,7 @@ datasets = [
         type=SWEBenchDataset,
         abbr="swebench_multilingual_mini",
         # Relative to AIS_BENCH_DATASETS_CACHE (default: project root); missing -> HF download
-<<<<<<< HEAD
-        path="", # necessary for mini datasets, get dataset from https://modelers.cn/datasets/AISBench/SWE-Bench_Multilingual_mini
-=======
         path="",  # Set local path to the mini dataset. Download from https://modelers.cn/datasets/AISBench/SWE-Bench_Multilingual_mini
->>>>>>> master_center
         name="multilingual",
         split="test",
         step_limit=STEP_LIMIT,

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual_mini.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual_mini.py
@@ -16,9 +16,12 @@ models = [
         url="http://127.0.0.1:8080/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
         generation_kwargs=dict(
+            # Supports arbitrary generation parameters, consistent with regular model tasks.
+            # Common parameters include temperature, top_p, top_k, timeout, etc.
             # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
             # top_p=1.0,
             # top_k=-1,
+            # timeout=200,       # Inference timeout in seconds
         ),
     )
 ]

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual_mini.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual_mini.py
@@ -15,7 +15,11 @@ models = [
         api_key="EMPTY",
         url="http://127.0.0.1:8080/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
-        generation_kwargs=dict(),
+        generation_kwargs=dict(
+            # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
+            # top_p=1.0,
+            # top_k=-1,
+        ),
     )
 ]
 

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified.py
@@ -15,7 +15,11 @@ models = [
         api_key="EMPTY",
         url="http://127.0.0.1:8000/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
-        generation_kwargs=dict(),
+        generation_kwargs=dict(
+            # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
+            # top_p=1.0,
+            # top_k=-1,
+        ),
     )
 ]
 

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified.py
@@ -16,9 +16,12 @@ models = [
         url="http://127.0.0.1:8000/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
         generation_kwargs=dict(
+            # Supports arbitrary generation parameters, consistent with regular model tasks.
+            # Common parameters include temperature, top_p, top_k, timeout, etc.
             # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
             # top_p=1.0,
             # top_k=-1,
+            # timeout=200,       # Inference timeout in seconds
         ),
     )
 ]

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified_mini.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified_mini.py
@@ -16,9 +16,12 @@ models = [
         url="http://127.0.0.1:8080/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
         generation_kwargs=dict(
+            # Supports arbitrary generation parameters, consistent with regular model tasks.
+            # Common parameters include temperature, top_p, top_k, timeout, etc.
             # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
             # top_p=1.0,
             # top_k=-1,
+            # timeout=200,       # Inference timeout in seconds
         ),
     )
 ]

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified_mini.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified_mini.py
@@ -15,7 +15,11 @@ models = [
         api_key="EMPTY",
         url="http://127.0.0.1:8080/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
-        generation_kwargs=dict(),
+        generation_kwargs=dict(
+            # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
+            # top_p=1.0,
+            # top_k=-1,
+        ),
     )
 ]
 

--- a/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py
+++ b/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py
@@ -15,7 +15,11 @@ models = [
         api_key="EMPTY",
         url="http://127.0.0.1:8000/v1",
         batch_size=1,
-        generation_kwargs=dict(),
+        generation_kwargs=dict(
+            # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
+            # top_p=1.0,
+            # top_k=-1,
+        ),
     )
 ]
 

--- a/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py
+++ b/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py
@@ -16,9 +16,12 @@ models = [
         url="http://127.0.0.1:8000/v1",
         batch_size=1,
         generation_kwargs=dict(
+            # Supports arbitrary generation parameters, consistent with regular model tasks.
+            # Common parameters include temperature, top_p, top_k, timeout, etc.
             # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
             # top_p=1.0,
             # top_k=-1,
+            # timeout=200,       # Inference timeout in seconds
         ),
     )
 ]

--- a/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py
+++ b/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py
@@ -15,7 +15,11 @@ models = [
         api_key="EMPTY",
         url="http://127.0.0.1:8000/v1",
         batch_size=1,
-        generation_kwargs=dict(),
+        generation_kwargs=dict(
+            # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
+            # top_p=1.0,
+            # top_k=-1,
+        ),
     )
 ]
 

--- a/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py
+++ b/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py
@@ -16,9 +16,12 @@ models = [
         url="http://127.0.0.1:8000/v1",
         batch_size=1,
         generation_kwargs=dict(
+            # Supports arbitrary generation parameters, consistent with regular model tasks.
+            # Common parameters include temperature, top_p, top_k, timeout, etc.
             # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
             # top_p=1.0,
             # top_k=-1,
+            # timeout=200,       # Inference timeout in seconds
         ),
     )
 ]


### PR DESCRIPTION
## Summary

Add commented-out `temperature`, `top_p`, `top_k` defaults to `generation_kwargs` in all 8 SWE-bench and SWE-bench Pro example config files. This shows users where to configure inference randomness for reproducible results.

## Problem

All 8 SWE-bench example configs had `generation_kwargs=dict()` (empty), while other benchmark examples (e.g., `api_examples/infer_vllm_api_general_chat.py`) properly demonstrate `temperature`, `top_k`, `top_p`. Users were unaware they could/should configure these generation parameters for SWE-bench.

## Analysis

The merge pipeline is already correct:

- `_get_minisweagent_config()` converts `generation_kwargs` → `model.model_kwargs`
- `recursive_merge` (swebench) and `merge_nested_dicts` (swebench_pro) both do proper **deep merge** of `model_kwargs` into the mini-swe-agent YAML config
- No code changes needed — just the config examples

## Changes

Updated all 8 files with commented-out defaults:

```python
generation_kwargs=dict(
    # temperature=0.0,   # Set 0 for deterministic output; omit or set >0 for diversity
    # top_p=1.0,
    # top_k=-1,
),
```

### Files changed:

- `ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified.py`
- `ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_full.py`
- `ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_lite.py`
- `ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_verified_mini.py`
- `ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual.py`
- `ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_multilingual_mini.py`
- `ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py`
- `ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py`

Closes #376