### PR TITLE
feat(swebench): set LiteLLM inference timeout default to 200s

### DIFF
--- a/ais_bench/benchmark/tasks/swebench/swebench_infer.py
+++ b/ais_bench/benchmark/tasks/swebench/swebench_infer.py
@@ -28,13 +28,12 @@ from ais_bench.benchmark.utils.logging.exceptions import (
 )
 from ais_bench.benchmark.tasks.swebench.utils import (
     DATASET_MAPPING,
+    DEFAULT_LITELLM_TIMEOUT,
     add_swebench_session_label_to_run_args,
     cleanup_swebench_containers,
     ensure_swebench_docker_images,
     make_swebench_session_id,
 )
-
-DEFAULT_LITELLM_TIMEOUT = 200
 
 
 def _get_minisweagent_config(model_cfg: ConfigDict) -> dict:

--- a/ais_bench/benchmark/tasks/swebench/swebench_infer.py
+++ b/ais_bench/benchmark/tasks/swebench/swebench_infer.py
@@ -41,19 +41,23 @@ def _get_minisweagent_config(model_cfg: ConfigDict) -> dict:
     # LiteLLM requires provider prefix (e.g. hosted_vllm/qwen3) for custom API; add it when url is set and name has no /
     if model_cfg.get("url") and model_name:
         model_name = f"hosted_vllm/{model_name}"
