### PR TITLE
【feature】Support Multi Lora Infer

### DIFF
--- a/ais_bench/benchmark/models/api_models/mindie_stream_api.py
+++ b/ais_bench/benchmark/models/api_models/mindie_stream_api.py
@@ -111,6 +111,12 @@ class MindieStreamApi(BaseAPIModel):
         lora_model_name = self._resolve_lora_model_name(output)
         if lora_model_name:
             generation_kwargs["adapter_id"] = lora_model_name
+        # Debug: log LoRA routing decision for observability.
+        self.logger.debug(
+            f"[Multi-LoRA] data_id={getattr(output, 'data_id', None)} "
+            f"lora_model_name={lora_model_name} "
+            f"adapter_id_in_request_body={lora_model_name}"
+        )
         request_body = dict(inputs=input_data, stream=True, parameters=generation_kwargs)
         return request_body
 

--- a/ais_bench/benchmark/models/api_models/mindie_stream_api.py
+++ b/ais_bench/benchmark/models/api_models/mindie_stream_api.py
@@ -1,3 +1,5 @@
+import json
+import os
 import urllib
 from typing import Dict, Optional, Union
 
@@ -64,6 +66,8 @@ class MindieStreamApi(BaseAPIModel):
         self.url = self._get_url()
         self.template_parser = LMTemplateParser(meta_template)
         # For non-chat APIs, the actual prompt is passed as a plain string (just like with offline models), so LMTemplateParser is used.
+        # Multi-LoRA: load data_id -> lora adapter name map from generation_kwargs (optional).
+        self.lora_data_map = self._load_lora_data_map(generation_kwargs)
 
     def _get_url(self) -> str:
         endpoint = "infer"
@@ -71,12 +75,42 @@ class MindieStreamApi(BaseAPIModel):
         self.logger.debug(f"Request url: {url}")
         return url
 
+    @staticmethod
+    def _load_lora_data_map(generation_kwargs):
+        """Load data_id -> LoRA adapter name mapping JSON file."""
+        if not generation_kwargs:
+            return None
+        lora_data_map_file = generation_kwargs.get("lora_data_map_file")
+        if not (isinstance(lora_data_map_file, str) and lora_data_map_file):
+            return None
+        file_path = os.path.abspath(lora_data_map_file)
+        if not os.path.exists(file_path):
+            return None
+        try:
+            with open(file_path, "r") as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+    def _resolve_lora_model_name(self, output: Output):
+        """Look up LoRA adapter name for the current sample's data_id."""
+        if not self.lora_data_map:
+            return None
+        data_id = getattr(output, "data_id", None)
+        if data_id is None:
+            return None
+        return self.lora_data_map.get(f"{data_id}")
+
     async def get_request_body(
         self, input_data: PromptType, max_out_len: int, output: Output, **args
     ):
         output.input = input_data
         generation_kwargs = self.generation_kwargs.copy()
         generation_kwargs.update({"max_new_tokens": max_out_len})
+        # Multi-LoRA: MindIE native API uses ``parameters.adapter_id`` for LoRA selection.
+        lora_model_name = self._resolve_lora_model_name(output)
+        if lora_model_name:
+            generation_kwargs["adapter_id"] = lora_model_name
         request_body = dict(inputs=input_data, stream=True, parameters=generation_kwargs)
         return request_body
 

--- a/ais_bench/benchmark/models/api_models/tgi_api.py
+++ b/ais_bench/benchmark/models/api_models/tgi_api.py
@@ -113,6 +113,12 @@ class TGICustomAPI(BaseAPIModel):
         lora_model_name = self._resolve_lora_model_name(output)
         if lora_model_name:
             generation_kwargs["adapter_id"] = lora_model_name
+        # Debug: log LoRA routing decision for observability.
+        self.logger.debug(
+            f"[Multi-LoRA] data_id={getattr(output, 'data_id', None)} "
+            f"lora_model_name={lora_model_name} "
+            f"adapter_id_in_request_body={lora_model_name}"
+        )
         request_body = dict(inputs=input_data, parameters=generation_kwargs)
         return request_body
 

--- a/ais_bench/benchmark/models/api_models/tgi_api.py
+++ b/ais_bench/benchmark/models/api_models/tgi_api.py
@@ -1,3 +1,5 @@
+import json
+import os
 import urllib
 from typing import Dict, Optional, Union
 
@@ -65,12 +67,40 @@ class TGICustomAPI(BaseAPIModel):
         self.url = self._get_url()
         self.template_parser = LMTemplateParser(meta_template)
         # For non-chat APIs, the actual prompt is passed as a plain string (just like with offline models), so LMTemplateParser is used.
+        # Multi-LoRA: load data_id -> lora adapter name map from generation_kwargs (optional).
+        self.lora_data_map = self._load_lora_data_map(generation_kwargs)
 
     def _get_url(self) -> str:
         endpoint = "generate_stream" if self.stream else "generate"
         url = urllib.parse.urljoin(self.base_url, endpoint)
         self.logger.debug(f"Request url: {url}")
         return url
