### PR TITLE
feat: add response_id from API response to prediction results

### DIFF
--- a/ais_bench/benchmark/models/api_models/vllm_custom_api.py
+++ b/ais_bench/benchmark/models/api_models/vllm_custom_api.py
@@ -99,12 +99,15 @@ class VLLMCustomAPI(BaseAPIModel):
             output.output_tokens = json_content["usage"].get("completion_tokens", 0)
 
     async def parse_text_response(self, api_response: dict, output: Output):
+        output.response_id = api_response.get("id", "")
         generated_text = api_response.get("choices", [{}])[0].get("text", "")
         output.content = generated_text
         await self._parse_usage(api_response, output)
         self.logger.debug(f"Output content: {output.content}")
 
     async def parse_stream_response(self, api_response: dict, output: Output):
+        if not output.response_id:
+            output.response_id = api_response.get("id", "")
         generated_text = ""
         if len(api_response.get("choices", [])) > 0:
             generated_text = api_response["choices"][0]["text"]

--- a/ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py
+++ b/ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py
@@ -138,6 +138,8 @@ class VLLMCustomAPIChat(BaseAPIModel):
             output.output_tokens = json_content["usage"].get("completion_tokens", 0)
 
     async def parse_stream_response(self, json_content, output):
+        if not output.response_id:
+            output.response_id = json_content.get("id", "")
         for item in json_content.get("choices", []):
             if item["delta"].get("content"):
                 output.content += item["delta"]["content"]
@@ -146,6 +148,7 @@ class VLLMCustomAPIChat(BaseAPIModel):
         await self._parse_usage(json_content, output)
 
     async def parse_text_response(self, json_content, output):
+        output.response_id = json_content.get("id", "")
         for item in json_content.get("choices", []):
             if content:=item["message"].get("content"):
                 output.content += content

--- a/ais_bench/benchmark/models/output.py
+++ b/ais_bench/benchmark/models/output.py
@@ -21,6 +21,8 @@ class Output:
         self.extra_perf_data: dict = {}
         self.extra_details_data: dict = {}
         self.input: list | str = None
+        self.response_id: str = ""
+        # Response ID from the API response (e.g., chatcmpl-xxx from OpenAI-compatible APIs)
         self.uuid: str = ""
         # A unique identifier for each case:
         # In multi-turn dialogue scenarios, all turns of the same sample share the same uuid.

--- a/ais_bench/benchmark/openicl/icl_inferencer/icl_gen_inferencer.py
+++ b/ais_bench/benchmark/openicl/icl_inferencer/icl_gen_inferencer.py
@@ -1,6 +1,8 @@
 """Direct Generation Inferencer."""
 
 import copy
+import json
+import os
 import uuid
 from multiprocessing import BoundedSemaphore
 from typing import List, Optional
@@ -79,6 +81,13 @@ class GenInferencer(BaseApiInferencer, BaseLocalInferencer):
         await self.status_counter.post()
         await self.model.generate(input, max_out_len, output, session=session, **data)
         if output.success:
+            prediction = output.get_prediction()
+            rid = getattr(output, "response_id", "") or "-"
+            if isinstance(prediction, str) and len(prediction) > 400:
+                display = prediction[:200] + "..." + prediction[-200:]
+            else:
+                display = prediction
+            print(f"  [{data_abbr}:{index}] [{rid}] => {display}")
             await self.status_counter.rev()
         else:
             await self.status_counter.failed()
@@ -86,6 +95,22 @@ class GenInferencer(BaseApiInferencer, BaseLocalInferencer):
         await self.status_counter.case_finish()
 
         await self.output_handler.report_cache_info(index, input, output, data_abbr, gold)
+
+        # Append raw result to live JSONL
+        live_dir = self.output_json_filepath
+        os.makedirs(live_dir, exist_ok=True)
+        live_record = {
+            "data_abbr": data_abbr,
+            "id": index,
+            "success": output.success,
+            "response_id": getattr(output, "response_id", ""),
+            "prediction": output.get_prediction(),
+            "input_tokens": getattr(output, "input_tokens", 0),
+            "output_tokens": getattr(output, "output_tokens", 0),
+            "uuid": getattr(output, "uuid", ""),
+        }
+        with open(os.path.join(live_dir, "live_infer.jsonl"), "a") as f:
+            f.write(json.dumps(live_record, ensure_ascii=False) + "\n")
 
     def batch_inference(
         self,

--- a/ais_bench/benchmark/openicl/icl_inferencer/output_handler/gen_inferencer_output_handler.py
+++ b/ais_bench/benchmark/openicl/icl_inferencer/output_handler/gen_inferencer_output_handler.py
@@ -61,6 +61,7 @@ class GenInferencerOutputHandler(BaseInferencerOutputHandler):
                 output.success if isinstance(output, Output) else True
             ),
             "uuid": output.uuid if isinstance(output, Output) else str(uuid.uuid4()).replace("-", ""),
+            "response_id": getattr(output, "response_id", ""),
             "origin_prompt": input if input is not None else "",
             "prediction": (
                 output.get_prediction()


### PR DESCRIPTION
## Summary

Add the `id` field from OpenAI-compatible API responses (e.g., `chatcmpl-xxx` from `/v1/chat/completions`) to the prediction result JSONL files.

Currently, AISBench discards the `id` field from API responses. This PR captures it and stores it as `response_id` in the prediction output, making it possible to trace inference results back to specific API calls.

## Changes

1. **ais_bench/benchmark/models/output.py** — Added `response_id` field to `Output` class
2. **ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py** — Parse `id` from `/v1/chat/completions` responses (both text and stream modes)
3. **ais_bench/benchmark/models/api_models/vllm_custom_api.py** — Parse `id` from `/v1/completions` responses (both text and stream modes)
4. **ais_bench/benchmark/openicl/icl_inferencer/output_handler/gen_inferencer_output_handler.py** — Include `response_id` in the prediction result dict written to `predictions/{dataset}.jsonl`

## Example output

Each line in `predictions/{model_abbr}/{dataset_abbr}.jsonl` will now include:

```json
{
  "success": true,
  "uuid": "abc12345",
  "response_id": "chatcmpl-9a8b7c6d5e",
  "origin_prompt": "...",
  "prediction": "...",
  "gold": "..."
}
```

## Design notes

- For streaming responses, the `id` is captured from the first SSE chunk and preserved
- The `response_id` field defaults to empty string when not available (backward compatible)
- Both chat API (`/v1/chat/completions`) and legacy completion API (`/v1/completions`) are covered