### PR TITLE
[Bugfix] Add .gitignore rules to exclude downloaded dataset data files in ais_bench/datasets/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ test_reports
 .venv
 .eggs
 ais_bench_benchmark.egg-info
+
+# Ignore downloaded dataset data files (keep Python source modules)
+ais_bench/datasets/**
+!ais_bench/datasets/**/*.py

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ ais_bench_benchmark.egg-info
 
 # Ignore downloaded dataset data files (keep Python source modules)
 ais_bench/datasets/**
+!ais_bench/datasets/**/
 !ais_bench/datasets/**/*.py


### PR DESCRIPTION
 #  PR Type / PR类型
  - [x] Bugfix（Bug 修复）
  - [ ] Feature（功能新增）
  - [ ] Docs（文档更新）
  - [ ] CI/CD（持续集成/持续部署）
  - [ ] Refactor（代码重构）
  - [ ] Perf（性能优化）
  - [ ] Dependency（依赖项更新）
  - [ ] Test-Cases（测试用例更新）
  - [ ] Other（其他）


 #  🔍 Motivation / 变更动机

  数据集（如 GSM8K、GPQA、AIME2025 等）下载后默认存放在 ais_bench/datasets/ 目录下，产生大量 .jsonl、.csv、.zip 等数据文件。由于 .gitignore 未覆盖该目录，这些数据文件会作为 untracked files
  出现在 git status 中，影响日常开发的代码审查和提交体验。

  # 📝 Modification / 修改内容

  在 .gitignore 中新增 32行规则：

  - ais_bench/datasets/** — 忽略 ais_bench/datasets/ 下所有文件及子目录
  - !ais_bench/datasets/**/*.py — 例外放行 .py 源码文件（如 __init__.py、synthetic_config.py），确保 Python 模块仍可被 git 正常跟踪

  这样后续下载任何新数据集的数据文件都会被自动忽略，无需手动维护。

  # 📐 Associated Test Results / 关联测试结果

仅为 .gitignore 变更，不涉及代码逻辑

 #  ⚠️  BC-breaking (Optional) / 向后不兼容变更（可选）

  无。

  # ⚠️  Performance degradation (Optional) / 性能下降（可选）

  无。

