### PR TITLE
refactor(swebp): 重构swebp镜像操作逻辑，优化镜像管理粒度

### DIFF
--- a/ais_bench/benchmark/tasks/swebench/utils.py
+++ b/ais_bench/benchmark/tasks/swebench/utils.py
@@ -26,7 +26,7 @@ def make_swebench_session_id() -> str:
     return uuid.uuid4().hex
 
 
-def _merge_docker_labels(labels, session_id: str) -> dict:
+def _merge_docker_labels(labels, session_id: str, label_key: str = SWEBENCH_SESSION_LABEL) -> dict:
     """Merge session label into Docker labels dict.
 
     Docker SDK ``containers.create/run(labels=...)`` expects a mapping
@@ -43,19 +43,21 @@ def _merge_docker_labels(labels, session_id: str) -> dict:
                 merged[k] = v
     else:
         merged = {}
-    merged[SWEBENCH_SESSION_LABEL] = session_id
+    merged[label_key] = session_id
     return merged
 
 
 class _DockerContainersWithSessionLabel:
-    def __init__(self, containers, session_id: str):
+    def __init__(self, containers, session_id: str, label_key: str = SWEBENCH_SESSION_LABEL):
         self._containers = containers
         self._session_id = session_id
+        self._label_key = label_key
 
     def create(self, *args, **kwargs):
         kwargs["labels"] = _merge_docker_labels(
             kwargs.get("labels"),
             self._session_id,
+            self._label_key,
         )
         return self._containers.create(*args, **kwargs)
 
@@ -63,6 +65,7 @@ class _DockerContainersWithSessionLabel:
         kwargs["labels"] = _merge_docker_labels(
             kwargs.get("labels"),
             self._session_id,
+            self._label_key,
         )
         return self._containers.run(*args, **kwargs)
 
@@ -71,23 +74,24 @@ class _DockerContainersWithSessionLabel:
 
 
 class _DockerClientWithSessionLabel:
-    def __init__(self, client, session_id: str):
+    def __init__(self, client, session_id: str, label_key: str = SWEBENCH_SESSION_LABEL):
         self._client = client
         self.containers = _DockerContainersWithSessionLabel(
             client.containers,
             session_id,
+            label_key,
         )
 
     def __getattr__(self, name):
         return getattr(self._client, name)
 
 
-def add_swebench_session_label_to_docker_client(client, session_id: str):
+def add_swebench_session_label_to_docker_client(client, session_id: str, label_key: str = SWEBENCH_SESSION_LABEL):
     """Return a Docker client wrapper that labels containers it creates."""
-    return _DockerClientWithSessionLabel(client, session_id)
+    return _DockerClientWithSessionLabel(client, session_id, label_key)
 
 
-def list_swebench_container_ids(session_id: Optional[str] = None) -> Set[str]:
+def list_swebench_container_ids(session_id: Optional[str] = None, label_key: str = SWEBENCH_SESSION_LABEL) -> Set[str]:
     """Return Docker container IDs tagged for one SWE-bench task session."""
     if not session_id:
         return set()
@@ -100,7 +104,7 @@ def list_swebench_container_ids(session_id: Optional[str] = None) -> Set[str]:
                 "ps",
                 "-aq",
                 "--filter",
-                f"label={SWEBENCH_SESSION_LABEL}={session_id}",
+                f"label={label_key}={session_id}",
             ],
             capture_output=True,
             text=True,
@@ -123,10 +127,11 @@ def cleanup_swebench_containers(
     *,
     container_ids: Optional[Iterable[str]] = None,
     session_id: Optional[str] = None,
+    label_key: str = SWEBENCH_SESSION_LABEL,
 ):
     """Stop and remove containers created by the current SWE-bench task."""
     targets = set(container_ids or [])
-    targets.update(list_swebench_container_ids(session_id))
+    targets.update(list_swebench_container_ids(session_id, label_key))
     targets = sorted(targets)
     if not targets:
         return
@@ -144,11 +149,11 @@ def cleanup_swebench_containers(
         _logger.warning("Unexpected error removing containers", exc_info=True)
 
 
-def add_swebench_session_label_to_run_args(config: dict, session_id: str) -> None:
+def add_swebench_session_label_to_run_args(config: dict, session_id: str, label_key: str = SWEBENCH_SESSION_LABEL) -> None:
     """Add this task's Docker label to mini-swe-agent Docker run args."""
     environment = config.setdefault("environment", {})
     run_args = list(environment.get("run_args", ["--rm"]))
