### PR TITLE
fix the logic for displaying steady-state test results

### DIFF
--- a/ais_bench/benchmark/calculators/stable_perf_metric_calculator.py
+++ b/ais_bench/benchmark/calculators/stable_perf_metric_calculator.py
@@ -10,18 +10,17 @@ from ais_bench.benchmark.calculators.base_perf_metric_calculator import (
 from ais_bench.benchmark.utils.logging.error_codes import CALC_CODES
 from ais_bench.benchmark.utils.logging.exceptions import AISBenchDataContentError
 
-WAVE_OFFSET = 0.02
-INTERVAL_OFFSET = 0.001
 
 @PERF_METRIC_CALCULATORS.register_module()
 class StablePerfMetricCalculator(BasePerfMetricCalculator):
     """
     Performance metric calculator for stable stage analysis.
 
-    This calculator focuses on analyzing the stable phase of benchmark execution,
-    where the system operates at maximum concurrency with minimal fluctuations.
-    It identifies and analyzes the stable period to provide more accurate
-    performance metrics.
+    This calculator identifies the stable phase as the interval from the first
+    time concurrency reaches max_concurrency to the last time it is at that level.
+    All requests starting within this interval are included regardless of
+    concurrency fluctuations, providing a robust steady-state performance measurement
+    without requiring manual parameter tuning.
 
     Args:
         stats_list (list, optional): List of statistics to calculate
@@ -63,6 +62,11 @@ class StablePerfMetricCalculator(BasePerfMetricCalculator):
         """
         Identify requests that belong to the stable stage.
 
+        The stable stage is defined as the interval from the first moment
+        concurrency reaches max_concurrency to the last moment concurrency
+        is at max_concurrency. All requests with start_time within this
+        closed interval are included, regardless of concurrency fluctuations.
+
         Args:
             perf_details (dict): Performance details dictionary
 
@@ -70,11 +74,12 @@ class StablePerfMetricCalculator(BasePerfMetricCalculator):
             list: List of request IDs in the stable stage
 
         Raises:
-            RuntimeError: If no stable stage can be identified
+            AISBenchDataContentError: If no stable stage can be identified
         """
         # Calculate the minimum start time as the baseline
         min_start_time = min(perf_details["start_time"])
-        time_point_concurrency = [0] * 2 * len(perf_details["id"])
+
+        # Build sorted list of start/end events for all requests
         request_time_sections = []
         for id in range(len(perf_details["id"])):
             request_time_sections.append(
@@ -92,84 +97,52 @@ class StablePerfMetricCalculator(BasePerfMetricCalculator):
                 }
             )
         sorted_time_sections = sorted(request_time_sections, key=lambda x: x["time"])
-        id_lists = []
+
         self.logger.info("Starting stable stage calculation...")
-        requested = 0
+        first_max_time = None
+        last_max_time = None
+        concurrency = 0
+
         progress_bar = tqdm(
             total=len(sorted_time_sections),
             desc="Calculating stable stage",
             unit=" req",
         )
-        for i, section in enumerate(sorted_time_sections):
+
+        for section in sorted_time_sections:
             if section["attr"] == "start":
-                time_point_concurrency[i] = time_point_concurrency[i - 1] + 1
-                requested += 1
+                concurrency += 1
             else:
-                time_point_concurrency[i] = time_point_concurrency[i - 1] - 1
-            if (
-                section["attr"] == "start"
-                and time_point_concurrency[i] == self.max_concurrency
-            ):
-                id_lists.append(section["id"])
-                if len(id_lists) == 2:
-                    self.stage_section[0] = section["time"]  # total start time
-            elif (
-                section["attr"] == "start"
-                and time_point_concurrency[i]
-                >= int(self.max_concurrency * (1 - WAVE_OFFSET))
-                and len(id_lists) > 2
-            ):
-                id_lists.append(section["id"])
-            elif requested == len(perf_details["id"]) and section["attr"] == "end":
-                self.stage_section[1] = section["time"]
-                progress_bar.update(len(sorted_time_sections) - progress_bar.n)
-                break
-            elif (
-                len(id_lists) > 1
-                and section["attr"] == "end"
-                and time_point_concurrency[i]
-                < int(self.max_concurrency * (1 - WAVE_OFFSET))
-            ):
-                # Check if there's a start event within INTERVAL_OFFSET that recovers concurrency
-                # Skip consecutive end events and look ahead for start events
-                should_exit_stable = True
-                current_time = section["time"]
-                current_concurrency = time_point_concurrency[i]
+                concurrency -= 1
 
-                # Look ahead to find the next start event within INTERVAL_OFFSET
-                for j in range(i + 1, len(sorted_time_sections)):
-                    next_section = sorted_time_sections[j]
-                    time_interval = next_section["time"] - current_time
+            if concurrency == self.max_concurrency:
+                if first_max_time is None:
+                    first_max_time = section["time"]
+                last_max_time = section["time"]
 
-                    # If time interval exceeds INTERVAL_OFFSET, exit stable stage
-                    if time_interval > INTERVAL_OFFSET:
-                        break
-
-                    # Update concurrency based on the event type
-                    if next_section["attr"] == "end":
-                        current_concurrency -= 1
-                    else:  # start event
-                        current_concurrency += 1
-                        # If concurrency recovers to threshold, don't exit stable stage
-                        if current_concurrency >= int(
-                            self.max_concurrency * (1 - WAVE_OFFSET)
-                        ):
-                            should_exit_stable = False
-                            break
-
-                if should_exit_stable:
-                    self.stage_section[1] = section["time"]
-                    progress_bar.update(len(sorted_time_sections) - progress_bar.n)
-                    break
             progress_bar.update(1)
         progress_bar.close()
-        if len(id_lists) > 0:
-            id_lists.pop(0)  # ignore first request that reached max concurrency
+
+        if first_max_time is None:
+            raise AISBenchDataContentError(
+                CALC_CODES.CAN_NOT_FIND_STABLE_STAGE,
+                "Can not find a stable stage from performance results! Please check the conccurency plot.",
+            )
+
+        self.stage_section = [first_max_time, last_max_time]
+
+        # Collect all requests whose start_time falls within the stable interval
+        id_lists = [
+            id for id in range(len(perf_details["id"]))
+            if first_max_time <= perf_details["start_time"][id] <= last_max_time
+        ]
+
         if len(id_lists) == 0:
             raise AISBenchDataContentError(
                 CALC_CODES.CAN_NOT_FIND_STABLE_STAGE,
                 "Can not find a stable stage from performance results! Please check the conccurency plot.",
             )
+
         # Convert to relative time based on minimum start time
         relative_start_time = self.stage_section[0] - min_start_time
         relative_end_time = self.stage_section[1] - min_start_time

--- a/ais_bench/benchmark/calculators/stable_perf_metric_calculator.py
+++ b/ais_bench/benchmark/calculators/stable_perf_metric_calculator.py
@@ -16,11 +16,12 @@ class StablePerfMetricCalculator(BasePerfMetricCalculator):
     """
     Performance metric calculator for stable stage analysis.
 
-    This calculator identifies the stable phase as the interval from the first
-    time concurrency reaches max_concurrency to the last time it is at that level.
-    All requests starting within this interval are included regardless of
-    concurrency fluctuations, providing a robust steady-state performance measurement
-    without requiring manual parameter tuning.
+    This calculator identifies the stable phase as the interval from the second
+    request that reaches max_concurrency (the first is treated as a warm-up) to
+    the last time concurrency is at that level. All requests starting within this
+    interval are included regardless of concurrency fluctuations, providing a
+    robust steady-state performance measurement without requiring manual
+    parameter tuning.
 
     Args:
         stats_list (list, optional): List of statistics to calculate
@@ -62,10 +63,11 @@ class StablePerfMetricCalculator(BasePerfMetricCalculator):
         """
         Identify requests that belong to the stable stage.
 
-        The stable stage is defined as the interval from the first moment
-        concurrency reaches max_concurrency to the last moment concurrency
-        is at max_concurrency. All requests with start_time within this
-        closed interval are included, regardless of concurrency fluctuations.
+        The stable stage is defined as the interval from the second request
+        that reaches max_concurrency (the first is treated as a warm-up) to
+        the last moment concurrency is at max_concurrency. All requests with
+        start_time within this closed interval are included, regardless of
+        concurrency fluctuations.
 
         Args:
             perf_details (dict): Performance details dictionary
@@ -102,6 +104,7 @@ class StablePerfMetricCalculator(BasePerfMetricCalculator):
         first_max_time = None
         last_max_time = None
         concurrency = 0
+        max_start_count = 0
 
         progress_bar = tqdm(
             total=len(sorted_time_sections),
@@ -116,8 +119,11 @@ class StablePerfMetricCalculator(BasePerfMetricCalculator):
                 concurrency -= 1
 
             if concurrency == self.max_concurrency:
-                if first_max_time is None:
-                    first_max_time = section["time"]
+                if section["attr"] == "start":
+                    max_start_count += 1
+                    if max_start_count == 2:
+                        # 第 2 个达到 max 的请求才是稳定阶段起点，忽略首个达到 max 的请求
+                        first_max_time = section["time"]
                 last_max_time = section["time"]
 
             progress_bar.update(1)

--- a/tests/UT/calculators/test_stable_perf_metric_calculator.py
+++ b/tests/UT/calculators/test_stable_perf_metric_calculator.py
@@ -300,7 +300,8 @@ class TestStablePerfMetricCalculator(unittest.TestCase):
     
     def test_edge_case_empty_stable_stage(self):
         # 测试边缘情况 - 稳定阶段只有少量请求
-        # 新算法：单个请求达到 max_concurrency=1 时也是有效的稳定阶段
+        # 单个请求达到 max_concurrency=1 时，作为首个达到 max 的请求会被忽略（pop），
+        # 不存在第 2 个达到 max 的请求，因此应抛出异常
         calculator = StablePerfMetricCalculator()
         calculator.max_concurrency = 1
         calculator.logger = self.mock_logger
@@ -314,9 +315,9 @@ class TestStablePerfMetricCalculator(unittest.TestCase):
             "success": [True]
         }
 
-        result = calculator._get_requests_id(perf_details)
-        self.assertEqual(result, [0])
-        self.assertEqual(calculator.stage_section, [1.0, 1.0])
+        # 验证抛出异常
+        with self.assertRaises(AISBenchDataContentError):
+            calculator._get_requests_id(perf_details)
 
 
 if __name__ == "__main__":

--- a/tests/UT/calculators/test_stable_perf_metric_calculator.py
+++ b/tests/UT/calculators/test_stable_perf_metric_calculator.py
@@ -169,7 +169,68 @@ class TestStablePerfMetricCalculator(unittest.TestCase):
         calculator.stage_section = [2.0, 4.0]
         self.assertTrue(calculator.stage_section[0] > 0)
         self.assertTrue(calculator.stage_section[1] > calculator.stage_section[0])
-    
+
+    def test_get_requests_id_second_max_concurrency_as_start(self):
+        # 稳定阶段起点应为第 2 个达到 max_concurrency 的请求，而非第 1 个
+        calculator = StablePerfMetricCalculator()
+        calculator.max_concurrency = 2
+        calculator.logger = self.mock_logger
+        calculator.stage_section = [0, 0]
+
+        # req0/req1 爬坡：req1 启动时并发达到 2（第 1 个达到 max）
+        # req2 启动时并发再次达到 2（第 2 个达到 max）-> 稳定阶段起点
+        # req3 启动时并发第三次达到 2（最后一次达到 max）-> 稳定阶段终点
+        perf_details = {
+            "id": [0, 1, 2, 3],
+            "start_time": [1.0, 2.0, 4.0, 6.0],
+            "end_time": [3.5, 5.5, 7.0, 9.0],
+            "success": [True, True, True, True]
+        }
+
+        result = calculator._get_requests_id(perf_details)
+
+        # 起点 = req2 的 start(4.0)，终点 = 最后一次达到 max 的 req3 的 start(6.0)
+        self.assertEqual(calculator.stage_section, [4.0, 6.0])
+        # 第 1 个达到 max 的 req1 被排除；req2、req3 纳入
+        self.assertEqual(result, [2, 3])
+
+    def test_get_requests_id_single_max_reaching_raises(self):
+        # 并发只达到 max 一次（不存在第 2 个达到 max 的请求）时应抛出异常
+        calculator = StablePerfMetricCalculator()
+        calculator.max_concurrency = 2
+        calculator.logger = self.mock_logger
+        calculator.stage_section = [0, 0]
+
+        perf_details = {
+            "id": [0, 1],
+            "start_time": [1.0, 2.0],
+            "end_time": [3.0, 4.0],
+            "success": [True, True]
+        }
+
+        with self.assertRaises(AISBenchDataContentError):
+            calculator._get_requests_id(perf_details)
+
+    def test_get_requests_id_excludes_requests_after_last_max(self):
+        # 稳定阶段终点为最后一次达到 max 的时间，之后启动的请求应被排除
+        calculator = StablePerfMetricCalculator()
+        calculator.max_concurrency = 2
+        calculator.logger = self.mock_logger
+        calculator.stage_section = [0, 0]
+
+        perf_details = {
+            "id": [0, 1, 2, 3, 4],
+            "start_time": [1.0, 2.0, 3.5, 5.0, 8.0],
+            "end_time": [3.0, 4.0, 6.0, 7.0, 9.0],
+            "success": [True, True, True, True, True]
+        }
+
+        result = calculator._get_requests_id(perf_details)
+
+        self.assertEqual(calculator.stage_section, [3.5, 5.0])
+        # req2(3.5)、req3(5.0) 落在区间内；req4(8.0) 在终点之后被排除
+        self.assertEqual(result, [2, 3])
+
     def test_process_result(self):
         # 测试处理结果方法
         calculator = StablePerfMetricCalculator()

--- a/tests/UT/calculators/test_stable_perf_metric_calculator.py
+++ b/tests/UT/calculators/test_stable_perf_metric_calculator.py
@@ -300,11 +300,12 @@ class TestStablePerfMetricCalculator(unittest.TestCase):
     
     def test_edge_case_empty_stable_stage(self):
         # 测试边缘情况 - 稳定阶段只有少量请求
+        # 新算法：单个请求达到 max_concurrency=1 时也是有效的稳定阶段
         calculator = StablePerfMetricCalculator()
         calculator.max_concurrency = 1
         calculator.logger = self.mock_logger
         calculator.stage_section = [0, 0]  # 初始化必要的属性
-        
+
         # 准备测试数据 - 只有一个请求
         perf_details = {
             "id": [0],
@@ -312,10 +313,10 @@ class TestStablePerfMetricCalculator(unittest.TestCase):
             "end_time": [2.0],
             "success": [True]
         }
-        
-        # 验证抛出异常
-        with self.assertRaises(AISBenchDataContentError):
-            calculator._get_requests_id(perf_details)
+
+        result = calculator._get_requests_id(perf_details)
+        self.assertEqual(result, [0])
+        self.assertEqual(calculator.stage_section, [1.0, 1.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [x] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)

## 🔍 Motivation / 变更动机

Please describe the motivation of this PR and the goal you want to achieve through this PR.
请描述您的拉取请求的动机和您希望通过此拉取请求实现的目标。

## 📝 Modification / 修改内容

Please briefly describe what modification is made in this PR.
请简要描述此拉取请求中进行的修改。
将稳态检测中的判断逻辑算法修改下。
修改后逻辑：
首条达到max_concurrency，不会存储。
第二条达到max_concurrency，认为是稳态请求开端。
一直到最后一次达到max_concurrency，认为是稳态请求。
若是仅有单条达到max_concurrency，则认为没有稳态数据。

## 📐 Associated Test Results / 关联测试结果

主线用同一个performence跑之后
<img width="1351" height="1238" alt="image" src="https://github.com/user-attachments/assets/ff19ee85-3724-49dd-a35e-58590f245dd0" />
<img width="2302" height="1172" alt="image" src="https://github.com/user-attachments/assets/ce651698-59f4-4c89-8895-a1930cd6f443" />

修复后
<img width="2304" height="1115" alt="image" src="https://github.com/user-attachments/assets/30dfbb86-fa14-4501-9758-edee384ad27c" />
<img width="1349" height="1168" alt="image" src="https://github.com/user-attachments/assets/a3911872-42a8-46c2-93ea-c2626e166d96" />



Please provide links to the related test results, such as CI pipelines, test reports, etc.
请提供相关测试结果的链接，例如 CI 管道、测试报告等。

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
|`/pr_check`| 手动重新触发 PR 合入质量检查工作流（PR Quality Check），并在 PR 上评论即可生效。 / Manually re-runs the PR Quality Check workflow by commenting on the pull request. |