-    model_type = (
-        getattr(model_cfg.get("type"), "__name__", None)
-        or (model_cfg.get("type", "") if isinstance(model_cfg.get("type"), str) else "")
+    model_type = getattr(model_cfg.get("type"), "__name__", None) or (
+        model_cfg.get("type", "") if isinstance(model_cfg.get("type"), str) else ""
     )
     if isinstance(model_type, str):
         model_type = model_type.split(".")[-1]
     model_kwargs = dict(model_cfg.get("generation_kwargs", {}))
+    # Set default inference timeout to 200s (LiteLLM default is 600s, too long for SWE-bench)
+    model_kwargs.setdefault("timeout", 200)
     if model_cfg.get("api_key"):
         model_kwargs["api_key"] = model_cfg["api_key"]
     if model_cfg.get("url"):
         model_kwargs["api_base"] = model_cfg["url"]
     model_class = "litellm"
-    if "openrouter" in (model_type or "").lower() or "openrouter" in (str(model_cfg.get("type", ""))).lower():
+    if (
+        "openrouter" in (model_type or "").lower()
+        or "openrouter" in (str(model_cfg.get("type", ""))).lower()
+    ):
         model_class = "openrouter"
     # Avoid cost-calculation errors for local/custom models (e.g. hosted_vllm) not in litellm price map
     model_dict = {
@@ -150,7 +154,9 @@ def _make_swebench_progress_manager(
             RunBatchProgressManager,
         )
 
-        run_batch_manager = RunBatchProgressManager(num_instances, yaml_report_path=None)
+        run_batch_manager = RunBatchProgressManager(
+            num_instances, yaml_report_path=None
+        )
         composite = _CompositeProgressManager(tsm_manager, run_batch_manager)
         return composite, run_batch_manager.render_group
     except ImportError:
@@ -240,7 +246,9 @@ class SWEBenchInferTask(BaseTask):
         existing_ids = set(existing_preds.keys())
         instances = [i for i in instances if i["instance_id"] not in existing_ids]
         if existing_ids:
-            self.logger.info("Reuse: skipping %d already-done instances", len(existing_ids))
+            self.logger.info(
+                "Reuse: skipping %d already-done instances", len(existing_ids)
+            )
         if not instances:
             self.logger.info("All instances already done, nothing to run.")
             return
@@ -269,7 +277,9 @@ class SWEBenchInferTask(BaseTask):
         our_config.setdefault("environment", {})["environment_class"] = "docker"
         base_config = recursive_merge(default_swebench_config, our_config)
         if dataset_cfg.get("step_limit") is not None:
-            base_config.setdefault("agent", {})["step_limit"] = dataset_cfg["step_limit"]
+            base_config.setdefault("agent", {})["step_limit"] = dataset_cfg[
+                "step_limit"
+            ]
         session_id = make_swebench_session_id()
         add_swebench_session_label_to_run_args(base_config, session_id)
 

--- a/ais_bench/benchmark/tasks/swebench/swebench_infer.py
+++ b/ais_bench/benchmark/tasks/swebench/swebench_infer.py
@@ -34,6 +34,8 @@ from ais_bench.benchmark.tasks.swebench.utils import (
     make_swebench_session_id,
 )
 
+DEFAULT_LITELLM_TIMEOUT = 200
+
 
 def _get_minisweagent_config(model_cfg: ConfigDict) -> dict:
     """Build mini-swe-agent model config from ais_bench model_cfg (e.g. LiteLLMChat)."""
@@ -47,8 +49,8 @@ def _get_minisweagent_config(model_cfg: ConfigDict) -> dict:
     if isinstance(model_type, str):
         model_type = model_type.split(".")[-1]
     model_kwargs = dict(model_cfg.get("generation_kwargs", {}))
-    # Set default inference timeout to 200s (LiteLLM default is 600s, too long for SWE-bench)
-    model_kwargs.setdefault("timeout", 200)
+    # Set default inference timeout (LiteLLM default is 600s, too long for SWE-bench)
+    model_kwargs.setdefault("timeout", DEFAULT_LITELLM_TIMEOUT)
     if model_cfg.get("api_key"):
         model_kwargs["api_key"] = model_cfg["api_key"]
     if model_cfg.get("url"):

--- a/ais_bench/benchmark/tasks/swebench/utils.py
+++ b/ais_bench/benchmark/tasks/swebench/utils.py
@@ -8,6 +8,8 @@ from ais_bench.benchmark.utils.logging.exceptions import AISBenchRuntimeError
 
 _logger = AISLogger(name="swebench.utils")
 
+DEFAULT_LITELLM_TIMEOUT = 200
+
 DATASET_MAPPING = {
     "full": "princeton-nlp/SWE-Bench",
     "verified": "princeton-nlp/SWE-Bench_Verified",

--- a/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
+++ b/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
@@ -35,6 +35,8 @@ from ais_bench.benchmark.tasks.swebench_pro.utils import (
     build_problem_statement,
 )
 
+DEFAULT_LITELLM_TIMEOUT = 200
+
 
 def _get_minisweagent_config(model_cfg: ConfigDict) -> dict:
     model_name = model_cfg.get("model") or model_cfg.get("model_name") or ""
@@ -46,8 +48,8 @@ def _get_minisweagent_config(model_cfg: ConfigDict) -> dict:
     if isinstance(model_type, str):
         model_type = model_type.split(".")[-1]
     model_kwargs = dict(model_cfg.get("generation_kwargs", {}))
-    # Set default inference timeout to 200s (LiteLLM default is 600s, too long for SWE-bench)
-    model_kwargs.setdefault("timeout", 200)
+    # Set default inference timeout (LiteLLM default is 600s, too long for SWE-bench)
+    model_kwargs.setdefault("timeout", DEFAULT_LITELLM_TIMEOUT)
     if model_cfg.get("api_key"):
         model_kwargs["api_key"] = model_cfg["api_key"]
     if model_cfg.get("url"):

--- a/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
+++ b/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
@@ -33,6 +33,7 @@ from ais_bench.benchmark.tasks.swebench_pro.utils import (
     get_dockerhub_image_uri,
     merge_nested_dicts,
     build_problem_statement,
+    sanitize_config_for_logging,
 )
 from ais_bench.benchmark.tasks.swebench.utils import DEFAULT_LITELLM_TIMEOUT
 
@@ -281,7 +282,7 @@ class SWEBenchProInferTask(BaseTask):
             base_config.setdefault("agent", {})["step_limit"] = dataset_cfg[
                 "step_limit"
             ]
-        self.logger.info(f"base_config '{base_config}'")
+        self.logger.info("base_config '%s'", sanitize_config_for_logging(base_config))
 
         progress_manager, live_render_group = _make_swebench_pro_progress_manager(
             task_state_manager, len(instances), out_dir

--- a/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
+++ b/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
@@ -34,8 +34,7 @@ from ais_bench.benchmark.tasks.swebench_pro.utils import (
     merge_nested_dicts,
     build_problem_statement,
 )
-
-DEFAULT_LITELLM_TIMEOUT = 200
+from ais_bench.benchmark.tasks.swebench.utils import DEFAULT_LITELLM_TIMEOUT
 
 
 def _get_minisweagent_config(model_cfg: ConfigDict) -> dict:

--- a/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
+++ b/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
@@ -40,19 +40,23 @@ def _get_minisweagent_config(model_cfg: ConfigDict) -> dict:
     model_name = model_cfg.get("model") or model_cfg.get("model_name") or ""
     if model_cfg.get("url") and model_name:
         model_name = f"hosted_vllm/{model_name}"
-    model_type = (
-        getattr(model_cfg.get("type"), "__name__", None)
-        or (model_cfg.get("type", "") if isinstance(model_cfg.get("type"), str) else "")
+    model_type = getattr(model_cfg.get("type"), "__name__", None) or (
+        model_cfg.get("type", "") if isinstance(model_cfg.get("type"), str) else ""
     )
     if isinstance(model_type, str):
         model_type = model_type.split(".")[-1]
     model_kwargs = dict(model_cfg.get("generation_kwargs", {}))
+    # Set default inference timeout to 200s (LiteLLM default is 600s, too long for SWE-bench)
+    model_kwargs.setdefault("timeout", 200)
     if model_cfg.get("api_key"):
         model_kwargs["api_key"] = model_cfg["api_key"]
     if model_cfg.get("url"):
         model_kwargs["api_base"] = model_cfg["url"]
     model_class = "litellm"
-    if "openrouter" in (model_type or "").lower() or "openrouter" in (str(model_cfg.get("type", ""))).lower():
+    if (
+        "openrouter" in (model_type or "").lower()
+        or "openrouter" in (str(model_cfg.get("type", ""))).lower()
+    ):
         model_class = "openrouter"
     model_dict = {
         "model_name": model_name,
@@ -153,7 +157,9 @@ def _make_swebench_pro_progress_manager(
         )
         from rich.live import Live
 
-        run_batch_manager = RunBatchProgressManager(num_instances, yaml_report_path=out_dir / "exit_statuses.yaml")
+        run_batch_manager = RunBatchProgressManager(
+            num_instances, yaml_report_path=out_dir / "exit_statuses.yaml"
+        )
         composite = _CompositeProgressManager(tsm_manager, run_batch_manager)
         return composite, run_batch_manager.render_group
     except ImportError:
@@ -191,7 +197,7 @@ class SWEBenchProInferTask(BaseTask):
             raise AISBenchImportError(
                 SWEBP_CODES.MINISWEAGENT_IMPORT_ERROR,
                 "SWEBenchProInferTask requires mini-swe-agent. "
-                "Install with: pip install mini-swe-agent"
+                "Install with: pip install mini-swe-agent",
             ) from e
 
         dataset_cfg = self.dataset_cfgs[0]
@@ -239,7 +245,9 @@ class SWEBenchProInferTask(BaseTask):
         existing_ids = set(existing_preds.keys())
         instances = [i for i in instances if i["instance_id"] not in existing_ids]
         if existing_ids:
-            self.logger.info("Reuse: skipping %d already-done instances", len(existing_ids))
+            self.logger.info(
+                "Reuse: skipping %d already-done instances", len(existing_ids)
+            )
         if not instances:
             self.logger.info("All instances already done, nothing to run.")
             return
@@ -262,14 +270,16 @@ class SWEBenchProInferTask(BaseTask):
                 SWEBP_CODES.MODEL_NOT_SET,
                 "No model set for SWEBenchPro infer. In your config, set "
                 "models[0]['model'], models[0]['url'], and models[0]['api_key']. "
-                "Example for local vLLM: model='hosted_vllm/qwen3', url='http://127.0.0.1:2998/v1', api_key='EMPTY'."
+                "Example for local vLLM: model='hosted_vllm/qwen3', url='http://127.0.0.1:2998/v1', api_key='EMPTY'.",
             )
         our_config.setdefault("environment", {})["environment_class"] = "docker"
         # SWE-bench Pro images have hardcoded entrypoint=bin/bash which prevents sleep command execution, need to override to empty for default bin/sh
         our_config.setdefault("environment", {})["run_args"] = ["--rm", "--entrypoint="]
         base_config = merge_nested_dicts(default_swebench_config, our_config)
         if dataset_cfg.get("step_limit") is not None:
-            base_config.setdefault("agent", {})["step_limit"] = dataset_cfg["step_limit"]
+            base_config.setdefault("agent", {})["step_limit"] = dataset_cfg[
+                "step_limit"
+            ]
         self.logger.info(f"base_config '{base_config}'")
 
         progress_manager, live_render_group = _make_swebench_pro_progress_manager(
@@ -286,24 +296,24 @@ class SWEBenchProInferTask(BaseTask):
 
         def build_instance(raw_instance: dict) -> BatchInstance:
             return BatchInstance(
-                        instance_id=raw_instance["instance_id"],
-                        problem_statement=build_problem_statement(raw_instance),
-                        image_name=get_dockerhub_image_uri(raw_instance),
-                        repo_name=raw_instance["repo"],
-                        base_commit=raw_instance["base_commit"],
-                        extra_fields={
-                            k: v
-                            for k, v in raw_instance.items()
-                            if k
-                            not in [
-                                "instance_id",
-                                "problem_statement",
-                                "image_name",
-                                "repo_name",
-                                "base_commit",
-                            ]
-                        },
-                    )
+                instance_id=raw_instance["instance_id"],
+                problem_statement=build_problem_statement(raw_instance),
+                image_name=get_dockerhub_image_uri(raw_instance),
+                repo_name=raw_instance["repo"],
+                base_commit=raw_instance["base_commit"],
+                extra_fields={
+                    k: v
+                    for k, v in raw_instance.items()
+                    if k
+                    not in [
+                        "instance_id",
+                        "problem_statement",
+                        "image_name",
+                        "repo_name",
+                        "base_commit",
+                    ]
+                },
+            )
 
         workers = self.model_cfg.get("batch_size", 1)
         pro_instances = [build_instance(inst) for inst in instances]
@@ -311,7 +321,7 @@ class SWEBenchProInferTask(BaseTask):
         run_config = RunBatchConfig(
             workers=workers,
             redo_existing=False,
-            raise_exceptions=True, # raise exceptions in the main thread
+            raise_exceptions=True,  # raise exceptions in the main thread
         )
 
         def process_futures(futures):
@@ -367,6 +377,7 @@ class SWEBenchProInferTask(BaseTask):
 
         if live_render_group is not None:
             from rich.live import Live
+
             with Live(live_render_group, refresh_per_second=4):
                 run_executor()
         else:

--- a/ais_bench/benchmark/tasks/swebench_pro/utils.py
+++ b/ais_bench/benchmark/tasks/swebench_pro/utils.py
@@ -4,9 +4,28 @@ import re
 from typing import Callable, Iterable, TypeVar
 import json
 
+import copy
+
 from ais_bench.benchmark.utils.logging import AISLogger
 from ais_bench.benchmark.utils.logging.error_codes import SWEBP_CODES
 from ais_bench.benchmark.utils.logging.exceptions import AISBenchRuntimeError, AISBenchImportError
+
+
+def sanitize_config_for_logging(config: dict) -> dict:
+    """Deep-copy a config dict and mask sensitive fields (e.g. api_key) for safe logging."""
+    SENSITIVE_KEYS = {"api_key"}
+
+    def _mask(obj):
+        if isinstance(obj, dict):
+            return {
+                k: "***" if k in SENSITIVE_KEYS else _mask(v)
+                for k, v in obj.items()
+            }
+        if isinstance(obj, list):
+            return [_mask(v) for v in obj]
+        return obj
+
+    return _mask(copy.deepcopy(config))
 
 
 def cleanup_swebench_pro_containers():

--- a/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_full.py
+++ b/ais_bench/configs/swe_bench_examples/mini_swe_agent_swe_bench_full.py
@@ -13,7 +13,7 @@ models = [
         type="LiteLLMChat",
         model="",
         api_key="EMPTY",
-        url="http://127.0.0.1:8000/v1",  #API base, e.g. http://127.0.0.1:8000/v1
+        url="http://127.0.0.1:8000/v1",  # API base, e.g. http://127.0.0.1:8000/v1
         batch_size=1,
         generation_kwargs=dict(
             # Supports arbitrary generation parameters, consistent with regular model tasks.

--- a/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py
+++ b/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py
@@ -39,8 +39,8 @@ datasets = [
         step_limit=STEP_LIMIT,
         filter_spec="",
         shuffle=False,
-        swebp_scripts_dir= SWEBP_SCRIPT_PATH_ABS,
-        swebp_docker_dir= SWEBP_DOCKER_PATH_ABS,
+        swebp_scripts_dir=SWEBP_SCRIPT_PATH_ABS,
+        swebp_docker_dir=SWEBP_DOCKER_PATH_ABS,
     ),
 ]
 

--- a/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py
+++ b/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py
@@ -39,8 +39,8 @@ datasets = [
         step_limit=STEP_LIMIT,
         filter_spec="",
         shuffle=False,
-        swebp_scripts_dir= SWEBP_SCRIPT_PATH_ABS,
-        swebp_docker_dir= SWEBP_DOCKER_PATH_ABS,
+        swebp_scripts_dir=SWEBP_SCRIPT_PATH_ABS,
+        swebp_docker_dir=SWEBP_DOCKER_PATH_ABS,
     ),
 ]
 

--- a/tests/UT/tasks/sweb/test_swebench_infer.py
+++ b/tests/UT/tasks/sweb/test_swebench_infer.py
@@ -29,11 +29,14 @@ class TestGetMinisweagentConfig(unittest.TestCase):
         self.assertIn("model_class", result["model"])
         self.assertIn("model_kwargs", result["model"])
 
-    def test_sets_default_timeout_200(self):
-        """Default timeout should be 200s (not LiteLLM default of 600s)."""
+    def test_sets_default_timeout(self):
+        """Default timeout should match DEFAULT_LITELLM_TIMEOUT (not LiteLLM default of 600s)."""
         cfg = {}
         result = self.infer_module._get_minisweagent_config(cfg)
-        self.assertEqual(result["model"]["model_kwargs"]["timeout"], 200)
+        self.assertEqual(
+            result["model"]["model_kwargs"]["timeout"],
+            self.infer_module.DEFAULT_LITELLM_TIMEOUT,
+        )
 
     def test_user_timeout_overrides_default(self):
         """User-specified timeout in generation_kwargs should override default of 200."""

--- a/tests/UT/tasks/sweb/test_swebench_infer.py
+++ b/tests/UT/tasks/sweb/test_swebench_infer.py
@@ -1,0 +1,88 @@
+"""Unit tests for ais_bench.benchmark.tasks.swebench.swebench_infer"""
+
+import unittest
+import os
+import sys
+from unittest.mock import MagicMock
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from ais_bench.benchmark.tasks.swebench import swebench_infer as infer_module
+
+
+class TestGetMinisweagentConfig(unittest.TestCase):
+    """Test _get_minisweagent_config function for SWE-bench (non-Pro)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.infer_module = infer_module
+
+    def test_returns_dict_with_model_key(self):
+        cfg = {"model": "test-model", "generation_kwargs": {"temperature": 0.7}}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertIn("model", result)
+        self.assertIn("model_name", result["model"])
+        self.assertIn("model_class", result["model"])
+        self.assertIn("model_kwargs", result["model"])
+
+    def test_sets_default_timeout_200(self):
+        """Default timeout should be 200s (not LiteLLM default of 600s)."""
+        cfg = {}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_kwargs"]["timeout"], 200)
+
+    def test_user_timeout_overrides_default(self):
+        """User-specified timeout in generation_kwargs should override default of 200."""
+        cfg = {"generation_kwargs": {"timeout": 120}}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_kwargs"]["timeout"], 120)
+
+    def test_handles_empty_config(self):
+        result = self.infer_module._get_minisweagent_config({})
+        self.assertIsInstance(result, dict)
+        self.assertIn("model", result)
+
+    def test_sets_model_name_from_model_key(self):
+        cfg = {"model": "gpt-4"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_name"], "gpt-4")
+
+    def test_sets_model_name_from_model_name_key(self):
+        cfg = {"model_name": "claude-3"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_name"], "claude-3")
+
+    def test_includes_api_key_in_model_kwargs(self):
+        cfg = {"api_key": "sk-test-123"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_kwargs"]["api_key"], "sk-test-123")
+
+    def test_includes_url_as_api_base(self):
+        cfg = {"url": "https://api.example.com/v1"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(
+            result["model"]["model_kwargs"]["api_base"], "https://api.example.com/v1"
+        )
+
+    def test_includes_cost_tracking(self):
+        cfg = {"model": "test-model"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["cost_tracking"], "ignore_errors")
+
+    def test_sets_litellm_class_by_default(self):
+        cfg = {"model": "test-model"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_class"], "litellm")
+
+    def test_sets_hosted_vllm_prefix(self):
+        cfg = {"model": "qwen3", "url": "http://127.0.0.1:8000/v1"}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_name"], "hosted_vllm/qwen3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py
+++ b/tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py
@@ -59,11 +59,14 @@ class TestGetMinisweagentConfig(unittest.TestCase):
             result["model"]["model_kwargs"]["api_base"], "https://api.example.com/v1"
         )
 
-    def test_sets_default_timeout_200(self):
-        """Default timeout should be 200s (not LiteLLM default of 600s)."""
+    def test_sets_default_timeout(self):
+        """Default timeout should match DEFAULT_LITELLM_TIMEOUT (not LiteLLM default of 600s)."""
         cfg = {}
         result = self.infer_module._get_minisweagent_config(cfg)
-        self.assertEqual(result["model"]["model_kwargs"]["timeout"], 200)
+        self.assertEqual(
+            result["model"]["model_kwargs"]["timeout"],
+            self.infer_module.DEFAULT_LITELLM_TIMEOUT,
+        )
 
     def test_user_timeout_overrides_default(self):
         """User-specified timeout in generation_kwargs should override default of 200."""

--- a/tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py
+++ b/tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py
@@ -1,14 +1,16 @@
 """Unit tests for ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer"""
+
 import unittest
 import tempfile
 import os
 import sys
 import json
-import shutil
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
@@ -53,7 +55,21 @@ class TestGetMinisweagentConfig(unittest.TestCase):
     def test_includes_url_as_api_base(self):
         cfg = {"url": "https://api.example.com/v1"}
         result = self.infer_module._get_minisweagent_config(cfg)
-        self.assertEqual(result["model"]["model_kwargs"]["api_base"], "https://api.example.com/v1")
+        self.assertEqual(
+            result["model"]["model_kwargs"]["api_base"], "https://api.example.com/v1"
+        )
+
+    def test_sets_default_timeout_200(self):
+        """Default timeout should be 200s (not LiteLLM default of 600s)."""
+        cfg = {}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_kwargs"]["timeout"], 200)
+
+    def test_user_timeout_overrides_default(self):
+        """User-specified timeout in generation_kwargs should override default of 200."""
+        cfg = {"generation_kwargs": {"timeout": 120}}
+        result = self.infer_module._get_minisweagent_config(cfg)
+        self.assertEqual(result["model"]["model_kwargs"]["timeout"], 120)
 
 
 class TestAISBenchProgressManager(unittest.TestCase):
@@ -114,7 +130,7 @@ class TestParseArgs(unittest.TestCase):
     def setUpClass(cls):
         cls.infer_module = infer_module
 
-    @patch('argparse.ArgumentParser.parse_args')
+    @patch("argparse.ArgumentParser.parse_args")
     def test_parses_config_argument(self, mock_parse):
         mock_parse.return_value = MagicMock(config="test_config.py", infer_kwargs="{}")
 
@@ -122,11 +138,10 @@ class TestParseArgs(unittest.TestCase):
 
         self.assertEqual(args.config, "test_config.py")
 
-    @patch('argparse.ArgumentParser.parse_args')
+    @patch("argparse.ArgumentParser.parse_args")
     def test_parses_infer_kwargs(self, mock_parse):
         mock_parse.return_value = MagicMock(
-            config="test_config.py",
-            infer_kwargs='{"key": "value"}'
+            config="test_config.py", infer_kwargs='{"key": "value"}'
         )
 
         args = self.infer_module.parse_args()
@@ -225,8 +240,12 @@ class TestSWEBenchProInferTask(unittest.TestCase):
         cls.infer_module = infer_module
 
     def test_get_command(self):
-        with patch.object(self.infer_module.SWEBenchProInferTask, '__init__', lambda self, cfg: None):
-            task = self.infer_module.SWEBenchProInferTask.__new__(self.infer_module.SWEBenchProInferTask)
+        with patch.object(
+            self.infer_module.SWEBenchProInferTask, "__init__", lambda self, cfg: None
+        ):
+            task = self.infer_module.SWEBenchProInferTask.__new__(
+                self.infer_module.SWEBenchProInferTask
+            )
             command = task.get_command("config_path.yaml", "python {task_cmd}")
             self.assertIn("python", command)
             self.assertIn("config_path.yaml", command)
@@ -239,14 +258,16 @@ class TestMakeSWEBenchProProgressManager(unittest.TestCase):
     def setUpClass(cls):
         cls.infer_module = infer_module
 
-    @patch('minisweagent.run.extra.utils.batch_progress.RunBatchProgressManager')
+    @patch("minisweagent.run.extra.utils.batch_progress.RunBatchProgressManager")
     def test_returns_composite_manager(self, mock_rbpm_class):
         mock_tsm = MagicMock()
         mock_rbpm = MagicMock()
         mock_rbpm_class.return_value = mock_rbpm
         mock_rbpm.render_group = "render_group"
 
-        manager, render_group = self.infer_module._make_swebench_pro_progress_manager(mock_tsm, 10, Path("out_dir"))
+        manager, render_group = self.infer_module._make_swebench_pro_progress_manager(
+            mock_tsm, 10, Path("out_dir")
+        )
 
         self.assertIsNotNone(manager)
         self.assertEqual(render_group, "render_group")
@@ -254,10 +275,17 @@ class TestMakeSWEBenchProProgressManager(unittest.TestCase):
     def test_handles_import_error(self):
         mock_tsm = MagicMock()
 
-        with patch.dict(sys.modules, {
-            'minisweagent.run.extra.utils.batch_progress': None,
-        }):
-            manager, render_group = self.infer_module._make_swebench_pro_progress_manager(mock_tsm, 10, "out_dir")
+        with patch.dict(
+            sys.modules,
+            {
+                "minisweagent.run.extra.utils.batch_progress": None,
+            },
+        ):
+            manager, render_group = (
+                self.infer_module._make_swebench_pro_progress_manager(
+                    mock_tsm, 10, "out_dir"
+                )
+            )
 
         self.assertIsNotNone(manager)
         self.assertIsNone(render_group)
@@ -303,31 +331,60 @@ class TestSWEBenchProInferTaskRun(unittest.TestCase):
     def setUpClass(cls):
         cls.infer_module = infer_module
 
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager')
-    @patch('yaml.safe_load')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg')
-    @patch('concurrent.futures.ThreadPoolExecutor')
-    @patch('concurrent.futures.as_completed')
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager"
+    )
+    @patch("yaml.safe_load")
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg"
+    )
+    @patch("concurrent.futures.ThreadPoolExecutor")
+    @patch("concurrent.futures.as_completed")
     def test_run_all_instances_done(
-        self, mock_as_completed, mock_executor_class, mock_task_abbr, mock_model_abbr,
-        mock_build_dataset, mock_get_output_path, mock_yaml_load,
-        mock_make_progress, mock_ensure_images, mock_cleanup
+        self,
+        mock_as_completed,
+        mock_executor_class,
+        mock_task_abbr,
+        mock_model_abbr,
+        mock_build_dataset,
+        mock_get_output_path,
+        mock_yaml_load,
+        mock_make_progress,
+        mock_ensure_images,
+        mock_cleanup,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
             cfg = MagicMock()
             cfg.cli_args = {"debug": False}
             cfg.work_dir = tmpdir
 
-            task = self.infer_module.SWEBenchProInferTask.__new__(self.infer_module.SWEBenchProInferTask)
+            task = self.infer_module.SWEBenchProInferTask.__new__(
+                self.infer_module.SWEBenchProInferTask
+            )
             task.cfg = cfg
             task.work_dir = tmpdir
             task.logger = MagicMock()
-            task.model_cfg = {"type": "test", "model": "test-model", "api_key": "test-key", "url": "http://test"}
+            task.model_cfg = {
+                "type": "test",
+                "model": "test-model",
+                "api_key": "test-key",
+                "url": "http://test",
+            }
             task.dataset_cfgs = [{}]
 
             mock_model_abbr.return_value = "model1"
@@ -350,29 +407,55 @@ class TestSWEBenchProInferTaskRun(unittest.TestCase):
 
             task.run(task_state_manager)
 
-            task.logger.info.assert_any_call("All instances already done, nothing to run.")
+            task.logger.info.assert_any_call(
+                "All instances already done, nothing to run."
+            )
 
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager')
-    @patch('yaml.safe_load')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg')
-    @patch('concurrent.futures.ThreadPoolExecutor')
-    @patch('concurrent.futures.as_completed')
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager"
+    )
+    @patch("yaml.safe_load")
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg"
+    )
+    @patch("concurrent.futures.ThreadPoolExecutor")
+    @patch("concurrent.futures.as_completed")
     def test_run_no_model_set(
-        self, mock_as_completed, mock_executor_class, mock_task_abbr, mock_model_abbr,
-        mock_build_dataset, mock_get_output_path, mock_yaml_load,
-        mock_make_progress, mock_ensure_images, mock_cleanup
+        self,
+        mock_as_completed,
+        mock_executor_class,
+        mock_task_abbr,
+        mock_model_abbr,
+        mock_build_dataset,
+        mock_get_output_path,
+        mock_yaml_load,
+        mock_make_progress,
+        mock_ensure_images,
+        mock_cleanup,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
             cfg = MagicMock()
             cfg.cli_args = {"debug": False}
             cfg.work_dir = tmpdir
 
-            task = self.infer_module.SWEBenchProInferTask.__new__(self.infer_module.SWEBenchProInferTask)
+            task = self.infer_module.SWEBenchProInferTask.__new__(
+                self.infer_module.SWEBenchProInferTask
+            )
             task.cfg = cfg
             task.work_dir = tmpdir
             task.logger = MagicMock()
@@ -395,43 +478,74 @@ class TestSWEBenchProInferTaskRun(unittest.TestCase):
             with self.assertRaises(Exception):
                 task.run(task_state_manager)
 
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager')
-    @patch('yaml.safe_load')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg')
-    @patch('ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg')
-    @patch('concurrent.futures.ThreadPoolExecutor')
-    @patch('concurrent.futures.as_completed')
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.cleanup_swebench_pro_containers"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.ensure_swebench_pro_docker_images"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer._make_swebench_pro_progress_manager"
+    )
+    @patch("yaml.safe_load")
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.get_infer_output_path"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.build_dataset_from_cfg"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.model_abbr_from_cfg"
+    )
+    @patch(
+        "ais_bench.benchmark.tasks.swebench_pro.swebench_pro_infer.task_abbr_from_cfg"
+    )
+    @patch("concurrent.futures.ThreadPoolExecutor")
+    @patch("concurrent.futures.as_completed")
     def test_run_with_instances(
-        self, mock_as_completed, mock_executor_class, mock_task_abbr, mock_model_abbr,
-        mock_build_dataset, mock_get_output_path, mock_yaml_load,
-        mock_make_progress, mock_ensure_images, mock_cleanup
+        self,
+        mock_as_completed,
+        mock_executor_class,
+        mock_task_abbr,
+        mock_model_abbr,
+        mock_build_dataset,
+        mock_get_output_path,
+        mock_yaml_load,
+        mock_make_progress,
+        mock_ensure_images,
+        mock_cleanup,
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
             cfg = MagicMock()
             cfg.cli_args = {"debug": False}
             cfg.work_dir = tmpdir
 
-            task = self.infer_module.SWEBenchProInferTask.__new__(self.infer_module.SWEBenchProInferTask)
+            task = self.infer_module.SWEBenchProInferTask.__new__(
+                self.infer_module.SWEBenchProInferTask
+            )
             task.cfg = cfg
             task.work_dir = tmpdir
             task.logger = MagicMock()
-            task.model_cfg = {"type": "test", "model": "test-model", "api_key": "test-key", "batch_size": 1}
+            task.model_cfg = {
+                "type": "test",
+                "model": "test-model",
+                "api_key": "test-key",
+                "batch_size": 1,
+            }
             task.dataset_cfgs = [{}]
 
             mock_model_abbr.return_value = "model1"
             mock_task_abbr.return_value = "task1"
 
             mock_dataset = MagicMock()
-            mock_dataset.test = [{
-                "instance_id": "id1",
-                "problem_statement": "test problem",
-                "repo": "test/repo",
-                "base_commit": "abc123"
-            }]
+            mock_dataset.test = [
+                {
+                    "instance_id": "id1",
+                    "problem_statement": "test problem",
+                    "repo": "test/repo",
+                    "base_commit": "abc123",
+                }
+            ]
             mock_build_dataset.return_value = mock_dataset
 
             mock_get_output_path.return_value = os.path.join(tmpdir, "preds.json")
@@ -458,5 +572,5 @@ class TestSWEBenchProInferTaskRun(unittest.TestCase):
             mock_executor_class.assert_called_once()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Override the LiteLLM default inference timeout (600s) with a more reasonable 200s default for SWE-bench / SWE-bench Pro agent tasks.

## Changes

- `ais_bench/benchmark/tasks/swebench/swebench_infer.py`: Add `model_kwargs.setdefault("timeout", 200)` in `_get_minisweagent_config()`
- `ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py`: Same change for SWE-bench Pro
- `tests/UT/tasks/swebp_pro/test_swebench_pro_infer.py`: Add unit tests for default timeout (200s) and user override behavior

## Behavior

- When no `timeout` is specified in `generation_kwargs`, it defaults to **200s** (instead of LiteLLM's 600s)
- Users can still override via `generation_kwargs=dict(timeout=N)` in their config

Closes #382