+
+    @staticmethod
+    def _load_lora_data_map(generation_kwargs):
+        """Load data_id -> LoRA adapter name mapping JSON file."""
+        if not generation_kwargs:
+            return None
+        lora_data_map_file = generation_kwargs.get("lora_data_map_file")
+        if not (isinstance(lora_data_map_file, str) and lora_data_map_file):
+            return None
+        file_path = os.path.abspath(lora_data_map_file)
+        if not os.path.exists(file_path):
+            return None
+        try:
+            with open(file_path, "r") as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+    def _resolve_lora_model_name(self, output: Output):
+        """Look up LoRA adapter name for the current sample's data_id."""
+        if not self.lora_data_map:
+            return None
+        data_id = getattr(output, "data_id", None)
+        if data_id is None:
+            return None
+        return self.lora_data_map.get(f"{data_id}")
 
     async def get_request_body(
         self, input_data: PromptType, max_out_len: int, output: Output, **args
@@ -79,6 +109,10 @@ class TGICustomAPI(BaseAPIModel):
 
         generation_kwargs = self.generation_kwargs.copy()
         generation_kwargs.update({"max_new_tokens": max_out_len})
+        # Multi-LoRA: TGI uses ``parameters.adapter_id`` for LoRA selection.
+        lora_model_name = self._resolve_lora_model_name(output)
+        if lora_model_name:
+            generation_kwargs["adapter_id"] = lora_model_name
         request_body = dict(inputs=input_data, parameters=generation_kwargs)
         return request_body
 

--- a/ais_bench/benchmark/models/api_models/vllm_custom_api.py
+++ b/ais_bench/benchmark/models/api_models/vllm_custom_api.py
@@ -1,3 +1,5 @@
+import json
+import os
 import urllib
 from typing import Dict, Optional, Union
 from ais_bench.benchmark.registry import MODELS
@@ -70,6 +72,8 @@ class VLLMCustomAPI(BaseAPIModel):
         self.url = self._get_url()
         self.template_parser = LMTemplateParser(meta_template)
         # For non-chat APIs, the actual prompt is passed as a plain string (just like with offline models), so LMTemplateParser is used.
+        # Multi-LoRA: load data_id -> lora adapter name map from generation_kwargs (optional).
+        self.lora_data_map = self._load_lora_data_map(generation_kwargs)
 
     def _get_url(self) -> str:
         endpoint = "v1/completions"
@@ -77,13 +81,45 @@ class VLLMCustomAPI(BaseAPIModel):
         self.logger.debug(f"Request url: {url}")
         return url
 
+    @staticmethod
+    def _load_lora_data_map(generation_kwargs):
+        """Load data_id -> LoRA adapter name mapping JSON file.
+
+        Returns None when ``lora_data_map_file`` is absent/invalid; the caller
+        then falls back to the base model without error.
+        """
+        if not generation_kwargs:
+            return None
+        lora_data_map_file = generation_kwargs.get("lora_data_map_file")
+        if not (isinstance(lora_data_map_file, str) and lora_data_map_file):
+            return None
+        file_path = os.path.abspath(lora_data_map_file)
+        if not os.path.exists(file_path):
+            return None
+        try:
+            with open(file_path, "r") as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+    def _resolve_lora_model_name(self, output: Output):
+        """Look up LoRA adapter name for the current sample's data_id."""
+        if not self.lora_data_map:
+            return None
+        data_id = getattr(output, "data_id", None)
+        if data_id is None:
+            return None
+        return self.lora_data_map.get(f"{data_id}")
+
     async def get_request_body(
         self, input_data: PromptType, max_out_len: int, output: Output, **args
     ):
         output.input = input_data
         generation_kwargs = self.generation_kwargs.copy()
         generation_kwargs.update({"max_tokens": max_out_len})
-        generation_kwargs.update({"model": self.model})
+        # Multi-LoRA: override model field with the resolved LoRA adapter name.
+        lora_model_name = self._resolve_lora_model_name(output)
+        generation_kwargs.update({"model": lora_model_name if lora_model_name else self.model})
         request_body = dict(
             prompt=input_data,
             stream=self.stream,

--- a/ais_bench/benchmark/models/api_models/vllm_custom_api.py
+++ b/ais_bench/benchmark/models/api_models/vllm_custom_api.py
@@ -119,7 +119,15 @@ class VLLMCustomAPI(BaseAPIModel):
         generation_kwargs.update({"max_tokens": max_out_len})
         # Multi-LoRA: override model field with the resolved LoRA adapter name.
         lora_model_name = self._resolve_lora_model_name(output)
-        generation_kwargs.update({"model": lora_model_name if lora_model_name else self.model})
+        lora_active = lora_model_name is not None
+        actual_model_in_body = lora_model_name if lora_active else self.model
+        generation_kwargs.update({"model": actual_model_in_body})
+        # Debug: log LoRA routing decision for observability.
+        self.logger.debug(
+            f"[Multi-LoRA] data_id={getattr(output, 'data_id', None)} "
+            f"lora_model_name={lora_model_name} "
+            f"model_in_request_body={actual_model_in_body}"
+        )
         request_body = dict(
             prompt=input_data,
             stream=self.stream,

--- a/ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py
+++ b/ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py
@@ -160,7 +160,15 @@ class VLLMCustomAPIChat(BaseAPIModel):
         generation_kwargs.update({"max_tokens": max_out_len})
         # Multi-LoRA: override model field with the resolved LoRA adapter name.
         lora_model_name = self._resolve_lora_model_name(output)
-        generation_kwargs.update({"model": lora_model_name if lora_model_name else self.model})
+        lora_active = lora_model_name is not None
+        actual_model_in_body = lora_model_name if lora_active else self.model
+        generation_kwargs.update({"model": actual_model_in_body})
+        # Debug: log LoRA routing decision for observability.
+        self.logger.debug(
+            f"[Multi-LoRA] data_id={getattr(output, 'data_id', None)} "
+            f"lora_model_name={lora_model_name} "
+            f"model_in_request_body={actual_model_in_body}"
+        )
         if args.get("tools"):
             generation_kwargs.update({"tools": args["tools"]})
 

--- a/ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py
+++ b/ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py
@@ -1,3 +1,5 @@
+import json
+import os
 import urllib
 from typing import Dict, Optional, Union
 
@@ -91,12 +93,49 @@ class VLLMCustomAPIChat(BaseAPIModel):
         self.url = self._get_url()
         self.template_parser = APITemplateParser(self.meta_template)
         self.session = None
+        # Multi-LoRA: load data_id -> lora adapter name map from generation_kwargs (optional).
+        self.lora_data_map = self._load_lora_data_map(generation_kwargs)
 
     def _get_url(self) -> str:
         endpoint = "v1/chat/completions"
         url = urllib.parse.urljoin(self.base_url, endpoint)
         self.logger.debug(f"Request url: {url}")
         return url
+
+    @staticmethod
+    def _load_lora_data_map(generation_kwargs):
+        """Load data_id -> LoRA adapter name mapping JSON file.
+
+        Returns None when ``lora_data_map_file`` is absent/invalid; the caller
+        then falls back to the base model without error.
+        """
+        if not generation_kwargs:
+            return None
+        lora_data_map_file = generation_kwargs.get("lora_data_map_file")
+        if not (isinstance(lora_data_map_file, str) and lora_data_map_file):
+            return None
+        file_path = os.path.abspath(lora_data_map_file)
+        if not os.path.exists(file_path):
+            return None
+        try:
+            with open(file_path, "r") as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+    def _resolve_lora_model_name(self, output: RequestOutput):
+        """Look up LoRA adapter name for the current sample's data_id.
+
+        ``output.data_id`` is set by ``GenInferencer.do_request``; if not
+        available or not in the map, returns None and the caller falls back
+        to the base model.
+        """
+        if not self.lora_data_map:
+            return None
+        data_id = getattr(output, "data_id", None)
+        if data_id is None:
+            return None
+        return self.lora_data_map.get(f"{data_id}")
 
     async def get_request_body(
         self, input: PromptType, max_out_len: int, output: RequestOutput, **args
@@ -119,7 +158,9 @@ class VLLMCustomAPIChat(BaseAPIModel):
         output.input = messages
         generation_kwargs = self.generation_kwargs.copy()
         generation_kwargs.update({"max_tokens": max_out_len})
-        generation_kwargs.update({"model": self.model})
+        # Multi-LoRA: override model field with the resolved LoRA adapter name.
+        lora_model_name = self._resolve_lora_model_name(output)
+        generation_kwargs.update({"model": lora_model_name if lora_model_name else self.model})
         if args.get("tools"):
             generation_kwargs.update({"tools": args["tools"]})
 

--- a/ais_bench/benchmark/openicl/icl_inferencer/icl_gen_inferencer.py
+++ b/ais_bench/benchmark/openicl/icl_inferencer/icl_gen_inferencer.py
@@ -76,6 +76,7 @@ class GenInferencer(BaseApiInferencer, BaseLocalInferencer):
         uid = str(uuid.uuid4()).replace("-", "")
         output = RequestOutput(self.perf_mode)
         output.uuid = uid
+        output.data_id = index
         await self.status_counter.post()
         await self.model.generate(input, max_out_len, output, session=session, **data)
         if output.success:

--- a/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py
+++ b/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_full.py
@@ -26,8 +26,8 @@ models = [
     )
 ]
 
-SWEBP_SCRIPT_PATH_ABS = ""
-SWEBP_DOCKER_PATH_ABS = ""
+SWEBP_SCRIPT_PATH_ABS = "/opt/src/SWE-bench_Pro-os/run_scripts"  # 必须指定, agent runtime容器中 "/opt/src/SWE-bench_Pro-os/run_scripts"为默认路径
+SWEBP_DOCKER_PATH_ABS = "/opt/src/SWE-bench_Pro-os/dockerfiles"  # 必须指定，agent runtime容器中 "/opt/src/SWE-bench_Pro-os/dockerfiles"为默认路径
 
 datasets = [
     dict(

--- a/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py
+++ b/ais_bench/configs/swe_bench_pro_examples/mini_swe_agent_swe_bench_pro_mini.py
@@ -26,8 +26,8 @@ models = [
     )
 ]
 
-SWEBP_SCRIPT_PATH_ABS = ""
-SWEBP_DOCKER_PATH_ABS = ""
+SWEBP_SCRIPT_PATH_ABS = "/opt/src/SWE-bench_Pro-os/run_scripts"  # 必须指定, agent runtime容器中 "/opt/src/SWE-bench_Pro-os/run_scripts"为默认路径
+SWEBP_DOCKER_PATH_ABS = "/opt/src/SWE-bench_Pro-os/dockerfiles"  # 必须指定，agent runtime容器中 "/opt/src/SWE-bench_Pro-os/dockerfiles"为默认路径
 
 datasets = [
     dict(

--- a/docs/source_en/base_tutorials/all_params/models.md
+++ b/docs/source_en/base_tutorials/all_params/models.md
@@ -97,6 +97,45 @@ The description of configurable parameters for the service-oriented inference ba
 - When using an IPv6 literal (such as `::1` or `2001:db8::1`) as `host_ip`, the tool will automatically wrap it in brackets in the generated URL (for example, `http://[2001:db8::1]:8080/`), so you do not need to manually add brackets in the configuration.
 
 
+### Multi-LoRA Routing
+
+Route each sample to the correct LoRA adapter by `data_id` (dataset row index). Supported backends: `VLLMCustomAPIChat`, `VLLMCustomAPI`, `TGICustomAPI`, `MindieStreamApi`. No new model class is required; just add `lora_data_map_file` under `generation_kwargs`.
+
+```python
+from ais_bench.benchmark.models import VLLMCustomAPIChat
+
+models = [
+    dict(
+        type=VLLMCustomAPIChat,
+        abbr='vllm-chat-lora',
+        host_ip='127.0.0.1', host_port=8080,
+        generation_kwargs=dict(
+            temperature=0,
+            lora_data_map_file='./lora_data_map.json',
+        ),
+    ),
+]
+```
+
+`lora_data_map.json` (key = stringified `data_id`, value = LoRA adapter name registered on the server):
+
+```json
+{"0": "LoraAdapter1", "1": "LoraAdapter2", "6": "LoraAdapter1"}
+```
+
+> ⚠️ **Recommendation**: Use an **absolute path** for `lora_data_map_file` to avoid resolution failures caused by different working directories.
+
+| Backend class | Where LoRA is set in the request body | Corresponding preset configs |
+| --- | --- | --- |
+| `VLLMCustomAPIChat` | Overwrites `model` field with the adapter name | `vllm_api_general_chat`, `vllm_api_stream_chat`, `vllm_api_stream_chat_multiturn`, `vllm_api_function_call_chat` |
+| `VLLMCustomAPI` | Overwrites `model` field with the adapter name | `vllm_api_general`, `vllm_api_general_stream` |
+| `TGICustomAPI` | Sets `parameters.adapter_id` to the adapter name | `tgi_api_general` |
+| `MindieStreamApi` | Sets `parameters.adapter_id` to the adapter name | `mindie_stream_api_general` |
+
+- If the `data_id` is not in the mapping, the JSON file is missing/invalid, or `data_id` is absent → the request silently falls back to the base model (no error).
+- Run with `--debug` (or set `verbose=True` in the model config) to log each routing decision as `[Multi-LoRA] data_id=... lora_model_name=...`.
+
+
 ## Local Model Backend
 
 | Model Configuration Name | Description | Prerequisites for Use | Supported Prompt Formats (String Format or Dialogue Format) | Corresponding Source Code Configuration File Path |

--- a/docs/source_zh_cn/base_tutorials/all_params/models.md
+++ b/docs/source_zh_cn/base_tutorials/all_params/models.md
@@ -90,6 +90,44 @@ models = [
 - 服务化推理评测 API 默认使用的服务地址为 `localhost:8080`。实际使用时需根据实际部署修改为服务化后端的 IP 和端口。
 - 当使用 IPv6 字面量（如 `::1`、`2001:db8::1`）作为 `host_ip` 时，工具会在生成的访问 URL 中自动为其添加方括号（例如 `http://[2001:db8::1]:8080/`），无需在配置中手动编写方括号。
 
+### Multi-LoRA 路由
+
+按数据样本的 `data_id`（数据集行号）自动路由到对应的 LoRA 适配器。支持的模型类：`VLLMCustomAPIChat`、`VLLMCustomAPI`、`TGICustomAPI`、`MindieStreamApi`。无需新增模型类，只需要在 `generation_kwargs` 下增加 `lora_data_map_file` 参数即可启用。
+
+```python
+from ais_bench.benchmark.models import VLLMCustomAPIChat
+
+models = [
+    dict(
+        type=VLLMCustomAPIChat,
+        abbr='vllm-chat-lora',
+        host_ip='127.0.0.1', host_port=8080,
+        generation_kwargs=dict(
+            temperature=0,
+            lora_data_map_file='./lora_data_map.json',
+        ),
+    ),
+]
+```
+
+`lora_data_map.json`（key 为字符串化的 `data_id`，value 为服务端已注册的 LoRA 适配器名）：
+
+```json
+{"0": "LoraAdapter1", "1": "LoraAdapter2", "6": "LoraAdapter1"}
+```
+
+> ⚠️ **建议**：`lora_data_map_file` 路径**最好使用绝对路径**，避免不同工作目录导致的相对路径解析失败或路径错位。
+
+| 后端类 | 请求体中 LoRA 字段位置 | 对应预设配置 |
+| --- | --- | --- |
+| `VLLMCustomAPIChat` | 覆写 `model` 字段为适配器名 | `vllm_api_general_chat`、`vllm_api_stream_chat`、`vllm_api_stream_chat_multiturn`、`vllm_api_function_call_chat` |
+| `VLLMCustomAPI` | 覆写 `model` 字段为适配器名 | `vllm_api_general`、`vllm_api_general_stream` |
+| `TGICustomAPI` | 设置 `parameters.adapter_id` 为适配器名 | `tgi_api_general` |
+| `MindieStreamApi` | 设置 `parameters.adapter_id` 为适配器名 | `mindie_stream_api_general` |
+
+- `data_id` 不在映射中、JSON 文件缺失 / 损坏、或 `data_id` 缺失时，请求静默回退到 base 模型，不抛异常。
+- 启动时加 `--debug`（或在模型配置设 `verbose=True`）即可按 case 打印 `[Multi-LoRA] data_id=... lora_model_name=...` 日志，便于观测路由命中情况。
+
 ## 本地模型后端
 |模型配置名称|简介|使用前提|支持的prompt格式(字符串格式或对话格式)|对应源码配置文件路径|
 | --- | --- | --- | --- | --- |

--- a/docs/source_zh_cn/extended_benchmark/agent/harbor_bench.md
+++ b/docs/source_zh_cn/extended_benchmark/agent/harbor_bench.md
@@ -54,92 +54,37 @@
    ```
 > ⚠️注意：安装harbor会将datasets库的版本升级到4.0.0以上的版本，这会导致安装后报datasets库的依赖冲突，对于执行harbor测试terminal-bench相关数据集没有影响，但是如果你需要测试其他数据集，需要降低datasets库的版本。
 
-#### 2.2 一键准备方案（推荐）
-
-如果不想手动处理依赖冲突 / DinD 配置，推荐使用 **AISBench Agent Runtime 一键准备方案**。同一脚本同时覆盖**快速入门（在线）**与**离线场景（内网/隔离环境）**，通过 `--runtime-tar` / `--case-tar` / `--datasets` 自由组合，无需切换不同流程。
-
-```bash
-# 1. 物理机上准备数据集（已有可跳过）
-#    mini-* 数据集从 modelers 的 terminal-bench-2-offline-mini 仓库
-#    用 sparse-checkout 取 terminal-bench-2-offline-selected_<X.XX>/ 子目录
-mkdir -p /data/datasets/harbor/mini-0.10
-git clone --depth 1 --filter=blob:none --sparse \
-    https://modelers.cn/AISBench/terminal-bench-2-offline-mini.git /tmp/tb2m
-cd /tmp/tb2m
-git sparse-checkout set terminal-bench-2-offline-selected_0.10
-mkdir -p /data/datasets/harbor/mini-0.10/dataset
-mv terminal-bench-2-offline-selected_0.10 /data/datasets/harbor/mini-0.10/dataset
-# 此时 /data/datasets/harbor/mini-0.10/dataset/ 才是真正的数据集目录
-
-# 2. 准备 case 镜像 tar 包
-#    在线场景：从 obs://aisbench/terminal-bench-2-images/ 下载对应 tier 的 tar
-#    离线场景：由维护者 build + upload 后，从 OBS / 内部代理服务器下载，或 U 盘 / scp 拷贝
-#      - tar 包获取方式：
-#        - 让维护者跑 build_image_agent_runtime.sh --upload 1 上传到 OBS 后从 OBS 下载
-#        - 在能访问外网的机器上 docker save ghcr.io/aisbench/agent-runtime:<tag> -o agent-runtime.tar.gz 后拷贝
-curl -fsSL <OBS>/terminal-bench-2-offline-prepared-images-selected-0.10_x86_64.tar.gz \
-    -o /data/cases/case-tb2-mini-0.10.tar.gz
-# 离线场景放置路径示例：
-#   /opt/aisbench/agent-runtime.tar.gz
-#   /opt/aisbench/case-tb2-mini-0.10.tar.gz
-#   /data/datasets/harbor/mini-0.10/terminal-bench-2-offline-selected_0.10/
-
-# 3. 物理机上一键起 runtime 容器
-#    快速入门（在线）：省略 --runtime-tar / --case-tar 时，runtime 镜像从 ghcr.io 拉取，case 镜像需自行 docker load
-#    离线场景：通过 --runtime-tar 跳过外网拉取，--case-tar 在 bootstrap 时一次性加载到容器内
-#    --datasets  挂载数据集 + 注入 env var
-#    --case-tar  加载 case 镜像到容器内 docker daemon（可多次，可传目录）
-#    --runtime-tar / --runtime-image 可选
-#    快速入门（在线）示例：
-curl -fsSL https://aisbench.obs.cn-north-4.myhuaweicloud.com/agent/ais_bench_agent_bootstrap.sh \
-    | bash -s -- \
-        --datasets /data/datasets/harbor/mini-0.10/dataset \
-        --case-tar  /data/cases/case-tb2-mini-0.10.tar.gz
-
-#    离线场景示例（runtime + case 镜像都在本地）：
-bash ais_bench_agent_bootstrap.sh \
-    --datasets /data/datasets/harbor/mini-0.10/terminal-bench-2-offline-selected_0.10 \
-    --runtime-tar /opt/aisbench/agent-runtime.tar.gz \
-    --case-tar /opt/aisbench/case-tb2-mini-0.10.tar.gz
-
-#    离线场景：也可一次加载多个 case 镜像（可多次 --case-tar 或传目录）
-bash ais_bench_agent_bootstrap.sh \
-    --datasets /data/datasets/harbor/mini-0.10/terminal-bench-2-offline-selected_0.10 \
-    --runtime-tar /opt/aisbench/agent-runtime.tar.gz \
-    --case-tar /opt/aisbench/case-tb2-mini-0.10.tar.gz \
-    --case-tar /opt/aisbench/case-tb2-mini-0.14.tar.gz \
-    --case-tar /opt/aisbench/case-tars/      # 目录下所有 tar 自动加载
-
-# 4. 进入容器（case 镜像已在内部，直接可用）
-docker exec -it ais_bench_agent bash
-
-# 5. （无需改 path）原生配置 path 已自动从 AISBENCH_AGENT_DATASET_PATH 读
-#    仅 vim 改 model_names / api_base
-vim ais_bench/configs/agent_example/harbor_terminal_bench_2_task.py
-
-# 6. 验证 runtime 就绪
-ais_bench_agent_doctor.sh harbor
-
-# 7. 用原生 ais_bench 命令跑测评
-agent_env harbor
-ais_bench ais_bench/configs/agent_example/harbor_terminal_bench_2_task.py --debug
+#### 2.2 在docker容器中安装
+1. 参考[镜像概览](https://github.com/AISBench/benchmark/blob/master/docker/OVERVIEW.zh.md)的“运行 Agent / 沙箱类测评（在容器内使用 Docker）”章节启动基于**python3.12及以上版本镜像（2026.7.1之后发布的镜像才支持）**的容器。
+2. 在容器内执行以下命令安装 Harbor：
+   ```bash
+   pip install harbor==0.6.1 --break-system-packages
+   ```
+3. 编辑harbor中的docker compose配置文件`/usr/local/lib/python3.12/dist-packages/harbor/environments/docker/docker-compose-base.yaml`
+```yaml
+services:
+  main:
+    network_mode: host # 共享主机网络，必须配置
+    security_opt: # 模式 B 启动的容器需要配置
+      - seccomp=unconfined
+    volumes:
+      - type: bind
+        source: ${HOST_VERIFIER_LOGS_PATH}
+        target: ${ENV_VERIFIER_LOGS_PATH}
+      - type: bind
+        source: ${HOST_AGENT_LOGS_PATH}
+        target: ${ENV_AGENT_LOGS_PATH}
+      - type: bind
+        source: ${HOST_ARTIFACTS_PATH}
+        target: ${ENV_ARTIFACTS_PATH}
+    deploy:
+      resources:
+        limits:
+          cpus: ${CPUS}
+          memory: ${MEMORY}
 ```
+> ⚠️注意：安装harbor会将datasets库的版本升级到4.0.0以上的版本，这会导致安装后报datasets库的依赖冲突，对于执行harbor测试terminal-bench相关数据集没有影响，但是如果你需要测试其他数据集，需要降低datasets库的版本。
 
-切到其它数据集（mini-0.14 / mini-0.20 / full）：销毁旧容器 → 重新 `bash ... --datasets <新路径> --case-tar <新tar>` 起容器。
-
-`--runtime-tar` / `--case-tar` / `--datasets` 三者完全独立，可任意组合。三个都不会触发任何 `docker pull` 或 `curl` 到外网的操作；在快速入门（在线）场景中省略 `--runtime-tar`，脚本会自动从网络拉取 runtime 镜像。
-
-`--case-tar` 在 A/B 两种模式下都生效：脚本会 `docker cp` 把 tar 拷进 runtime 容器，再在容器内 `docker load` 加载到该容器的 docker daemon。
-
-该方案解决了以下痛点：
-- **依赖冲突**：harbor==0.6.1 强制升级 datasets 到 4.0+ 会污染主环境，runtime 镜像用独立 venv 隔离
-- **容器配置易错**：DinD 模式 A/B、`--cgroupns=host`、`daemon.json`、seccomp 自动处理
-- **数据集版本频繁**：数据集与 case 镜像均不烤入 runtime 镜像，由用户在物理机准备后通过 `--datasets` 挂载 / `--case-tar` 加载，避免镜像频繁过期
-- **case 镜像管理**：通过 `--case-tar` 在 bootstrap 时一次性加载到容器内，容器内无需手动 `docker pull` / `docker load`
-- **环境无验证**：`doctor.sh` 在跑测评前验证 runtime 就绪，失败时给精确修复指引
-- **离线部署**：支持 `--runtime-tar <PATH>` 跳过 runtime 镜像的网络获取；支持 `--case-tar <PATH>` 加载 case 镜像到容器内（可多次，可传目录）。内网隔离环境可全程零外网请求
-
-方案原理与脚本实现见 [`docker/agent_runtime/`](../../../docker/agent_runtime/README.md)。
 
 ### 3. 准备AISBench修改过的Terminal-Bench-2数据集和对应镜像
 AISBench修改的数据集获取链接：https://github.com/AISBench/terminal-bench-2

--- a/docs/source_zh_cn/extended_benchmark/agent/harbor_bench.md
+++ b/docs/source_zh_cn/extended_benchmark/agent/harbor_bench.md
@@ -54,37 +54,92 @@
    ```
 > ⚠️注意：安装harbor会将datasets库的版本升级到4.0.0以上的版本，这会导致安装后报datasets库的依赖冲突，对于执行harbor测试terminal-bench相关数据集没有影响，但是如果你需要测试其他数据集，需要降低datasets库的版本。
 
-#### 2.2 在docker容器中安装
-1. 参考[镜像概览](https://github.com/AISBench/benchmark/blob/master/docker/OVERVIEW.zh.md)的“运行 Agent / 沙箱类测评（在容器内使用 Docker）”章节启动基于**python3.12及以上版本镜像（2026.7.1之后发布的镜像才支持）**的容器。
-2. 在容器内执行以下命令安装 Harbor：
-   ```bash
-   pip install harbor==0.6.1 --break-system-packages
-   ```
-3. 编辑harbor中的docker compose配置文件`/usr/local/lib/python3.12/dist-packages/harbor/environments/docker/docker-compose-base.yaml`
-```yaml
-services:
-  main:
-    network_mode: host # 共享主机网络，必须配置
-    security_opt: # 模式 B 启动的容器需要配置
-      - seccomp=unconfined
-    volumes:
-      - type: bind
-        source: ${HOST_VERIFIER_LOGS_PATH}
-        target: ${ENV_VERIFIER_LOGS_PATH}
-      - type: bind
-        source: ${HOST_AGENT_LOGS_PATH}
-        target: ${ENV_AGENT_LOGS_PATH}
-      - type: bind
-        source: ${HOST_ARTIFACTS_PATH}
-        target: ${ENV_ARTIFACTS_PATH}
-    deploy:
-      resources:
-        limits:
-          cpus: ${CPUS}
-          memory: ${MEMORY}
-```
-> ⚠️注意：安装harbor会将datasets库的版本升级到4.0.0以上的版本，这会导致安装后报datasets库的依赖冲突，对于执行harbor测试terminal-bench相关数据集没有影响，但是如果你需要测试其他数据集，需要降低datasets库的版本。
+#### 2.2 一键准备方案（推荐）
 
+如果不想手动处理依赖冲突 / DinD 配置，推荐使用 **AISBench Agent Runtime 一键准备方案**。同一脚本同时覆盖**快速入门（在线）**与**离线场景（内网/隔离环境）**，通过 `--runtime-tar` / `--case-tar` / `--datasets` 自由组合，无需切换不同流程。
+
+```bash
+# 1. 物理机上准备数据集（已有可跳过）
+#    mini-* 数据集从 modelers 的 terminal-bench-2-offline-mini 仓库
+#    用 sparse-checkout 取 terminal-bench-2-offline-selected_<X.XX>/ 子目录
+mkdir -p /data/datasets/harbor/mini-0.10
+git clone --depth 1 --filter=blob:none --sparse \
+    https://modelers.cn/AISBench/terminal-bench-2-offline-mini.git /tmp/tb2m
+cd /tmp/tb2m
+git sparse-checkout set terminal-bench-2-offline-selected_0.10
+mkdir -p /data/datasets/harbor/mini-0.10/dataset
+mv terminal-bench-2-offline-selected_0.10 /data/datasets/harbor/mini-0.10/dataset
+# 此时 /data/datasets/harbor/mini-0.10/dataset/ 才是真正的数据集目录
+
+# 2. 准备 case 镜像 tar 包
+#    在线场景：从 obs://aisbench/terminal-bench-2-images/ 下载对应 tier 的 tar
+#    离线场景：由维护者 build + upload 后，从 OBS / 内部代理服务器下载，或 U 盘 / scp 拷贝
+#      - tar 包获取方式：
+#        - 让维护者跑 build_image_agent_runtime.sh --upload 1 上传到 OBS 后从 OBS 下载
+#        - 在能访问外网的机器上 docker save ghcr.io/aisbench/agent-runtime:<tag> -o agent-runtime.tar.gz 后拷贝
+curl -fsSL <OBS>/terminal-bench-2-offline-prepared-images-selected-0.10_x86_64.tar.gz \
+    -o /data/cases/case-tb2-mini-0.10.tar.gz
+# 离线场景放置路径示例：
+#   /opt/aisbench/agent-runtime.tar.gz
+#   /opt/aisbench/case-tb2-mini-0.10.tar.gz
+#   /data/datasets/harbor/mini-0.10/terminal-bench-2-offline-selected_0.10/
+
+# 3. 物理机上一键起 runtime 容器
+#    快速入门（在线）：省略 --runtime-tar / --case-tar 时，runtime 镜像从 ghcr.io 拉取，case 镜像需自行 docker load
+#    离线场景：通过 --runtime-tar 跳过外网拉取，--case-tar 在 bootstrap 时一次性加载到容器内
+#    --datasets  挂载数据集 + 注入 env var
+#    --case-tar  加载 case 镜像到容器内 docker daemon（可多次，可传目录）
+#    --runtime-tar / --runtime-image 可选
+#    快速入门（在线）示例：
+curl -fsSL https://aisbench.obs.cn-north-4.myhuaweicloud.com/agent/ais_bench_agent_bootstrap.sh \
+    | bash -s -- \
+        --datasets /data/datasets/harbor/mini-0.10/dataset \
+        --case-tar  /data/cases/case-tb2-mini-0.10.tar.gz
+
+#    离线场景示例（runtime + case 镜像都在本地）：
+bash ais_bench_agent_bootstrap.sh \
+    --datasets /data/datasets/harbor/mini-0.10/terminal-bench-2-offline-selected_0.10 \
+    --runtime-tar /opt/aisbench/agent-runtime.tar.gz \
+    --case-tar /opt/aisbench/case-tb2-mini-0.10.tar.gz
+
+#    离线场景：也可一次加载多个 case 镜像（可多次 --case-tar 或传目录）
+bash ais_bench_agent_bootstrap.sh \
+    --datasets /data/datasets/harbor/mini-0.10/terminal-bench-2-offline-selected_0.10 \
+    --runtime-tar /opt/aisbench/agent-runtime.tar.gz \
+    --case-tar /opt/aisbench/case-tb2-mini-0.10.tar.gz \
+    --case-tar /opt/aisbench/case-tb2-mini-0.14.tar.gz \
+    --case-tar /opt/aisbench/case-tars/      # 目录下所有 tar 自动加载
+
+# 4. 进入容器（case 镜像已在内部，直接可用）
+docker exec -it ais_bench_agent bash
+
+# 5. （无需改 path）原生配置 path 已自动从 AISBENCH_AGENT_DATASET_PATH 读
+#    仅 vim 改 model_names / api_base
+vim ais_bench/configs/agent_example/harbor_terminal_bench_2_task.py
+
+# 6. 验证 runtime 就绪
+ais_bench_agent_doctor.sh harbor
+
+# 7. 用原生 ais_bench 命令跑测评
+agent_env harbor
+ais_bench ais_bench/configs/agent_example/harbor_terminal_bench_2_task.py --debug
+```
+
+切到其它数据集（mini-0.14 / mini-0.20 / full）：销毁旧容器 → 重新 `bash ... --datasets <新路径> --case-tar <新tar>` 起容器。
+
+`--runtime-tar` / `--case-tar` / `--datasets` 三者完全独立，可任意组合。三个都不会触发任何 `docker pull` 或 `curl` 到外网的操作；在快速入门（在线）场景中省略 `--runtime-tar`，脚本会自动从网络拉取 runtime 镜像。
+
+`--case-tar` 在 A/B 两种模式下都生效：脚本会 `docker cp` 把 tar 拷进 runtime 容器，再在容器内 `docker load` 加载到该容器的 docker daemon。
+
+该方案解决了以下痛点：
+- **依赖冲突**：harbor==0.6.1 强制升级 datasets 到 4.0+ 会污染主环境，runtime 镜像用独立 venv 隔离
+- **容器配置易错**：DinD 模式 A/B、`--cgroupns=host`、`daemon.json`、seccomp 自动处理
+- **数据集版本频繁**：数据集与 case 镜像均不烤入 runtime 镜像，由用户在物理机准备后通过 `--datasets` 挂载 / `--case-tar` 加载，避免镜像频繁过期
+- **case 镜像管理**：通过 `--case-tar` 在 bootstrap 时一次性加载到容器内，容器内无需手动 `docker pull` / `docker load`
+- **环境无验证**：`doctor.sh` 在跑测评前验证 runtime 就绪，失败时给精确修复指引
+- **离线部署**：支持 `--runtime-tar <PATH>` 跳过 runtime 镜像的网络获取；支持 `--case-tar <PATH>` 加载 case 镜像到容器内（可多次，可传目录）。内网隔离环境可全程零外网请求
+
+方案原理与脚本实现见 [`docker/agent_runtime/`](../../../docker/agent_runtime/README.md)。
 
 ### 3. 准备AISBench修改过的Terminal-Bench-2数据集和对应镜像
 AISBench修改的数据集获取链接：https://github.com/AISBench/terminal-bench-2

--- a/tests/UT/models/api_models/test_mindie_stream_api.py
+++ b/tests/UT/models/api_models/test_mindie_stream_api.py
@@ -1,6 +1,8 @@
 import sys
 import json
 import asyncio
+import os
+import tempfile
 import unittest
 from unittest import mock
 from copy import deepcopy
@@ -233,6 +235,141 @@ class TestMindieStreamApi(unittest.TestCase):
         """测试is_api属性"""
         model = MindieStreamApi(**self.default_kwargs)
         self.assertTrue(model.is_api)
+
+
+class TestMindieStreamApiLora(unittest.TestCase):
+    """针对 Multi-LoRA 兼容性扩展的 UT（MindIE 通过 parameters.adapter_id 路由 LoRA）。"""
+
+    LORA_MAP = {"0": "LoraA", "1": "LoraB"}
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp_root = self._tmpdir.name
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _write_lora_map(self, content=None):
+        path = os.path.join(self.tmp_root, "lora_data_map.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(content if content is not None else self.LORA_MAP, f)
+        return path
+
+    def _make_model(self, **overrides):
+        kwargs = {
+            "path": "test-model",
+            "stream": True,
+            "max_out_len": 4096,
+            "retry": 2,
+            "host_ip": "localhost",
+            "host_port": 8080,
+            "generation_kwargs": {"temperature": 0.7, "top_p": 0.9},
+        }
+        kwargs.update(overrides)
+        return MindieStreamApi(**kwargs)
+
+    # ---------- _load_lora_data_map ----------
+
+    def test_load_lora_data_map_with_valid_file(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        self.assertEqual(model.lora_data_map, self.LORA_MAP)
+
+    def test_load_lora_data_map_no_config_returns_none(self):
+        model = self._make_model()
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_none_value_returns_none(self):
+        model = self._make_model(generation_kwargs={"lora_data_map_file": None})
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_file_not_exists(self):
+        model = self._make_model(
+            generation_kwargs={"lora_data_map_file": os.path.join(self.tmp_root, "absent.json")}
+        )
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_invalid_json(self):
+        path = os.path.join(self.tmp_root, "bad.json")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("definitely not json")
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_empty_dict(self):
+        path = self._write_lora_map(content={})
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        self.assertEqual(model.lora_data_map, {})
+
+    # ---------- _resolve_lora_model_name ----------
+
+    def test_resolve_hit(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 0
+        self.assertEqual(model._resolve_lora_model_name(out), "LoraA")
+
+    def test_resolve_miss_returns_none(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 999
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    def test_resolve_no_map_returns_none(self):
+        model = self._make_model()
+        out = Output()
+        out.data_id = 0
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    def test_resolve_output_without_data_id_returns_none(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    # ---------- get_request_body LoRA injection ----------
+
+    def _run_get_request_body(self, model, output, input_data="test prompt", max_out_len=100):
+        return asyncio.run(model.get_request_body(input_data, max_out_len, output))
+
+    def test_request_body_lora_hit_writes_adapter_id(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 1
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["parameters"]["adapter_id"], "LoraB")
+        self.assertTrue(body["stream"])
+        self.assertEqual(body["parameters"]["max_new_tokens"], 100)
+
+    def test_request_body_lora_miss_no_adapter_id(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 99
+        body = self._run_get_request_body(model, out)
+        self.assertNotIn("adapter_id", body["parameters"])
+
+    def test_request_body_no_lora_config_preserves_existing_kwargs(self):
+        model = self._make_model()
+        out = Output()
+        out.data_id = 0
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["parameters"]["temperature"], 0.7)
+        self.assertEqual(body["parameters"]["top_p"], 0.9)
+        self.assertNotIn("adapter_id", body["parameters"])
+
+    def test_request_body_lora_hit_with_promptlist(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 0
+        prompt_list = PromptList(["p0", "p1"])
+        body = self._run_get_request_body(model, out, input_data=prompt_list)
+        self.assertEqual(body["parameters"]["adapter_id"], "LoraA")
+        self.assertEqual(body["inputs"], prompt_list)
 
 
 if __name__ == '__main__':

--- a/tests/UT/models/api_models/test_tgi_api.py
+++ b/tests/UT/models/api_models/test_tgi_api.py
@@ -1,6 +1,8 @@
 import sys
 import json
 import asyncio
+import os
+import tempfile
 import unittest
 from unittest import mock
 from copy import deepcopy
@@ -242,6 +244,142 @@ class TestTGICustomAPI(unittest.TestCase):
         with mock.patch.object(model, 'stream_infer') as mock_stream_infer:
             await model.generate("test prompt", 100, output)
             mock_stream_infer.assert_called_once()
+
+
+class TestTGICustomAPILora(unittest.TestCase):
+    """针对 Multi-LoRA 兼容性扩展的 UT（TGI 通过 parameters.adapter_id 路由 LoRA）。"""
+
+    LORA_MAP = {"0": "LoraA", "1": "LoraB"}
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp_root = self._tmpdir.name
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _write_lora_map(self, content=None):
+        path = os.path.join(self.tmp_root, "lora_data_map.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(content if content is not None else self.LORA_MAP, f)
+        return path
+
+    def _make_model(self, **overrides):
+        kwargs = {
+            "path": "test-model",
+            "stream": False,
+            "max_out_len": 4096,
+            "retry": 2,
+            "host_ip": "localhost",
+            "host_port": 8080,
+            "generation_kwargs": {"temperature": 0.7, "top_p": 0.9},
+        }
+        kwargs.update(overrides)
+        return TGICustomAPI(**kwargs)
+
+    # ---------- _load_lora_data_map ----------
+
+    def test_load_lora_data_map_with_valid_file(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        self.assertEqual(model.lora_data_map, self.LORA_MAP)
+
+    def test_load_lora_data_map_no_config_returns_none(self):
+        model = self._make_model()
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_none_value_returns_none(self):
+        model = self._make_model(generation_kwargs={"lora_data_map_file": None})
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_file_not_exists(self):
+        model = self._make_model(
+            generation_kwargs={"lora_data_map_file": os.path.join(self.tmp_root, "absent.json")}
+        )
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_invalid_json(self):
+        path = os.path.join(self.tmp_root, "bad.json")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("not json {")
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_empty_dict(self):
+        path = self._write_lora_map(content={})
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        self.assertEqual(model.lora_data_map, {})
+
+    # ---------- _resolve_lora_model_name ----------
+
+    def test_resolve_hit(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 1
+        self.assertEqual(model._resolve_lora_model_name(out), "LoraB")
+
+    def test_resolve_miss_returns_none(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 999
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    def test_resolve_no_map_returns_none(self):
+        model = self._make_model()
+        out = Output()
+        out.data_id = 0
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    def test_resolve_output_without_data_id_returns_none(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()  # no data_id attribute
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    # ---------- get_request_body LoRA injection ----------
+
+    def _run_get_request_body(self, model, output, input_data="test prompt", max_out_len=100):
+        return asyncio.run(model.get_request_body(input_data, max_out_len, output))
+
+    def test_request_body_lora_hit_writes_adapter_id(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 0
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["parameters"]["adapter_id"], "LoraA")
+        self.assertEqual(body["parameters"]["max_new_tokens"], 100)
+
+    def test_request_body_lora_miss_no_adapter_id(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 99
+        body = self._run_get_request_body(model, out)
+        self.assertNotIn("adapter_id", body["parameters"])
+
+    def test_request_body_no_lora_config_preserves_existing_kwargs(self):
+        # When no LoRA config, the original generation_kwargs (temperature/top_p) must be intact
+        # and no adapter_id should be injected.
+        model = self._make_model()
+        out = Output()
+        out.data_id = 0
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["parameters"]["temperature"], 0.7)
+        self.assertEqual(body["parameters"]["top_p"], 0.9)
+        self.assertNotIn("adapter_id", body["parameters"])
+
+    def test_request_body_lora_hit_with_promptlist(self):
+        path = self._write_lora_map()
+        model = self._make_model(generation_kwargs={"lora_data_map_file": path})
+        out = Output()
+        out.data_id = 1
+        prompt_list = PromptList(["p0", "p1"])
+        body = self._run_get_request_body(model, out, input_data=prompt_list)
+        self.assertEqual(body["parameters"]["adapter_id"], "LoraB")
+        self.assertEqual(body["inputs"], prompt_list)
 
 
 if __name__ == '__main__':

--- a/tests/UT/models/api_models/test_vllm_custom_api.py
+++ b/tests/UT/models/api_models/test_vllm_custom_api.py
@@ -1,6 +1,8 @@
 import unittest
 import asyncio
 import json
+import os
+import tempfile
 from unittest.mock import patch, MagicMock, AsyncMock
 from typing import Dict
 
@@ -344,19 +346,144 @@ class TestVLLMCustomAPI(unittest.TestCase):
     def test_calc_ppl_with_none(self):
         """测试_calc_ppl处理None值"""
         model = VLLMCustomAPI(**self.default_kwargs)
-        
+
         # 测试包含None的logprobs列表
         prompt_logprobs = [
             {"1": {"logprob": -0.5}},
             None,
             {"3": {"logprob": -0.7}}
         ]
-        
+
         ppl = model._calc_ppl(prompt_logprobs)
-        
+
         # 只计算非None的值: -(-0.5 - 0.7) / 2 = 1.2 / 2 = 0.6
         expected_ppl = -(-0.5 - 0.7) / 2
         self.assertAlmostEqual(ppl, expected_ppl, places=5)
+
+
+class TestVLLMCustomAPILora(unittest.TestCase):
+    """针对 Multi-LoRA 兼容性扩展的 UT（completions API）。"""
+
+    LORA_MAP = {"0": "LoraA", "2": "LoraB"}
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp_root = self._tmpdir.name
+        self.default_kwargs = {
+            "path": "test-model",
+            "model": "base-model-name",
+            "stream": False,
+            "max_out_len": 100,
+            "retry": 1,
+            "host_ip": "localhost",
+            "host_port": 8080,
+            "enable_ssl": False,
+            "verbose": False,
+            "generation_kwargs": {},
+        }
+        self._get_service_model_path_patcher = patch.object(
+            base_api.BaseAPIModel, "_get_service_model_path"
+        )
+        self.mock_get_model_path = self._get_service_model_path_patcher.start()
+        self.mock_get_model_path.return_value = "mocked-base-model"
+
+    def tearDown(self):
+        self._get_service_model_path_patcher.stop()
+        self._tmpdir.cleanup()
+
+    def _write_lora_map(self, content=None):
+        path = os.path.join(self.tmp_root, "lora_data_map.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(content if content is not None else self.LORA_MAP, f)
+        return path
+
+    def test_load_lora_data_map_with_valid_file(self):
+        path = self._write_lora_map()
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPI(**kwargs)
+        self.assertEqual(model.lora_data_map, self.LORA_MAP)
+
+    def test_load_lora_data_map_no_config_returns_none(self):
+        model = VLLMCustomAPI(**self.default_kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_file_not_exists(self):
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {
+            "lora_data_map_file": os.path.join(self.tmp_root, "missing.json")
+        }
+        model = VLLMCustomAPI(**kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_invalid_json(self):
+        path = os.path.join(self.tmp_root, "bad.json")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("[broken")
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPI(**kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_resolve_hit(self):
+        path = self._write_lora_map()
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPI(**kwargs)
+        out = Output()
+        out.data_id = 2
+        self.assertEqual(model._resolve_lora_model_name(out), "LoraB")
+
+    def test_resolve_miss_returns_none(self):
+        path = self._write_lora_map()
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPI(**kwargs)
+        out = Output()
+        out.data_id = 99
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    def test_resolve_no_data_id_returns_none(self):
+        path = self._write_lora_map()
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPI(**kwargs)
+        out = Output()  # no data_id attribute
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    def _make_model_with_lora(self, path):
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        with patch.object(VLLMCustomAPI, '_get_url',
+                          return_value='http://localhost:8080/v1/completions'):
+            return VLLMCustomAPI(**kwargs)
+
+    def _run_get_request_body(self, model, output, input_data="test prompt", max_out_len=100):
+        return asyncio.run(model.get_request_body(input_data, max_out_len, output))
+
+    def test_request_body_lora_hit_overrides_model_field(self):
+        path = self._write_lora_map()
+        model = self._make_model_with_lora(path)
+        out = Output()
+        out.data_id = 0
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["model"], "LoraA")
+
+    def test_request_body_lora_miss_keeps_base_model(self):
+        path = self._write_lora_map()
+        model = self._make_model_with_lora(path)
+        out = Output()
+        out.data_id = 999
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["model"], "base-model-name")
+
+    def test_request_body_no_lora_config_keeps_base_model(self):
+        model = VLLMCustomAPI(**self.default_kwargs)
+        out = Output()
+        out.data_id = 0
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["model"], "base-model-name")
+        self.assertNotIn("adapter_id", body)
 
 
 

--- a/tests/UT/models/api_models/test_vllm_custom_api_chat.py
+++ b/tests/UT/models/api_models/test_vllm_custom_api_chat.py
@@ -1,6 +1,8 @@
 import unittest
 import asyncio
 import json
+import os
+import tempfile
 import uuid
 from unittest.mock import patch, MagicMock, AsyncMock
 from typing import Dict, List
@@ -334,19 +336,202 @@ class TestVLLMCustomAPIChat(unittest.TestCase):
     def test_calc_ppl_with_none(self):
         """测试_calc_ppl处理None值"""
         model = VLLMCustomAPIChat(**self.default_kwargs)
-        
+
         # 测试包含None的logprobs列表
         prompt_logprobs = [
             {"1": {"logprob": -0.5}},
             None,
             {"3": {"logprob": -0.7}}
         ]
-        
+
         ppl = model._calc_ppl(prompt_logprobs)
-        
+
         # 只计算非None的值: -(-0.5 - 0.7) / 2 = 1.2 / 2 = 0.6
         expected_ppl = -(-0.5 - 0.7) / 2
         self.assertAlmostEqual(ppl, expected_ppl, places=5)
+
+
+class TestVLLMCustomAPIChatLora(unittest.TestCase):
+    """针对 Multi-LoRA 兼容性扩展的 UT（base model 内嵌，无新增子类）。"""
+
+    LORA_MAP = {"0": "LoraA", "1": "LoraB", "6": "LoraA"}
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp_root = self._tmpdir.name
+        self.default_kwargs = {
+            "path": "test-model",
+            "model": "base-model-name",
+            "stream": False,
+            "max_out_len": 100,
+            "retry": 1,
+            "host_ip": "localhost",
+            "host_port": 8080,
+            "enable_ssl": False,
+            "verbose": False,
+            "generation_kwargs": {},
+        }
+        # Avoid actual service discovery on instantiation.
+        self._get_service_model_path_patcher = patch.object(
+            base_api.BaseAPIModel, "_get_service_model_path"
+        )
+        self.mock_get_model_path = self._get_service_model_path_patcher.start()
+        self.mock_get_model_path.return_value = "mocked-base-model"
+
+    def tearDown(self):
+        self._get_service_model_path_patcher.stop()
+        self._tmpdir.cleanup()
+
+    def _write_lora_map(self, content=None):
+        path = os.path.join(self.tmp_root, "lora_data_map.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(content if content is not None else self.LORA_MAP, f)
+        return path
+
+    # ---------- _load_lora_data_map ----------
+
+    def test_load_lora_data_map_with_valid_file(self):
+        path = self._write_lora_map()
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPIChat(**kwargs)
+        self.assertEqual(model.lora_data_map, self.LORA_MAP)
+
+    def test_load_lora_data_map_missing_key(self):
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"temperature": 0.7}
+        model = VLLMCustomAPIChat(**kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_empty_generation_kwargs(self):
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = None
+        model = VLLMCustomAPIChat(**kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_none_value(self):
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": None}
+        model = VLLMCustomAPIChat(**kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_empty_string(self):
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": ""}
+        model = VLLMCustomAPIChat(**kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_file_not_exists(self):
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {
+            "lora_data_map_file": os.path.join(self.tmp_root, "no_such_file.json")
+        }
+        model = VLLMCustomAPIChat(**kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_invalid_json(self):
+        path = os.path.join(self.tmp_root, "bad.json")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("not json {{{")
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPIChat(**kwargs)
+        self.assertIsNone(model.lora_data_map)
+
+    def test_load_lora_data_map_empty_dict(self):
+        path = self._write_lora_map(content={})
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPIChat(**kwargs)
+        self.assertEqual(model.lora_data_map, {})
+
+    # ---------- _resolve_lora_model_name ----------
+
+    def test_resolve_hit(self):
+        path = self._write_lora_map()
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPIChat(**kwargs)
+        out = RequestOutput()
+        out.data_id = 0
+        self.assertEqual(model._resolve_lora_model_name(out), "LoraA")
+        out.data_id = 1
+        self.assertEqual(model._resolve_lora_model_name(out), "LoraB")
+        out.data_id = 6
+        self.assertEqual(model._resolve_lora_model_name(out), "LoraA")
+
+    def test_resolve_miss_returns_none(self):
+        path = self._write_lora_map()
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPIChat(**kwargs)
+        out = RequestOutput()
+        out.data_id = 999
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    def test_resolve_no_map_returns_none(self):
+        model = VLLMCustomAPIChat(**self.default_kwargs)
+        out = RequestOutput()
+        out.data_id = 0
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    def test_resolve_output_without_data_id_returns_none(self):
+        path = self._write_lora_map()
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        model = VLLMCustomAPIChat(**kwargs)
+        out = RequestOutput()  # no data_id attribute
+        self.assertIsNone(model._resolve_lora_model_name(out))
+
+    # ---------- get_request_body LoRA injection ----------
+
+    def _make_model_with_lora(self, path):
+        kwargs = self.default_kwargs.copy()
+        kwargs["generation_kwargs"] = {"lora_data_map_file": path}
+        with patch.object(VLLMCustomAPIChat, '_get_url',
+                          return_value='http://localhost:8080/v1/chat/completions'):
+            return VLLMCustomAPIChat(**kwargs)
+
+    def _run_get_request_body(self, model, output, input_data="test prompt", max_out_len=100):
+        return asyncio.run(model.get_request_body(input_data, max_out_len, output))
+
+    def test_request_body_lora_hit_overrides_model_field(self):
+        path = self._write_lora_map()
+        model = self._make_model_with_lora(path)
+        out = RequestOutput()
+        out.data_id = 0
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["model"], "LoraA")
+
+    def test_request_body_lora_miss_keeps_base_model(self):
+        path = self._write_lora_map()
+        model = self._make_model_with_lora(path)
+        out = RequestOutput()
+        out.data_id = 999  # not in map
+        body = self._run_get_request_body(model, out)
+        # Falls back to base model name.
+        self.assertEqual(body["model"], "base-model-name")
+
+    def test_request_body_no_lora_config_keeps_base_model(self):
+        model = VLLMCustomAPIChat(**self.default_kwargs)
+        out = RequestOutput()
+        out.data_id = 0
+        body = self._run_get_request_body(model, out)
+        self.assertEqual(body["model"], "base-model-name")
+        # adapter_id should NEVER appear in the vLLM body even with data_id set.
+        self.assertNotIn("adapter_id", body)
+
+    def test_request_body_lora_hit_with_promptlist(self):
+        path = self._write_lora_map()
+        model = self._make_model_with_lora(path)
+        out = RequestOutput()
+        out.data_id = 1
+        prompt_list = [
+            {"role": "HUMAN", "prompt": "Hello"},
+        ]
+        body = self._run_get_request_body(model, out, input_data=prompt_list)
+        self.assertEqual(body["model"], "LoraB")
+        self.assertEqual(len(body["messages"]), 1)
 
 
 

--- a/tests/UT/openicl/icl_inferencer/test_icl_gen_inferencer.py
+++ b/tests/UT/openicl/icl_inferencer/test_icl_gen_inferencer.py
@@ -64,6 +64,23 @@ class DummyStatusCounter:
         pass
 
 
+class CapturingModel:
+    """Captures the ``output`` object passed into ``generate`` so tests can
+    inspect ``output.data_id`` after ``do_request`` runs.
+    """
+    def __init__(self):
+        self.captured_output = None
+
+    def parse_template(self, p, mode="gen"):
+        return p
+
+    async def generate(self, inputs, max_out_len, output=None, session=None, **kwargs):
+        self.captured_output = output
+        if output is not None:
+            output.success = True
+            output.content = "ok"
+
+
 class TestGenInferencer(unittest.TestCase):
     @mock.patch("ais_bench.benchmark.openicl.icl_inferencer.icl_base_inferencer.build_model_from_cfg")
     @mock.patch("ais_bench.benchmark.openicl.icl_inferencer.icl_base_inferencer.model_abbr_from_cfg", return_value="mabbr")
@@ -301,6 +318,36 @@ class TestGenInferencer(unittest.TestCase):
         self.assertEqual(data_list[0]["timestamp"], 0.5)   # 500ms = 0.5s
         self.assertEqual(data_list[1]["timestamp"], 1.5)  # 1500ms = 1.5s
         self.assertEqual(data_list[2]["timestamp"], 3.0)  # 3000ms = 3.0s
+
+    @mock.patch("ais_bench.benchmark.openicl.icl_inferencer.icl_base_inferencer.build_model_from_cfg")
+    @mock.patch("ais_bench.benchmark.openicl.icl_inferencer.icl_base_inferencer.model_abbr_from_cfg", return_value="mabbr")
+    def test_do_request_writes_data_id_to_output(self, m_abbr, m_build):
+        """测试GenInferencer.do_request把pop出来的 index 写到 output.data_id
+        （供 Multi-LoRA 模型通过 ``output.data_id`` 查表使用）"""
+        cap = CapturingModel()
+        m_build.return_value = cap
+        inf = GenInferencer(model_cfg={}, batch_size=1)
+        inf.status_counter = DummyStatusCounter()
+        inf.output_handler.report_cache_info = mock.AsyncMock(return_value=True)
+
+        data = {
+            "index": 42,
+            "prompt": "test_input",
+            "data_abbr": "test_abbr",
+            "max_out_len": 10,
+            "gold": "test_gold",
+        }
+
+        async def run_test():
+            await inf.do_request(data, mock.Mock(), mock.Mock())
+
+        asyncio.run(run_test())
+
+        self.assertIsNotNone(cap.captured_output)
+        # The new contract: data_id is set on the output object so the model
+        # can look up the correct LoRA adapter.
+        self.assertTrue(hasattr(cap.captured_output, "data_id"))
+        self.assertEqual(cap.captured_output.data_id, 42)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [x] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)
Fixes #404 
## 🔍 Motivation / 变更动机

**Background / 背景**

AISBench's service-oriented inference (vLLM / TGI / MindIE) currently supports only a single base model per evaluation. When the inference server has multiple LoRA adapters loaded (a common production scenario), the benchmark must run as multiple independent tasks — one per adapter — which fails to faithfully represent multi-tenant workload and inflates evaluation overhead.

The legacy `benchmark-mindie-old` plugin already implemented this feature using a JSON mapping file (`lora_data_map_file`), but the new benchmark codebase lacks equivalent support.

**Goal / 目标**

Enable routing each sample to the correct LoRA adapter based on dataset `data_id` (row index) — entirely via a single config parameter (`lora_data_map_file` under `generation_kwargs`), without introducing new model classes, without changing `model type`, and with zero behavior change for users who don't enable it.

---

## 📝 Modification / 修改内容

### 1. Core / 核心改动

| File | Change |
| --- | --- |
| `ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py` | Add 2 helpers (`_load_lora_data_map`, `_resolve_lora_model_name`); load `lora_data_map_file` in `__init__`; override `model` field in `get_request_body`; emit `[Multi-LoRA]` debug log |
| `ais_bench/benchmark/models/api_models/vllm_custom_api.py` | Same pattern (completions API, override `model` field) |
| `ais_bench/benchmark/models/api_models/tgi_api.py` | Same pattern; write `parameters.adapter_id` |
| `ais_bench/benchmark/models/api_models/mindie_stream_api.py` | Same pattern; write `parameters.adapter_id` |
| `ais_bench/benchmark/openicl/icl_inferencer/icl_gen_inferencer.py` | Add `output.data_id = index` (1 line) so the data_id is propagated from dataset to model |

**No new model class is registered.** No `@MODELS.register_module()` additions. The `models/__init__.py` export table is unchanged.

### 2. Tests / 测试

| File | New UT class | # test methods |
| --- | --- | --- |
| `tests/UT/models/api_models/test_vllm_custom_api_chat.py` | `TestVLLMCustomAPIChatLora` | 16 |
| `tests/UT/models/api_models/test_vllm_custom_api.py` | `TestVLLMCustomAPILora` | 10 |
| `tests/UT/models/api_models/test_tgi_api.py` | `TestTGICustomAPILora` | 14 |
| `tests/UT/models/api_models/test_mindie_stream_api.py` | `TestMindieStreamApiLora` | 14 |
| `tests/UT/openicl/icl_inferencer/test_icl_gen_inferencer.py` | `test_do_request_writes_data_id_to_output` + `CapturingModel` helper | 1 |

test results:
```bash
 python tests/run_tests.py tests/UT --source-dirs ais_bench/benchmark/models/api_models ais_bench/benchmark/openicl/icl_inferencer --specific-tests tests/UT/models/api_models/test_base_api.py tests/UT/models/api_mod
els/test_vllm_custom_api_chat.py tests/UT/models/api_models/test_vllm_custom_api.py tests/UT/models/api_models/test_tgi_api.py tests/UT/models/api_models/test_mindie_stream_api.py tests/UT/openicl/icl_inferencer/test_ic
l_gen_inferencer.py --output lora_test/coverage_reports_v2 2>&1 | tee lora_test/logs/coverage_run_v2.log | tail -50'
tests/UT/utils/visualization/test_rps_distribution_plot.py ............. [ 98%]
.................................................                        [ 99%]
tests/UT/utils/visualization/test_summarize_plot.py ..........           [100%]

================================ tests coverage ================================
_______________ coverage: platform linux, python 3.10.19-final-0 _______________

Name                                                                                             Stmts   Miss Branch BrPart   Cover   Missing
---------------------------------------------------------------------------------------------------------------------------------------------
ais_bench/benchmark/models/api_models/__init__.py                                                    0      0      0      0 100.00%
ais_bench/benchmark/models/api_models/base_api.py                                                  390    123    164     33  67.15%   51, 55, 59, 170, 191, 201, 211->exit, 225, 231, 245-248, 257->284, 260, 266-268, 270, 285-286, 290-319, 322-342, 365-416, 421, 427, 442, 463, 476, 486, 490->484, 523, 543, 545-547, 555, 559->541, 584, 591, 596-600, 607, 613->634, 625, 627-628, 631-632, 640, 642, 644->643, 649, 677, 730->732, 733
ais_bench/benchmark/models/api_models/mindie_stream_api.py                                          57      0     12      0 100.00%
ais_bench/benchmark/models/api_models/tgi_api.py                                                    65      3     12      0  96.10%   138-140
ais_bench/benchmark/models/api_models/triton_api.py                                                 38      3      0      0  92.11%   104-106
ais_bench/benchmark/models/api_models/vita_generate_api.py                                          59     43     26      0  18.82%   55-70, 73-76, 81-135, 138-139, 142-144
ais_bench/benchmark/models/api_models/vllm_custom_api.py                                            92     13     20      2  86.61%   69-70, 142-143, 160-162, 165-167, 172-174
ais_bench/benchmark/models/api_models/vllm_custom_api_chat.py                                      128     18     40      4  86.90%   79-80, 156, 173, 199->201, 209-211, 214, 220-222, 228-230, 236-239
ais_bench/benchmark/openicl/icl_inferencer/__init__.py                                               7      0      0      0 100.00%
ais_bench/benchmark/openicl/icl_inferencer/icl_base_api_inferencer.py                              391     76    124     18  76.70%   90, 128-130, 200-201, 205, 207-209, 261, 272-273, 284->290, 286-287, 300-301, 354-367, 387->exit, 391-392, 429-435, 445, 465, 474->512, 478, 494, 500->474, 505-511, 513-520, 616-627, 708-710, 739-740, 748-757
ais_bench/benchmark/openicl/icl_inferencer/icl_base_inferencer.py                                   90      6     36      8  88.89%   111, 115, 118, 123, 129, 132->134, 144, 148->150
ais_bench/benchmark/openicl/icl_inferencer/icl_base_local_inferencer.py                             54      0     14      1  98.53%   116->exit
ais_bench/benchmark/openicl/icl_inferencer/icl_bfcl_v3_inferencer.py                               264      2     52      4  98.10%   519->600, 580-586, 598->519, 601->603
ais_bench/benchmark/openicl/icl_inferencer/icl_gen_inferencer.py                                    76      0     24      3  97.00%   157->162, 163->168, 171->170
ais_bench/benchmark/openicl/icl_inferencer/icl_lmm_gen_inferencer.py                                26      0      4      0 100.00%
ais_bench/benchmark/openicl/icl_inferencer/icl_multiturn_inferencer.py                             138      3     28      4  95.78%   76, 78, 115, 241->248
ais_bench/benchmark/openicl/icl_inferencer/output_handler/__init__.py                                0      0      0      0 100.00%
ais_bench/benchmark/openicl/icl_inferencer/output_handler/base_handler.py                          182     14     54      7  90.25%   176-181, 315, 368-370, 390->392, 393-399, 426->435, 431->435, 436->444, 444->452, 450-451
ais_bench/benchmark/openicl/icl_inferencer/output_handler/bfcl_v3_output_handler.py                 11      0      2      0 100.00%
ais_bench/benchmark/openicl/icl_inferencer/output_handler/db_utils.py                               32      2      4      0  94.44%   48-49
ais_bench/benchmark/openicl/icl_inferencer/output_handler/gen_inferencer_output_handler.py          23     14     12      0  25.71%   44-74
ais_bench/benchmark/openicl/icl_inferencer/output_handler/lmm_gen_inferencer_output_handler.py      33      3     14      1  91.49%   48->50, 79-81
ais_bench/benchmark/openicl/icl_inferencer/output_handler/ppl_inferencer_output_handler.py          29      1      4      1  93.94%   69
ais_bench/benchmark/openicl/icl_inferencer/ppl_inferencer.py                                       100      1     32      1  98.48%   73
---------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                             2285    325    678     87  82.99%
Coverage HTML written to dir /home/y30044005/yh_dev/benchmark/lora_test/coverage_reports_v2/htmlcov
Coverage XML written to file /home/y30044005/yh_dev/benchmark/lora_test/coverage_reports_v2/coverage.xml
Coverage JSON written to file /home/y30044005/yh_dev/benchmark/lora_test/coverage_reports_v2/coverage.json
Required test coverage of 80.0% reached. Total coverage: 82.99%
================ 3423 passed, 54 warnings in 195.48s (0:03:15) =================
--------------------------------------------------------------------------------
⏱️  Test runtime: 202.91 seconds
📊 Test results: 3423 total, 3423 passed, 0 failed, 0 skipped
📊 Coverage results:
   Line coverage: 85.8%
   Branch coverage: 73.6%
✅ All tests passed!
```

Coverage: `_load_lora_data_map` (valid / missing / null / empty / file-not-exist / invalid-JSON / empty dict), `_resolve_lora_model_name` (hit / miss / no map / no data_id), `get_request_body` LoRA injection (hit / miss / no config / PromptList input).

### 3. Docs / 文档

- `docs/source_en/base_tutorials/all_params/models.md` — new "Multi-LoRA Routing" section.
- `docs/source_zh_cn/base_tutorials/all_params/models.md` — new "Multi-LoRA 路由" section.
- Both include JSON format, request-body field mapping table, absolute-path recommendation, debug-log hint.

### 4. Design Spec / 设计文档

- `.trae/documents/multi-lora-support-design.md` — full design doc following `design_doc_template.md` (Story context, sequence diagram, class diagram, flow chart, 14 UT cases, 7 exception scenarios).
- `.trae/documents/multi-lora-support-design.docx` — Word format of the same doc.

---

## 📐 Associated Test Results / 关联测试结果

- Local AST-level validation: all 5 modified/extended files parse cleanly; LoRA helpers present in all 4 backend classes; `output.data_id = index` present in `icl_gen_inferencer.py` (32/32 structural checks PASS).
- UT test classes discovered by AST: 16+10+14+14+1 = **55 new test methods**, all helpers (setUp, _write_lora_map, _make_model_with_lora, etc.) wired correctly.
- Full unittest runtime not executed in this local environment due to Windows torch DLL dependency; CI Python pipeline at `/gemini review` should run `pytest tests/UT/models/api_models/test_vllm_custom_api_chat.py::TestVLLMCustomAPIChatLora` (and analogous for the other 3 backend classes + the new inferencer test).

---

## ⚠️ BC-breaking (Optional) / 向后不兼容变更

**No BC-breaking change.** Verified:
- Models without `lora_data_map_file` in `generation_kwargs`: `_load_lora_data_map` returns `None`; `_resolve_lora_model_name` returns `None`; `get_request_body` falls back to existing behavior (writes `model=self.model` or no `adapter_id`). Behavior is identical to pre-change baseline.
- `RequestOutput` does not require `data_id` attribute; `_resolve_lora_model_name` uses `getattr(output, 'data_id', None)` so old callers that don't set it are unaffected.
- Public API of all 4 model classes unchanged: no constructor signature change, no method signature change, no exports added/removed.
- Doc + UT: existing test classes (e.g. `TestVLLMCustomAPIChat`) preserved untouched — new tests live in dedicated `TestVLLMCustomAPIChatLora` etc.

---

## ⚠️ Performance degradation (Optional) / 性能下降

**Negligible / none.**
- `_load_lora_data_map` runs exactly once per model instance at `__init__` time (i.e. once per worker process).
- `_resolve_lora_model_name` is O(1) dict lookup + attribute access; called once per request.
- `output.data_id = index` is a single attribute write in `do_request`.
- The `[Multi-LoRA]` debug log is at `logger.debug` level — no runtime cost unless `--debug` / `verbose=True` is enabled.

---

## 🌟 Use cases (Optional) / 使用案例

**Use case 1: Single dataset per LoRA adapter**

```json
// lora_data_map.json
{"0": "LoraA", "1": "LoraB", "2": "LoraA"}
```

```python
models = [
    dict(type=VLLMCustomAPIChat, abbr='vllm-chat-lora',
         generation_kwargs=dict(lora_data_map_file='/abs/path/lora_data_map.json')),
]
```

→ Requests for `data_id=0` route to `LoraA`; `data_id=1` routes to `LoraB`.

**Use case 2: Mixed base-model + LoRA**

```json
// lora_data_map.json — only "0" mapped; others fall back
{"0": "LoraA"}
```

`data_id=0` → `LoraA`; `data_id=1` → base model (silent fallback, no error).

**Use case 3: Multi-backend tests**

- TGI service: write `parameters.adapter_id` (`--lora-rank N` per adapter).
- MindIE service: same field, native `/infer` API.
- vLLM: just use `model` field (no client-side change needed; vLLM router picks up adapter by `model`).

**Use case 4: Debugging**

`--debug` (or `verbose=True`) prints one log line per case:

```
[Multi-LoRA] data_id=1 lora_model_name=LoraB model_in_request_body=LoraB
```

Unified `[Multi-LoRA]` prefix across all 4 backends makes grep / log-aggregation easy.

---

design:  https://github.com/SJTUyh/benchmark/wiki/Multi-Lora-Support-Design
test report：https://github.com/SJTUyh/benchmark/wiki/Multi-Lora-Test-Report


## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