-    label_flag = f"{SWEBENCH_SESSION_LABEL}={session_id}"
+    label_flag = f"{label_key}={session_id}"
     if label_flag not in run_args:
         run_args.extend(["--label", label_flag])
     environment["run_args"] = run_args

--- a/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_eval.py
+++ b/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_eval.py
@@ -35,6 +35,9 @@ from ais_bench.benchmark.tasks.swebench_pro.utils import (
     eval_with_docker,
     list_swebench_pro_images,
     clean_swebench_pro_images,
+    cleanup_swebench_pro_containers,
+    make_swebench_pro_session_id,
+    add_swebench_pro_session_label_to_docker_client,
 )
 
 KEY_INSTANCE_ID = "instance_id"
@@ -361,7 +364,10 @@ class SWEBenchProEvalTask(BaseTask):
                 SWEBP_CODES.SWEBENCH_HARNESS_IMPORT_ERROR,
                 "docker SDK is not installed. Install via 'pip install docker'"
             ) from e
-        docker_client = docker.from_env()
+        session_id = make_swebench_pro_session_id()
+        docker_client = add_swebench_pro_session_label_to_docker_client(
+            docker.from_env(), session_id
+        )
         prior_images = list_swebench_pro_images(docker_client)
         
         ensure_swebench_pro_docker_images(
@@ -482,9 +488,9 @@ class SWEBenchProEvalTask(BaseTask):
         finally:
             if pbar is not None:
                 pbar.close()
-        
+            cleanup_swebench_pro_containers(session_id=session_id)
+
         self.logger.info("All instances run.")
- 
         self.logger.info("Cleaning up SWE-bench Pro images...")
         clean_swebench_pro_images(docker_client, prior_images, self.logger)
         self.logger.info("Image cleanup completed.")

--- a/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
+++ b/ais_bench/benchmark/tasks/swebench_pro/swebench_pro_infer.py
@@ -28,9 +28,11 @@ from ais_bench.benchmark.utils.logging.exceptions import (
     AISBenchValueError,
 )
 from ais_bench.benchmark.tasks.swebench_pro.utils import (
+    add_swebench_pro_session_label_to_run_args,
     cleanup_swebench_pro_containers,
     ensure_swebench_pro_docker_images,
     get_dockerhub_image_uri,
+    make_swebench_pro_session_id,
     merge_nested_dicts,
     build_problem_statement,
     sanitize_config_for_logging,
@@ -282,6 +284,10 @@ class SWEBenchProInferTask(BaseTask):
             base_config.setdefault("agent", {})["step_limit"] = dataset_cfg[
                 "step_limit"
             ]
+
+        session_id = make_swebench_pro_session_id()
+        add_swebench_pro_session_label_to_run_args(base_config, session_id)
+
         self.logger.info("base_config '%s'", sanitize_config_for_logging(base_config))
 
         progress_manager, live_render_group = _make_swebench_pro_progress_manager(
@@ -369,13 +375,13 @@ class SWEBenchProInferTask(BaseTask):
                     for future in futures:
                         if not future.running() and not future.done():
                             future.cancel()
-                    cleanup_swebench_pro_containers()
+                    cleanup_swebench_pro_containers(session_id=session_id)
                     executor.shutdown(wait=False)
                     raise
             finally:
                 if not interrupted[0]:
                     executor.shutdown(wait=True)
-                cleanup_swebench_pro_containers()
+                cleanup_swebench_pro_containers(session_id=session_id)
 
         if live_render_group is not None:
             from rich.live import Live

--- a/ais_bench/benchmark/tasks/swebench_pro/utils.py
+++ b/ais_bench/benchmark/tasks/swebench_pro/utils.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import re
-from typing import Callable, Iterable, TypeVar
+from typing import Callable, Iterable, Optional, Set, TypeVar
 import json
 
 import copy
@@ -9,6 +9,17 @@ import copy
 from ais_bench.benchmark.utils.logging import AISLogger
 from ais_bench.benchmark.utils.logging.error_codes import SWEBP_CODES
 from ais_bench.benchmark.utils.logging.exceptions import AISBenchRuntimeError, AISBenchImportError
+
+from ais_bench.benchmark.tasks.swebench.utils import (
+    add_swebench_session_label_to_docker_client as _add_session_label_to_docker_client,
+    add_swebench_session_label_to_run_args as _add_session_label_to_run_args,
+    cleanup_swebench_containers as _cleanup_session_containers,
+    list_swebench_container_ids as _list_session_container_ids,
+    make_swebench_session_id as _make_session_id,
+)
+
+
+SWEBENCH_PRO_SESSION_LABEL = "ais_bench.swebench_pro.session"
 
 
 def sanitize_config_for_logging(config: dict) -> dict:
@@ -28,28 +39,37 @@ def sanitize_config_for_logging(config: dict) -> dict:
     return _mask(copy.deepcopy(config))
 
 
-def cleanup_swebench_pro_containers():
-    name_filters = ["minisweagent-", "sweb.eval"]
-    for name_filter in name_filters:
-        try:
-            r = subprocess.run(
-                ["docker", "ps", "-aq", "--filter", f"name={name_filter}"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            if r.returncode != 0 or not (r.stdout or "").strip():
-                continue
-            ids = [x.strip() for x in r.stdout.strip().splitlines() if x.strip()]
-            if not ids:
-                continue
-            subprocess.run(
-                ["docker", "rm", "-f"] + ids,
-                capture_output=True,
-                timeout=30,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
-            pass
+def make_swebench_pro_session_id() -> str:
+    """Generate a unique session id for one SWE-bench Pro task run."""
+    return _make_session_id()
+
+
+def add_swebench_pro_session_label_to_docker_client(client, session_id: str):
+    """Return a Docker client wrapper that labels containers it creates."""
+    return _add_session_label_to_docker_client(client, session_id, SWEBENCH_PRO_SESSION_LABEL)
+
+
+def list_swebench_pro_container_ids(session_id: Optional[str] = None) -> Set[str]:
+    """Return Docker container IDs tagged for one SWE-bench Pro task session."""
+    return _list_session_container_ids(session_id, SWEBENCH_PRO_SESSION_LABEL)
+
+
+def cleanup_swebench_pro_containers(
+    *,
+    container_ids: Optional[Iterable[str]] = None,
+    session_id: Optional[str] = None,
+):
+    """Stop and remove containers created by the current SWE-bench Pro task."""
+    _cleanup_session_containers(
+        container_ids=container_ids,
+        session_id=session_id,
+        label_key=SWEBENCH_PRO_SESSION_LABEL,
+    )
+
+
+def add_swebench_pro_session_label_to_run_args(config: dict, session_id: str) -> None:
+    """Add this task's Docker label to mini-swe-agent Docker run args."""
+    _add_session_label_to_run_args(config, session_id, SWEBENCH_PRO_SESSION_LABEL)
 
 
 def list_swebench_pro_images(client) -> set[str]:

--- a/tests/UT/tasks/swebp_pro/test_utils.py
+++ b/tests/UT/tasks/swebp_pro/test_utils.py
@@ -4,7 +4,6 @@ import tempfile
 import os
 import sys
 import json
-import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import patch, MagicMock, call

--- a/tests/UT/tasks/swebp_pro/test_utils.py
+++ b/tests/UT/tasks/swebp_pro/test_utils.py
@@ -7,7 +7,7 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
 if PROJECT_ROOT not in sys.path:
@@ -579,42 +579,162 @@ class TestCleanSwebenchProImages(unittest.TestCase):
                 mock_logger.debug.assert_called_once()
 
 
-class TestCleanupSwebenchProContainers(unittest.TestCase):
+class TestSwebenchProContainerCleanup(unittest.TestCase):
+    """Session-scoped container cleanup tests (mirror swebench session isolation)."""
+
     @classmethod
     def setUpClass(cls):
         cls.utils = utils_module
 
-    @patch('subprocess.run')
-    def test_cleanup_containers_success(self, mock_run):
-        mock_result1 = MagicMock()
-        mock_result1.returncode = 0
-        mock_result1.stdout = "container1\ncontainer2\n"
-        mock_result2 = MagicMock()
-        mock_result2.returncode = 0
-        mock_result2.stdout = ""
-        mock_run.side_effect = [mock_result1, MagicMock(), mock_result2]
+    def test_list_swebench_pro_container_ids_queries_session_label(self):
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout="one\ntwo\n")
 
-        self.utils.cleanup_swebench_pro_containers()
-        self.assertEqual(mock_run.call_count, 3)
+        with patch.object(utils_module.subprocess, "run", return_value=result) as mock_run:
+            container_ids = self.utils.list_swebench_pro_container_ids("session-1")
 
-    @patch('subprocess.run')
-    def test_cleanup_no_containers(self, mock_run):
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = ""
-        mock_run.return_value = mock_result
+        self.assertEqual(container_ids, {"one", "two"})
+        self.assertEqual(
+            mock_run.call_args_list,
+            [
+                call(
+                    [
+                        "docker",
+                        "ps",
+                        "-aq",
+                        "--filter",
+                        f"label={utils_module.SWEBENCH_PRO_SESSION_LABEL}=session-1",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                ),
+            ],
+        )
 
-        self.utils.cleanup_swebench_pro_containers()
+    def test_list_swebench_pro_container_ids_without_session_is_empty(self):
+        with patch.object(utils_module.subprocess, "run", MagicMock()) as mock_run:
+            container_ids = self.utils.list_swebench_pro_container_ids()
 
-    @patch('subprocess.run')
-    def test_cleanup_handles_docker_not_found(self, mock_run):
-        mock_run.side_effect = FileNotFoundError("docker not found")
-        self.utils.cleanup_swebench_pro_containers()
+        self.assertEqual(container_ids, set())
+        mock_run.assert_not_called()
 
-    @patch('subprocess.run')
-    def test_cleanup_handles_timeout(self, mock_run):
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=10)
-        self.utils.cleanup_swebench_pro_containers()
+    def test_cleanup_removes_only_session_tagged_ids(self):
+        # Simulate docker CLI: ``docker ps`` returns container IDs tagged with
+        # the session label, ``docker rm -f`` removes them.
+        def fake_run(cmd, **kwargs):
+            if "ps" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="session-a\nsession-b\n", stderr=""
+                )
+            if "rm" in cmd:
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch.object(utils_module.subprocess, "run", side_effect=fake_run) as mock_run:
+            self.utils.cleanup_swebench_pro_containers(session_id="session-1")
+
+        # docker ps (list) + docker rm -f (cleanup)
+        self.assertEqual(mock_run.call_count, 2)
+        rm_call = mock_run.call_args_list[1]
+        self.assertEqual(
+            rm_call,
+            call(
+                ["docker", "rm", "-f", "session-a", "session-b"],
+                capture_output=True,
+                timeout=30,
+            ),
+        )
+
+    def test_cleanup_without_recorded_or_session_ids_is_noop(self):
+        with patch.object(utils_module.subprocess, "run", MagicMock()) as mock_run:
+            self.utils.cleanup_swebench_pro_containers()
+
+        mock_run.assert_not_called()
+
+    def test_cleanup_handles_docker_not_found(self):
+        def fake_run(cmd, **kwargs):
+            if "ps" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="c1\n", stderr=""
+                )
+            if "rm" in cmd:
+                raise FileNotFoundError("docker not found")
+
+        with patch.object(utils_module.subprocess, "run", side_effect=fake_run):
+            # Should not raise even when docker rm fails with FileNotFoundError.
+            self.utils.cleanup_swebench_pro_containers(session_id="session-1")
+
+    def test_cleanup_handles_timeout(self):
+        def fake_run(cmd, **kwargs):
+            if "ps" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="c1\n", stderr=""
+                )
+            if "rm" in cmd:
+                raise subprocess.TimeoutExpired(cmd="docker", timeout=30)
+
+        with patch.object(utils_module.subprocess, "run", side_effect=fake_run):
+            # Should not raise even when docker rm times out.
+            self.utils.cleanup_swebench_pro_containers(session_id="session-1")
+
+    def test_add_session_label_to_run_args_preserves_existing_args(self):
+        config = {"environment": {"run_args": ["--rm", "--network", "none"]}}
+
+        self.utils.add_swebench_pro_session_label_to_run_args(config, "session-1")
+
+        self.assertEqual(
+            config["environment"]["run_args"],
+            [
+                "--rm",
+                "--network",
+                "none",
+                "--label",
+                f"{utils_module.SWEBENCH_PRO_SESSION_LABEL}=session-1",
+            ],
+        )
+
+    def test_add_session_label_to_run_args_defaults_run_args(self):
+        config = {}
+        self.utils.add_swebench_pro_session_label_to_run_args(config, "session-1")
+        self.assertEqual(
+            config["environment"]["run_args"],
+            ["--rm", "--label", f"{utils_module.SWEBENCH_PRO_SESSION_LABEL}=session-1"],
+        )
+
+    def test_docker_client_wrapper_adds_session_label_without_changing_name(self):
+        client = MagicMock()
+        wrapped = self.utils.add_swebench_pro_session_label_to_docker_client(
+            client,
+            "session-1",
+        )
+
+        wrapped.containers.run(
+            "image",
+            name="default-name",
+            labels={"existing": "value"},
+        )
+
+        client.containers.run.assert_called_once_with(
+            "image",
+            name="default-name",
+            labels={
+                "existing": "value",
+                utils_module.SWEBENCH_PRO_SESSION_LABEL: "session-1",
+            },
+        )
+
+    def test_docker_client_wrapper_passes_through_other_attrs(self):
+        client = MagicMock()
+        wrapped = self.utils.add_swebench_pro_session_label_to_docker_client(
+            client, "session-1"
+        )
+        # ``images`` and other APIs are not containers; ensure they pass through.
+        _ = wrapped.images
+        client.images.__getattr__  # attribute exists on mock
+        self.assertIs(wrapped.images, client.images)
+
+    def test_make_swebench_pro_session_id_is_unique(self):
+        ids = {self.utils.make_swebench_pro_session_id() for _ in range(100)}
+        self.assertEqual(len(ids), 100)
 
 
 class TestCollectOutputsLocal(unittest.TestCase):


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [x] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #380 

## 🔍 Motivation / 变更动机

1. 归一swe和swebp两个数据集的镜像操作，消除冗余代码。
2. 优化swebp临时容器清理逻辑，以Session粒度管理生命周期

## 📝 Modification / 修改内容

1. 归一swe和swebp两个数据集的镜像操作，消除冗余代码。
2. 优化swebp临时容器清理逻辑，以Session粒度管理生命周期

## 📐 Associated Test Results / 关联测试结果

步骤一：起两个Session，同时进行swebp测评，容器label拼接正常

```text
【Session1】
Starting container with command: docker run -d --name minisweagent-9084e9a9 -w / --rm --entrypoint= --label ais_bench.swebench_pro.session=04fd779200ec4701a11927ea46dc40cb  

【Session2】
Starting container with command: docker run -d --name minisweagent-cd19b7e8 -w / --rm --entrypoint= --label ais_bench.swebench_pro.session=3db54755680a4874b619b65c6e62f094 
```

步骤二：手动终止 Session2 的测评任务，触发清理 Session2 临时容器的动作
```text
 [BYF_TEST] cleanup_swebench_pro_containers, session_id=3db54755680a4874b619b65c6e62f094
```

步骤三：观察 Session1 的测评任务，测评容器没有被清理，测评流程不受影响
```text
session_id=04fd779200ec4701a11927ea46dc40cb
Exit Status  Count  Most recent instances 
Submitted    2        instance_gravitational__teleport-c782838c3a174fdff80...
Overall Progress ($0.00)  2/2 100% 0:09:38 eta: 0:00:00
[2026-06-30 19:52:02,310] [ais_bench] [[32mINFO[0m] SWEBenchPro infer time: 580.26s
[2026-06-30 19:52:02,358] [ais_bench] [[32mINFO[0m] Task state is finish, exit loop
```

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [x] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [x] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
