### PR TITLE
[Feature] Added herding_coreset_selector, a tool for compressing large model quantization evaluation sets.

### DIFF
--- a/tests/UT/tools/herding_coreset_selector/conftest.py
+++ b/tests/UT/tools/herding_coreset_selector/conftest.py
@@ -1,0 +1,12 @@
+"""Test configuration for the standalone herding coreset selector."""
+
+import sys
+from pathlib import Path
+
+
+TOOL_ROOT = (
+    Path(__file__).resolve().parents[4] / "tools" / "herding_coreset_selector"
+)
+
+if str(TOOL_ROOT) not in sys.path:
+    sys.path.insert(0, str(TOOL_ROOT))

--- a/tests/UT/tools/herding_coreset_selector/test_algorithm.py
+++ b/tests/UT/tools/herding_coreset_selector/test_algorithm.py
@@ -4,77 +4,46 @@ import torch
 from herding import algorithm
 
 
-def test_rbf_kernel_has_expected_values():
-    data = np.array([[0.0], [2.0]])
-
-    kernel = algorithm._rbf_kernel(data, data, length_scale=2.0)
-
-    expected = np.array([[1.0, np.exp(-0.5)], [np.exp(-0.5), 1.0]])
-    np.testing.assert_allclose(kernel, expected)
-
-
-def test_median_heuristic_uses_pairwise_distances():
+def test_kernel_helpers():
     data = np.array([[0.0], [2.0], [4.0]])
+    kernel = algorithm._rbf_kernel(data[:2], data[:2], length_scale=2.0)
 
+    np.testing.assert_allclose(
+        kernel,
+        [[1.0, np.exp(-0.5)], [np.exp(-0.5), 1.0]],
+    )
     assert algorithm._median_heuristic(data) == 2.0
 
 
-def test_features_to_coreset_matrix_moves_tensors_to_cpu():
-    features = (torch.tensor(values) for values in ([1.0, 2.0], [3.0, 4.0]))
-
-    matrix = algorithm.features_to_coreset_matrix(features)
-
+def test_features_to_coreset_matrix():
+    features = (torch.tensor(row) for row in ([1.0, 2.0], [3.0, 4.0]))
     np.testing.assert_array_equal(
-        matrix,
+        algorithm.features_to_coreset_matrix(features),
         np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32),
     )
 
 
-def test_coreset_indices_returns_all_indices_when_size_covers_dataset():
-    data = np.array([[0.0], [1.0], [2.0]])
-
-    assert algorithm.coreset_indices(data, coreset_size=3) == [0, 1, 2]
-    assert algorithm.coreset_indices(data, coreset_size=10) == [0, 1, 2]
-
-
-def test_coreset_indices_are_unique_and_deterministic():
+def test_coreset_indices_boundary_and_determinism():
     data = np.array([[0.0], [0.5], [2.0], [8.0], [9.0]])
 
-    first = algorithm.coreset_indices(data, coreset_size=3)
-    second = algorithm.coreset_indices(data, coreset_size=3)
-
-    assert first == second
-    assert len(first) == 3
-    assert len(set(first)) == 3
-    assert all(0 <= index < len(data) for index in first)
+    assert algorithm.coreset_indices(data, 5) == list(range(5))
+    first = algorithm.coreset_indices(data, 3)
+    assert first == algorithm.coreset_indices(data, 3)
+    assert len(first) == len(set(first)) == 3
 
 
-def test_coreset_indices_falls_back_for_zero_bandwidth(monkeypatch):
-    data = np.ones((4, 2))
-    monkeypatch.setattr(algorithm, "_median_heuristic", lambda _: 0.0)
-
-    selected = algorithm.coreset_indices(data, coreset_size=2)
-
-    assert selected == [0, 1]
-
-
-def test_coreset_indices_processes_kernel_in_batches(monkeypatch):
-    data = np.arange(10, dtype=float).reshape(5, 2)
+def test_coreset_indices_fallback_and_kernel_batches(monkeypatch):
+    data = np.ones((5, 2))
     calls = []
-    original_rbf_kernel = algorithm._rbf_kernel
+    original_kernel = algorithm._rbf_kernel
 
-    def recording_kernel(left, right, length_scale):
+    def record(left, right, length_scale):
         calls.append(left.shape[0])
-        return original_rbf_kernel(left, right, length_scale)
+        return original_kernel(left, right, length_scale)
 
     monkeypatch.setattr(algorithm, "KERNEL_BATCH", 2)
-    monkeypatch.setattr(algorithm, "_rbf_kernel", recording_kernel)
+    monkeypatch.setattr(algorithm, "_median_heuristic", lambda _: 0.0)
+    monkeypatch.setattr(algorithm, "_rbf_kernel", record)
 
-    selected = algorithm.coreset_indices(
-        data,
-        coreset_size=1,
-        length_scale=1.0,
-    )
-
-    assert len(selected) == 1
+    assert algorithm.coreset_indices(data, 2) == [0, 1]
     assert calls[:3] == [2, 2, 1]

--- a/tests/UT/tools/herding_coreset_selector/test_algorithm.py
+++ b/tests/UT/tools/herding_coreset_selector/test_algorithm.py
@@ -1,0 +1,80 @@
+import numpy as np
+import torch
+
+from herding import algorithm
+
+
+def test_rbf_kernel_has_expected_values():
+    data = np.array([[0.0], [2.0]])
+
+    kernel = algorithm._rbf_kernel(data, data, length_scale=2.0)
+
+    expected = np.array([[1.0, np.exp(-0.5)], [np.exp(-0.5), 1.0]])
+    np.testing.assert_allclose(kernel, expected)
+
+
+def test_median_heuristic_uses_pairwise_distances():
+    data = np.array([[0.0], [2.0], [4.0]])
+
+    assert algorithm._median_heuristic(data) == 2.0
+
+
+def test_features_to_coreset_matrix_moves_tensors_to_cpu():
+    features = (torch.tensor(values) for values in ([1.0, 2.0], [3.0, 4.0]))
+
+    matrix = algorithm.features_to_coreset_matrix(features)
+
+    np.testing.assert_array_equal(
+        matrix,
+        np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32),
+    )
+
+
+def test_coreset_indices_returns_all_indices_when_size_covers_dataset():
+    data = np.array([[0.0], [1.0], [2.0]])
+
+    assert algorithm.coreset_indices(data, coreset_size=3) == [0, 1, 2]
+    assert algorithm.coreset_indices(data, coreset_size=10) == [0, 1, 2]
+
+
+def test_coreset_indices_are_unique_and_deterministic():
+    data = np.array([[0.0], [0.5], [2.0], [8.0], [9.0]])
+
+    first = algorithm.coreset_indices(data, coreset_size=3)
+    second = algorithm.coreset_indices(data, coreset_size=3)
+
+    assert first == second
+    assert len(first) == 3
+    assert len(set(first)) == 3
+    assert all(0 <= index < len(data) for index in first)
+
+
+def test_coreset_indices_falls_back_for_zero_bandwidth(monkeypatch):
+    data = np.ones((4, 2))
+    monkeypatch.setattr(algorithm, "_median_heuristic", lambda _: 0.0)
+
+    selected = algorithm.coreset_indices(data, coreset_size=2)
+
+    assert selected == [0, 1]
+
+
+def test_coreset_indices_processes_kernel_in_batches(monkeypatch):
+    data = np.arange(10, dtype=float).reshape(5, 2)
+    calls = []
+    original_rbf_kernel = algorithm._rbf_kernel
+
+    def recording_kernel(left, right, length_scale):
+        calls.append(left.shape[0])
+        return original_rbf_kernel(left, right, length_scale)
+
+    monkeypatch.setattr(algorithm, "KERNEL_BATCH", 2)
+    monkeypatch.setattr(algorithm, "_rbf_kernel", recording_kernel)
+
+    selected = algorithm.coreset_indices(
+        data,
+        coreset_size=1,
+        length_scale=1.0,
+    )
+
+    assert len(selected) == 1
+    assert calls[:3] == [2, 2, 1]

--- a/tests/UT/tools/herding_coreset_selector/test_cli.py
+++ b/tests/UT/tools/herding_coreset_selector/test_cli.py
@@ -5,12 +5,10 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
-import torch
 
 import herding
 from herding import __main__ as cli
-from herding import algorithm, features
-from herding import eval_datasets
+from herding import algorithm, eval_datasets, features
 
 
 @pytest.mark.parametrize("value", ["0.1", "1", "1.0"])
@@ -18,66 +16,43 @@ def test_coreset_ratio_accepts_valid_values(value):
     assert cli._coreset_ratio(value) == float(value)
 
 
-@pytest.mark.parametrize("value", ["0", "-0.1", "1.01", "invalid"])
+@pytest.mark.parametrize("value", ["0", "-0.1", "1.01", "bad"])
 def test_coreset_ratio_rejects_invalid_values(value):
     with pytest.raises(argparse.ArgumentTypeError):
         cli._coreset_ratio(value)
 
 
-def test_model_name_supports_trailing_path_separator():
-    assert cli._model_name("/models/Qwen2.5-7B-Instruct/") == "Qwen2.5-7B-Instruct"
-    assert cli._model_name("C:\\models\\example\\") == "example"
-
-
-def test_model_name_rejects_path_without_a_name():
-    with pytest.raises(ValueError, match="Unable to infer model name"):
+def test_model_name_and_parse_defaults(monkeypatch):
+    assert cli._model_name("/models/example/") == "example"
+    with pytest.raises(ValueError, match="Unable to infer"):
         cli._model_name("/")
 
-
-def test_parse_args_uses_defaults(monkeypatch):
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "herding",
-            "--eval-dataset",
-            "aime2025",
-            "--dataset-path",
-            "/datasets/aime2025",
-            "--model-path",
-            "/models/example",
+            "--eval-dataset", "aime2025",
+            "--dataset-path", "/datasets/aime2025",
+            "--model-path", "/models/example",
         ],
     )
-
     args = cli.parse_args()
-
-    assert args.eval_dataset == "aime2025"
     assert args.coreset_ratio == cli.DEFAULT_CORESET_RATIO
     assert args.output_dir == cli.DEFAULT_OUTPUT_DIR
-
-
-class FakeEvalDataset:
-    def __init__(self, indices):
-        self.indices = indices
-        self.saved = []
-
-    def load_indices(self):
-        return self.indices
-
-    def save_data_by_indices(self, indices, outpath):
-        self.saved.append((list(indices), outpath))
-        return f"/saved/{outpath}"
 
 
 def test_main_generates_and_saves_coreset(tmp_path, monkeypatch, capsys):
     args = SimpleNamespace(
         eval_dataset="gpqa",
         dataset_path="/datasets/gpqa",
-        model_path="/models/example/",
+        model_path="/models/example",
         coreset_ratio=0.4,
         output_dir=str(tmp_path),
     )
-    dataset = FakeEvalDataset([0, 1, 2, 3, 4])
+    dataset = Mock()
+    dataset.load_indices.return_value = [0, 1, 2, 3, 4]
+    dataset.save_data_by_indices.side_effect = ["/saved/origin", "/saved/coreset"]
     get_dataset = Mock(return_value=dataset)
     generate = Mock(return_value=[3, 1])
     monkeypatch.setattr(cli, "parse_args", lambda: args)
@@ -91,58 +66,31 @@ def test_main_generates_and_saves_coreset(tmp_path, monkeypatch, capsys):
         dataset_path="/datasets/gpqa",
         output_dir=str(tmp_path / "gpqa" / "herding" / "example"),
     )
-    assert dataset.saved == [([0, 1, 2, 3, 4], "origin"), ([3, 1], "coreset")]
-    generate.assert_called_once_with(
-        2,
-        eval_dataset=dataset,
-        model_path="/models/example/",
+    assert dataset.save_data_by_indices.call_args_list[0].args == (
+        [0, 1, 2, 3, 4], "origin"
     )
+    generate.assert_called_once_with(2, eval_dataset=dataset, model_path="/models/example")
+    assert dataset.save_data_by_indices.call_args_list[1].args == ([3, 1], "coreset")
     assert "output: /saved/coreset" in capsys.readouterr().out
 
 
-def test_main_rejects_empty_dataset(tmp_path, monkeypatch):
-    args = SimpleNamespace(
-        eval_dataset="gpqa",
-        dataset_path="/datasets/gpqa",
-        model_path="/models/example",
-        coreset_ratio=0.2,
-        output_dir=str(tmp_path),
-    )
-    dataset = FakeEvalDataset([])
-    monkeypatch.setattr(cli, "parse_args", lambda: args)
-    monkeypatch.setattr(eval_datasets, "get_eval_dataset", Mock(return_value=dataset))
-
-    with pytest.raises(ValueError, match="dataset is empty"):
-        cli.main()
-
-
-def test_generate_coreset_orchestrates_feature_extraction(monkeypatch, capsys):
+def test_generate_coreset_pipeline(monkeypatch):
     dataset = Mock()
-    dataset.dataset_prompts.return_value = iter(["prompt one", "prompt two"])
+    dataset.dataset_prompts.return_value = iter(["one", "two"])
     dataset.dataset_size.return_value = 2
-    model = object()
-    tokenizer = object()
-    feature_tensors = [torch.tensor([1.0]), torch.tensor([2.0])]
-    load_model = Mock(return_value=(model, tokenizer))
-    generate_logits = Mock(return_value=iter(feature_tensors))
-    to_matrix = Mock(return_value=np.array([[1.0], [2.0]]))
+    load = Mock(return_value=("model", "tokenizer"))
+    generate = Mock(return_value=iter(["feature-1", "feature-2"]))
+    matrix = np.array([[1.0], [2.0]])
+    to_matrix = Mock(return_value=matrix)
     select = Mock(return_value=[1])
-    monkeypatch.setattr(features, "load_model", load_model)
-    monkeypatch.setattr(features, "generate_logits", generate_logits)
+    monkeypatch.setattr(features, "load_model", load)
+    monkeypatch.setattr(features, "generate_logits", generate)
     monkeypatch.setattr(algorithm, "features_to_coreset_matrix", to_matrix)
     monkeypatch.setattr(algorithm, "coreset_indices", select)
 
-    result = herding.generate_coreset(1, dataset, "/models/example")
-
-    assert result == [1]
-    load_model.assert_called_once_with("/models/example")
-    generate_logits.assert_called_once()
-    passed_model, passed_tokenizer, passed_prompts = generate_logits.call_args.args
-    assert passed_model is model
-    assert passed_tokenizer is tokenizer
-    assert list(passed_prompts) == ["prompt one", "prompt two"]
+    assert herding.generate_coreset(1, dataset, "/model") == [1]
+    load.assert_called_once_with("/model")
+    generate.assert_called_once()
     to_matrix.assert_called_once()
-    select.assert_called_once()
-    np.testing.assert_array_equal(select.call_args.args[0], np.array([[1.0], [2.0]]))
+    np.testing.assert_array_equal(select.call_args.args[0], matrix)
     assert select.call_args.args[1] == 1
-    assert "herding:" in capsys.readouterr().out

--- a/tests/UT/tools/herding_coreset_selector/test_cli.py
+++ b/tests/UT/tools/herding_coreset_selector/test_cli.py
@@ -1,0 +1,148 @@
+import argparse
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+
+import herding
+from herding import __main__ as cli
+from herding import algorithm, features
+from herding import eval_datasets
+
+
+@pytest.mark.parametrize("value", ["0.1", "1", "1.0"])
+def test_coreset_ratio_accepts_valid_values(value):
+    assert cli._coreset_ratio(value) == float(value)
+
+
+@pytest.mark.parametrize("value", ["0", "-0.1", "1.01", "invalid"])
+def test_coreset_ratio_rejects_invalid_values(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._coreset_ratio(value)
+
+
+def test_model_name_supports_trailing_path_separator():
+    assert cli._model_name("/models/Qwen2.5-7B-Instruct/") == "Qwen2.5-7B-Instruct"
+    assert cli._model_name("C:\\models\\example\\") == "example"
+
+
+def test_model_name_rejects_path_without_a_name():
+    with pytest.raises(ValueError, match="Unable to infer model name"):
+        cli._model_name("/")
+
+
+def test_parse_args_uses_defaults(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "herding",
+            "--eval-dataset",
+            "aime2025",
+            "--dataset-path",
+            "/datasets/aime2025",
+            "--model-path",
+            "/models/example",
+        ],
+    )
+
+    args = cli.parse_args()
+
+    assert args.eval_dataset == "aime2025"
+    assert args.coreset_ratio == cli.DEFAULT_CORESET_RATIO
+    assert args.output_dir == cli.DEFAULT_OUTPUT_DIR
+
+
+class FakeEvalDataset:
+    def __init__(self, indices):
+        self.indices = indices
+        self.saved = []
+
+    def load_indices(self):
+        return self.indices
+
+    def save_data_by_indices(self, indices, outpath):
+        self.saved.append((list(indices), outpath))
+        return f"/saved/{outpath}"
+
+
+def test_main_generates_and_saves_coreset(tmp_path, monkeypatch, capsys):
+    args = SimpleNamespace(
+        eval_dataset="gpqa",
+        dataset_path="/datasets/gpqa",
+        model_path="/models/example/",
+        coreset_ratio=0.4,
+        output_dir=str(tmp_path),
+    )
+    dataset = FakeEvalDataset([0, 1, 2, 3, 4])
+    get_dataset = Mock(return_value=dataset)
+    generate = Mock(return_value=[3, 1])
+    monkeypatch.setattr(cli, "parse_args", lambda: args)
+    monkeypatch.setattr(eval_datasets, "get_eval_dataset", get_dataset)
+    monkeypatch.setattr(herding, "generate_coreset", generate)
+
+    cli.main()
+
+    get_dataset.assert_called_once_with(
+        "gpqa",
+        dataset_path="/datasets/gpqa",
+        output_dir=str(tmp_path / "gpqa" / "herding" / "example"),
+    )
+    assert dataset.saved == [([0, 1, 2, 3, 4], "origin"), ([3, 1], "coreset")]
+    generate.assert_called_once_with(
+        2,
+        eval_dataset=dataset,
+        model_path="/models/example/",
+    )
+    assert "output: /saved/coreset" in capsys.readouterr().out
+
+
+def test_main_rejects_empty_dataset(tmp_path, monkeypatch):
+    args = SimpleNamespace(
+        eval_dataset="gpqa",
+        dataset_path="/datasets/gpqa",
+        model_path="/models/example",
+        coreset_ratio=0.2,
+        output_dir=str(tmp_path),
+    )
+    dataset = FakeEvalDataset([])
+    monkeypatch.setattr(cli, "parse_args", lambda: args)
+    monkeypatch.setattr(eval_datasets, "get_eval_dataset", Mock(return_value=dataset))
+
+    with pytest.raises(ValueError, match="dataset is empty"):
+        cli.main()
+
+
+def test_generate_coreset_orchestrates_feature_extraction(monkeypatch, capsys):
+    dataset = Mock()
+    dataset.dataset_prompts.return_value = iter(["prompt one", "prompt two"])
+    dataset.dataset_size.return_value = 2
+    model = object()
+    tokenizer = object()
+    feature_tensors = [torch.tensor([1.0]), torch.tensor([2.0])]
+    load_model = Mock(return_value=(model, tokenizer))
+    generate_logits = Mock(return_value=iter(feature_tensors))
+    to_matrix = Mock(return_value=np.array([[1.0], [2.0]]))
+    select = Mock(return_value=[1])
+    monkeypatch.setattr(features, "load_model", load_model)
+    monkeypatch.setattr(features, "generate_logits", generate_logits)
+    monkeypatch.setattr(algorithm, "features_to_coreset_matrix", to_matrix)
+    monkeypatch.setattr(algorithm, "coreset_indices", select)
+
+    result = herding.generate_coreset(1, dataset, "/models/example")
+
+    assert result == [1]
+    load_model.assert_called_once_with("/models/example")
+    generate_logits.assert_called_once()
+    passed_model, passed_tokenizer, passed_prompts = generate_logits.call_args.args
+    assert passed_model is model
+    assert passed_tokenizer is tokenizer
+    assert list(passed_prompts) == ["prompt one", "prompt two"]
+    to_matrix.assert_called_once()
+    select.assert_called_once()
+    np.testing.assert_array_equal(select.call_args.args[0], np.array([[1.0], [2.0]]))
+    assert select.call_args.args[1] == 1
+    assert "herding:" in capsys.readouterr().out

--- a/tests/UT/tools/herding_coreset_selector/test_eval_datasets.py
+++ b/tests/UT/tools/herding_coreset_selector/test_eval_datasets.py
@@ -11,12 +11,8 @@ from herding.eval_datasets.gpqa import GpqaDataset
 
 
 class DummyDataset(dataset_base.EvalDatasetBase):
-    def __init__(self, dataset_path, output_dir, size=3):
-        super().__init__(dataset_path, output_dir)
-        self.size = size
-
     def dataset_size(self):
-        return self.size
+        return 3
 
     def dataset_prompts(self):
         return iter(())
@@ -25,105 +21,71 @@ class DummyDataset(dataset_base.EvalDatasetBase):
         return indices, outpath
 
 
-def test_base_dataset_indices_round_trip(tmp_path):
-    dataset = DummyDataset(tmp_path / "data", tmp_path / "output")
-    strategy_dir = tmp_path / "output" / "existing"
+def test_base_indices_and_registry(tmp_path):
+    dataset = DummyDataset(tmp_path, tmp_path / "output")
+    strategy_dir = tmp_path / "output" / "strategy"
     strategy_dir.mkdir(parents=True)
-
     dataset.save_indices([2, 0], strategy_dir)
 
     assert dataset.load_indices() == [0, 1, 2]
-    assert dataset.load_indices_from_strategy("existing") == [2, 0]
+    assert dataset.load_indices_from_strategy("strategy") == [2, 0]
     assert dataset.load_indices_from_strategy("missing") is None
 
-
-def test_dataset_registry_constructs_registered_adapter(tmp_path):
     name = "unit_test_dataset"
-    dataset_base.EVAL_DATASETS.pop(name, None)
-
-    @dataset_base.reg_eval_dataset(name)
-    class RegisteredDataset(DummyDataset):
-        pass
-
+    dataset_base.reg_eval_dataset(name)(DummyDataset)
     try:
-        result = dataset_base.get_eval_dataset(name, tmp_path, tmp_path / "out")
-        assert isinstance(result, RegisteredDataset)
+        assert isinstance(
+            dataset_base.get_eval_dataset(name, tmp_path, tmp_path / "out"),
+            DummyDataset,
+        )
+        with pytest.raises(ValueError, match="Unknown dataset"):
+            dataset_base.get_eval_dataset("unknown", tmp_path, tmp_path)
     finally:
-        dataset_base.EVAL_DATASETS.pop(name, None)
+        dataset_base.EVAL_DATASETS.pop(name)
 
 
-def test_dataset_registry_rejects_unknown_name(tmp_path):
-    with pytest.raises(ValueError, match="Unknown dataset"):
-        dataset_base.get_eval_dataset("not-registered", tmp_path, tmp_path / "out")
-
-
-def test_aime2025_load_prompts_and_save_selected_rows(tmp_path):
-    dataset_path = tmp_path / "source"
-    dataset_path.mkdir()
-    source_rows = [
+def test_aime2025_load_prompt_and_save(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    rows = [
         {"question": "What is 1 + 1?", "answer": "2"},
         {"question": "What is 2 + 2?", "answer": "4"},
     ]
-    source_file = dataset_path / "aime2025.jsonl"
-    source_file.write_text(
-        "\n".join(json.dumps(row) for row in source_rows) + "\n\n",
+    (source / "aime2025.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n\n",
         encoding="utf-8",
     )
-    dataset = Aime2025Dataset(dataset_path, tmp_path / "result")
-
-    prompts = list(dataset.dataset_prompts())
-    output_dir = dataset.save_data_by_indices([1], "coreset")
+    dataset = Aime2025Dataset(source, tmp_path / "result")
 
     assert dataset.dataset_size() == 2
-    assert "What is 1 + 1?" in prompts[0]
-    saved_lines = (tmp_path / "result" / "coreset" / "aime2025.jsonl").read_text(
-        encoding="utf-8"
-    ).splitlines()
-    assert [json.loads(line) for line in saved_lines] == [source_rows[1]]
-    assert json.loads(
-        (tmp_path / "result" / "coreset" / "indices.json").read_text(
-            encoding="utf-8"
-        )
-    ) == [1]
-    assert output_dir == str(tmp_path / "result" / "coreset")
+    assert "What is 1 + 1?" in next(dataset.dataset_prompts())
+    output = dataset.save_data_by_indices([1], "coreset")
+    saved = (tmp_path / "result" / "coreset" / "aime2025.jsonl").read_text()
+    assert json.loads(saved) == rows[1]
+    assert json.loads((tmp_path / "result" / "coreset" / "indices.json").read_text()) == [1]
+    assert output == str(tmp_path / "result" / "coreset")
 
 
-def test_gpqa_builds_prompts_and_preserves_csv_rows(tmp_path, monkeypatch):
-    dataset_path = tmp_path / "source"
-    dataset_path.mkdir()
-    csv_path = dataset_path / GPQA_FILENAME
+def test_gpqa_prompt_and_save(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    source.mkdir()
     rows = [
         ["question", "A", "B", "C", "D", "answer"],
-        ["question one", "a1", "b1", "c1", "d1", "A"],
-        ["question two", "a2", "b2", "c2", "d2", "B"],
+        ["q1", "a1", "b1", "c1", "d1", "A"],
+        ["q2", "a2", "b2", "c2", "d2", "B"],
     ]
-    with csv_path.open("w", newline="", encoding="utf-8") as output:
+    with (source / GPQA_FILENAME).open("w", newline="") as output:
         csv.writer(output).writerows(rows)
-
-    built_rows = [
-        {"question": "question one", "A": "a1", "B": "b1", "C": "c1", "D": "d1"},
-        {"question": "question two", "A": "a2", "B": "b2", "C": "c2", "D": "d2"},
-    ]
-    build_mock = lambda _cfg: SimpleNamespace(test=built_rows)
+    items = [dict(zip(rows[0][:-1], row[:-1])) for row in rows[1:]]
     monkeypatch.setattr(
         "herding.eval_datasets.gpqa.build_dataset_from_cfg",
-        build_mock,
+        lambda _cfg: SimpleNamespace(test=items),
     )
-    dataset = GpqaDataset(dataset_path, tmp_path / "result")
+    dataset = GpqaDataset(source, tmp_path / "result")
 
-    prompts = list(dataset.dataset_prompts())
-    output_dir = dataset.save_data_by_indices([1, 0], "coreset")
-
-    assert dataset.dataset_size() == 2
-    assert "question one" in prompts[0]
-    assert "A) a1" in prompts[0]
-    with (tmp_path / "result" / "coreset" / GPQA_FILENAME).open(
-        newline="", encoding="utf-8"
-    ) as saved_file:
-        assert list(csv.reader(saved_file)) == [rows[0], rows[2], rows[1]]
-    assert json.loads(
-        (tmp_path / "result" / "coreset" / "indices.json").read_text(
-            encoding="utf-8"
-        )
-    ) == [1, 0]
-    assert output_dir == str(tmp_path / "result" / "coreset")
+    assert "A) a1" in next(dataset.dataset_prompts())
+    dataset.save_data_by_indices([1, 0], "coreset")
+    with (tmp_path / "result" / "coreset" / GPQA_FILENAME).open() as saved:
+        assert list(csv.reader(saved)) == [rows[0], rows[2], rows[1]]
+    indices = tmp_path / "result" / "coreset" / "indices.json"
+    assert json.loads(indices.read_text()) == [1, 0]

--- a/tests/UT/tools/herding_coreset_selector/test_eval_datasets.py
+++ b/tests/UT/tools/herding_coreset_selector/test_eval_datasets.py
@@ -1,0 +1,129 @@
+import csv
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from herding.eval_datasets import dataset_base
+from herding.eval_datasets.aime2025 import Aime2025Dataset
+from herding.eval_datasets.gpqa import FILENAME as GPQA_FILENAME
+from herding.eval_datasets.gpqa import GpqaDataset
+
+
+class DummyDataset(dataset_base.EvalDatasetBase):
+    def __init__(self, dataset_path, output_dir, size=3):
+        super().__init__(dataset_path, output_dir)
+        self.size = size
+
+    def dataset_size(self):
+        return self.size
+
+    def dataset_prompts(self):
+        return iter(())
+
+    def save_data_by_indices(self, indices, outpath):
+        return indices, outpath
+
+
+def test_base_dataset_indices_round_trip(tmp_path):
+    dataset = DummyDataset(tmp_path / "data", tmp_path / "output")
+    strategy_dir = tmp_path / "output" / "existing"
+    strategy_dir.mkdir(parents=True)
+
+    dataset.save_indices([2, 0], strategy_dir)
+
+    assert dataset.load_indices() == [0, 1, 2]
+    assert dataset.load_indices_from_strategy("existing") == [2, 0]
+    assert dataset.load_indices_from_strategy("missing") is None
+
+
+def test_dataset_registry_constructs_registered_adapter(tmp_path):
+    name = "unit_test_dataset"
+    dataset_base.EVAL_DATASETS.pop(name, None)
+
+    @dataset_base.reg_eval_dataset(name)
+    class RegisteredDataset(DummyDataset):
+        pass
+
+    try:
+        result = dataset_base.get_eval_dataset(name, tmp_path, tmp_path / "out")
+        assert isinstance(result, RegisteredDataset)
+    finally:
+        dataset_base.EVAL_DATASETS.pop(name, None)
+
+
+def test_dataset_registry_rejects_unknown_name(tmp_path):
+    with pytest.raises(ValueError, match="Unknown dataset"):
+        dataset_base.get_eval_dataset("not-registered", tmp_path, tmp_path / "out")
+
+
+def test_aime2025_load_prompts_and_save_selected_rows(tmp_path):
+    dataset_path = tmp_path / "source"
+    dataset_path.mkdir()
+    source_rows = [
+        {"question": "What is 1 + 1?", "answer": "2"},
+        {"question": "What is 2 + 2?", "answer": "4"},
+    ]
+    source_file = dataset_path / "aime2025.jsonl"
+    source_file.write_text(
+        "\n".join(json.dumps(row) for row in source_rows) + "\n\n",
+        encoding="utf-8",
+    )
+    dataset = Aime2025Dataset(dataset_path, tmp_path / "result")
+
+    prompts = list(dataset.dataset_prompts())
+    output_dir = dataset.save_data_by_indices([1], "coreset")
+
+    assert dataset.dataset_size() == 2
+    assert "What is 1 + 1?" in prompts[0]
+    saved_lines = (tmp_path / "result" / "coreset" / "aime2025.jsonl").read_text(
+        encoding="utf-8"
+    ).splitlines()
+    assert [json.loads(line) for line in saved_lines] == [source_rows[1]]
+    assert json.loads(
+        (tmp_path / "result" / "coreset" / "indices.json").read_text(
+            encoding="utf-8"
+        )
+    ) == [1]
+    assert output_dir == str(tmp_path / "result" / "coreset")
+
+
+def test_gpqa_builds_prompts_and_preserves_csv_rows(tmp_path, monkeypatch):
+    dataset_path = tmp_path / "source"
+    dataset_path.mkdir()
+    csv_path = dataset_path / GPQA_FILENAME
+    rows = [
+        ["question", "A", "B", "C", "D", "answer"],
+        ["question one", "a1", "b1", "c1", "d1", "A"],
+        ["question two", "a2", "b2", "c2", "d2", "B"],
+    ]
+    with csv_path.open("w", newline="", encoding="utf-8") as output:
+        csv.writer(output).writerows(rows)
+
+    built_rows = [
+        {"question": "question one", "A": "a1", "B": "b1", "C": "c1", "D": "d1"},
+        {"question": "question two", "A": "a2", "B": "b2", "C": "c2", "D": "d2"},
+    ]
+    build_mock = lambda _cfg: SimpleNamespace(test=built_rows)
+    monkeypatch.setattr(
+        "herding.eval_datasets.gpqa.build_dataset_from_cfg",
+        build_mock,
+    )
+    dataset = GpqaDataset(dataset_path, tmp_path / "result")
+
+    prompts = list(dataset.dataset_prompts())
+    output_dir = dataset.save_data_by_indices([1, 0], "coreset")
+
+    assert dataset.dataset_size() == 2
+    assert "question one" in prompts[0]
+    assert "A) a1" in prompts[0]
+    with (tmp_path / "result" / "coreset" / GPQA_FILENAME).open(
+        newline="", encoding="utf-8"
+    ) as saved_file:
+        assert list(csv.reader(saved_file)) == [rows[0], rows[2], rows[1]]
+    assert json.loads(
+        (tmp_path / "result" / "coreset" / "indices.json").read_text(
+            encoding="utf-8"
+        )
+    ) == [1, 0]
+    assert output_dir == str(tmp_path / "result" / "coreset")

--- a/tests/UT/tools/herding_coreset_selector/test_features.py
+++ b/tests/UT/tools/herding_coreset_selector/test_features.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from herding import features
+
+
+def test_load_model_uses_auto_device_map_and_eval(monkeypatch):
+    tokenizer = object()
+    model = Mock()
+    tokenizer_loader = Mock(return_value=tokenizer)
+    model_loader = Mock(return_value=model)
+    monkeypatch.setattr(features.AutoTokenizer, "from_pretrained", tokenizer_loader)
+    monkeypatch.setattr(
+        features.AutoModelForCausalLM,
+        "from_pretrained",
+        model_loader,
+    )
+
+    loaded_model, loaded_tokenizer = features.load_model("/models/example")
+
+    assert loaded_model is model
+    assert loaded_tokenizer is tokenizer
+    tokenizer_loader.assert_called_once_with("/models/example")
+    model_loader.assert_called_once_with("/models/example", device_map="auto")
+    model.eval.assert_called_once_with()
+
+
+def test_generate_logits_extracts_first_generated_hidden_state():
+    class FakeInputs:
+        input_ids = torch.tensor([[1, 2]])
+
+        def __init__(self):
+            self.target_device = None
+
+        def to(self, device):
+            self.target_device = device
+            return self
+
+    inputs = FakeInputs()
+    tokenizer = Mock(return_value=inputs)
+    expected = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    generated_step = [torch.zeros_like(expected), torch.ones_like(expected), expected]
+    model = Mock()
+    model.device = torch.device("cpu")
+    model.config.num_hidden_layers = 2
+    model.generate.return_value = SimpleNamespace(
+        hidden_states=[None, generated_step]
+    )
+
+    results = list(features.generate_logits(model, tokenizer, ["first prompt"]))
+
+    assert inputs.target_device == model.device
+    tokenizer.assert_called_once_with("first prompt", return_tensors="pt")
+    model.generate.assert_called_once_with(
+        inputs.input_ids,
+        max_new_tokens=2,
+        do_sample=False,
+        output_hidden_states=True,
+        return_dict_in_generate=True,
+    )
+    assert len(results) == 1
+    torch.testing.assert_close(results[0], torch.tensor([3.0, 4.0]))
+
+
+def test_generate_logits_handles_multiple_prompts():
+    class FakeInputs:
+        input_ids = torch.tensor([[1]])
+
+        def to(self, _device):
+            return self
+
+    tokenizer = Mock(side_effect=lambda *_args, **_kwargs: FakeInputs())
+    hidden = torch.tensor([[[5.0]]])
+    model = Mock()
+    model.device = torch.device("cpu")
+    model.config.num_hidden_layers = 0
+    model.generate.return_value = SimpleNamespace(hidden_states=[None, [hidden]])
+
+    results = list(features.generate_logits(model, tokenizer, ["one", "two"]))
+
+    assert tokenizer.call_count == 2
+    assert model.generate.call_count == 2
+    assert [result.item() for result in results] == [5.0, 5.0]

--- a/tests/UT/tools/herding_coreset_selector/test_features.py
+++ b/tests/UT/tools/herding_coreset_selector/test_features.py
@@ -6,53 +6,42 @@ import torch
 from herding import features
 
 
-def test_load_model_uses_auto_device_map_and_eval(monkeypatch):
+def test_load_model(monkeypatch):
     tokenizer = object()
     model = Mock()
     tokenizer_loader = Mock(return_value=tokenizer)
     model_loader = Mock(return_value=model)
     monkeypatch.setattr(features.AutoTokenizer, "from_pretrained", tokenizer_loader)
-    monkeypatch.setattr(
-        features.AutoModelForCausalLM,
-        "from_pretrained",
-        model_loader,
-    )
+    monkeypatch.setattr(features.AutoModelForCausalLM, "from_pretrained", model_loader)
 
-    loaded_model, loaded_tokenizer = features.load_model("/models/example")
-
-    assert loaded_model is model
-    assert loaded_tokenizer is tokenizer
+    assert features.load_model("/models/example") == (model, tokenizer)
     tokenizer_loader.assert_called_once_with("/models/example")
     model_loader.assert_called_once_with("/models/example", device_map="auto")
     model.eval.assert_called_once_with()
 
 
-def test_generate_logits_extracts_first_generated_hidden_state():
-    class FakeInputs:
+def test_generate_logits_extracts_hidden_state():
+    class Inputs:
         input_ids = torch.tensor([[1, 2]])
 
-        def __init__(self):
-            self.target_device = None
-
         def to(self, device):
-            self.target_device = device
+            self.device = device
             return self
 
-    inputs = FakeInputs()
+    inputs = Inputs()
     tokenizer = Mock(return_value=inputs)
-    expected = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
-    generated_step = [torch.zeros_like(expected), torch.ones_like(expected), expected]
-    model = Mock()
-    model.device = torch.device("cpu")
-    model.config.num_hidden_layers = 2
+    hidden = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    model = Mock(
+        device=torch.device("cpu"),
+        config=SimpleNamespace(num_hidden_layers=1),
+    )
     model.generate.return_value = SimpleNamespace(
-        hidden_states=[None, generated_step]
+        hidden_states=[None, [torch.zeros_like(hidden), hidden]]
     )
 
-    results = list(features.generate_logits(model, tokenizer, ["first prompt"]))
+    result = list(features.generate_logits(model, tokenizer, ["prompt"]))
 
-    assert inputs.target_device == model.device
-    tokenizer.assert_called_once_with("first prompt", return_tensors="pt")
+    tokenizer.assert_called_once_with("prompt", return_tensors="pt")
     model.generate.assert_called_once_with(
         inputs.input_ids,
         max_new_tokens=2,
@@ -60,26 +49,5 @@ def test_generate_logits_extracts_first_generated_hidden_state():
         output_hidden_states=True,
         return_dict_in_generate=True,
     )
-    assert len(results) == 1
-    torch.testing.assert_close(results[0], torch.tensor([3.0, 4.0]))
-
-
-def test_generate_logits_handles_multiple_prompts():
-    class FakeInputs:
-        input_ids = torch.tensor([[1]])
-
-        def to(self, _device):
-            return self
-
-    tokenizer = Mock(side_effect=lambda *_args, **_kwargs: FakeInputs())
-    hidden = torch.tensor([[[5.0]]])
-    model = Mock()
-    model.device = torch.device("cpu")
-    model.config.num_hidden_layers = 0
-    model.generate.return_value = SimpleNamespace(hidden_states=[None, [hidden]])
-
-    results = list(features.generate_logits(model, tokenizer, ["one", "two"]))
-
-    assert tokenizer.call_count == 2
-    assert model.generate.call_count == 2
-    assert [result.item() for result in results] == [5.0, 5.0]
+    assert inputs.device == model.device
+    torch.testing.assert_close(result[0], torch.tensor([3.0, 4.0]))

--- a/tools/herding_coreset_selector/README.md
+++ b/tools/herding_coreset_selector/README.md
@@ -6,32 +6,6 @@ Herding Coreset Selector 是一个用于评测数据集代表性样本筛选的�
 
 工具使用指定语言模型提取样本 Prompt 的隐藏状态特征，并基于 RBF Kernel 的 Kernel Herding 方法，从完整数据集中选择指定比例的代表性样本。生成结果保持原数据格式，同时保存样本在完整数据集中的索引，便于结果复现和追溯。
 
-## 工作流程
-
-```text
-原始评测数据
-    │
-    ▼
-构造样本 Prompt
-    │
-    ▼
-语言模型提取隐藏状态特征
-    │
-    ▼
-RBF Kernel
-    │
-    ▼
-Kernel Herding 选择代表性样本
-    │
-    ├── origin/   完整数据及索引
-    └── coreset/  压缩后的数据及索引
-    │
-    ▼
-复制到 ais_bench/datasets/ 对应目录
-```
-
-# Coreset 使用方法
-
 ## 1. 环境准备
 
 安装运行依赖：
@@ -40,95 +14,49 @@ Kernel Herding 选择代表性样本
 pip install numpy torch transformers tqdm
 ```
 
-如果数据集适配器复用了 AISBench 中的数据集或 Prompt 组件，需要保证当前环境可以导入 `ais_bench`。在 Benchmark 仓库中执行：
+数据集适配器会复用 AISBench 中的数据集或 Prompt 组件，因此需要保证当前环境可以导入 `ais_bench`。在 Benchmark 仓库中执行：
 
 ```shell
 cd benchmark
 pip install -e .
 ```
 
-> AISBench 在这里主要用于提供数据集和 Prompt 相关组件；执行 Coreset 时不会启动 AISBench 模型评测流程。
-
-## 2. 准备数据
-
-数据集通过 `herding/eval_datasets/` 下的适配器接入。适配器负责：
-
-1. 获取数据集样本数量；
-2. 将样本转换为用于特征提取的 Prompt；
-3. 根据筛选出的索引，以原数据格式保存 Coreset。
-
-如果原始数据已经放在 AISBench 的数据目录：
-
-```text
-benchmark/ais_bench/datasets/
-```
-
-可以通过 `CORESET_BASE_DIR` 指定数据根目录：
-
-```shell
-cd benchmark
-export CORESET_BASE_DIR=$(pwd)/ais_bench/datasets
-```
-
-也可以通过 `DATASET_PATH` 直接指定当前数据集目录：
-
-```shell
-export DATASET_PATH=$(pwd)/ais_bench/datasets/<dataset_name>
-```
-
-`DATASET_PATH` 的具体形式由对应的数据集适配器决定。
-
-## 3. 配置参数
-
-### 必选参数
-
-| 环境变量 | 说明 | 示例 |
-| --- | --- | --- |
-| `EVAL_DATASET` | 数据集适配器注册名称 | `gpqa` |
-| `CORESET_METRIC` | Coreset 方法名称，同时用于输出目录命名 | `herding` |
-| `LLM_MODEL` | 特征模型标识名称，用于组织输出目录 | `qwen25_7b` |
-| `CORESET_RATIO` | Coreset 占完整数据集的比例 | `0.2` |
-
-### 模型与路径参数
-
-| 环境变量 | 说明 |
-| --- | --- |
-| `MODEL_PATH` | 用于提取隐藏状态特征的本地 Hugging Face 模型路径，建议显式设置 |
-| `CORESET_MODEL_PATH` | 特征模型路径的备用配置；未设置 `MODEL_PATH` 时使用 |
-| `CORESET_BASE_DIR` | 原始数据的基础目录 |
-| `DATASET_PATH` | 当前数据集的具体路径，可覆盖适配器默认路径 |
-
-通用配置示例：
-
-```shell
-export EVAL_DATASET=<dataset_name>
-export CORESET_METRIC=herding
-export CORESET_RATIO=0.2
-export LLM_MODEL=<model_name>
-export MODEL_PATH=/path/to/model
-export DATASET_PATH=/path/to/datasets/<dataset_name>
-```
-
-其中：
-
-```text
-CORESET_RATIO=0.2
-```
-
-表示从完整数据集中选择约 20% 的样本作为 Coreset。
-
-## 4. 运行 Coreset 压缩
+## 2. 命令行帮助
 
 进入工具目录：
 
 ```shell
-cd tools/herding_coreset_selector
+cd benchmark/tools/herding_coreset_selector
 ```
 
-执行：
+查看完整参数说明：
 
 ```shell
-python -m herding
+python -m herding --help
+```
+
+主要参数：
+
+| 参数 | 是否必选 | 说明 |
+| --- | --- | --- |
+| `--eval-dataset` | 是 | 数据集适配器名称，当前支持 `gpqa`、`aime2025` |
+| `--dataset-path` | 是 | 原始评测数据所在目录 |
+| `--model-path` | 是 | 用于提取隐藏状态特征的本地 Hugging Face 模型路径 |
+| `--coreset-ratio` | 否 | Coreset 占完整数据集的比例，范围 `(0, 1]`，默认 `0.2` |
+| `--output-dir` | 否 | 结果输出根目录，默认 `./datasets` |
+
+工具运行时配置通过命令行显式传入，不依赖环境变量。
+
+## 3. 运行 Coreset 压缩
+
+通用命令：
+
+```shell
+python -m herding \
+  --eval-dataset <dataset_name> \
+  --dataset-path /path/to/datasets/<dataset_name> \
+  --model-path /path/to/model \
+  --coreset-ratio 0.2
 ```
 
 工具会依次完成：
@@ -147,15 +75,15 @@ Kernel Herding 选择样本
 保存 origin 与 coreset
 ```
 
-## 5. Coreset 输出
+## 4. 输出目录
 
-从 `tools/herding_coreset_selector` 目录运行时，结果默认写入：
+默认输出结构为：
 
 ```text
 datasets/
-└── <EVAL_DATASET>/
-    └── <CORESET_METRIC>/
-        └── <LLM_MODEL>/
+└── <eval_dataset>/
+    └── herding/
+        └── <model_name>/
             ├── origin/
             │   ├── <dataset_file>
             │   └── indices.json
@@ -164,232 +92,84 @@ datasets/
                 └── indices.json
 ```
 
-其中：
+其中 `<model_name>` 会从 `--model-path` 的最后一级目录名自动获取。
 
 - `origin/<dataset_file>`：本次筛选对应的完整数据；
 - `origin/indices.json`：完整数据对应的原始索引；
-- `coreset/<dataset_file>`：压缩后筛选出的 Coreset 数据；
+- `coreset/<dataset_file>`：筛选后的 Coreset；
 - `coreset/indices.json`：Coreset 样本在完整数据中的原始索引。
 
-实际需要保留的压缩数据位于：
+## 5. GPQA 压缩示例
+
+准备数据：
 
 ```text
-coreset/<dataset_file>
-```
-
-建议同时保留 `coreset/indices.json`，方便后续追溯样本来源。
-
-## 6. 将压缩结果保存到 AISBench 数据目录
-
-推荐不要覆盖原始完整数据，而是在 `ais_bench/datasets/` 下为 Coreset 建立独立目录：
-
-```text
-benchmark/ais_bench/datasets/
-├── <dataset_name>/
-│   └── <original_dataset_file>
-└── <dataset_name>_coreset/
-    ├── <dataset_file>
-    └── indices.json
-```
-
-例如：
-
-```shell
-cd benchmark
-
-mkdir -p ais_bench/datasets/<dataset_name>_coreset
-
-cp \
-  tools/herding_coreset_selector/datasets/<dataset_name>/herding/<model_name>/coreset/<dataset_file> \
-  ais_bench/datasets/<dataset_name>_coreset/<dataset_file>
-
-cp \
-  tools/herding_coreset_selector/datasets/<dataset_name>/herding/<model_name>/coreset/indices.json \
-  ais_bench/datasets/<dataset_name>_coreset/indices.json
-```
-
-这样原始数据和压缩后的 Coreset 会分别保存在 AISBench 数据目录中，互不覆盖。
-
-# GPQA 压缩示例
-
-下面给出已经验证可以运行的 GPQA Coreset 压缩流程。
-
-## 1. 准备 GPQA 数据
-
-将 GPQA 数据放到：
-
-```text
-benchmark/
-└── ais_bench/
-    └── datasets/
-        └── gpqa/
-            ├── gpqa_diamond.csv
-            ├── gpqa_main.csv
-            ├── gpqa_extended.csv
-            └── ...
-```
-
-当前使用 `gpqa_diamond.csv` 进行 Coreset 压缩。
-
-运行前可以先确认文件存在：
-
-```shell
-cd benchmark
-ls -lh ais_bench/datasets/gpqa/gpqa_diamond.csv
-```
-
-## 2. 配置 GPQA 压缩参数
-
-```shell
-cd benchmark
-
-export EVAL_DATASET=gpqa
-export CORESET_METRIC=herding
-export CORESET_RATIO=0.2
-
-# 用于输出目录命名
-export LLM_MODEL=qwen25_7b
-
-# 替换为实际的本地 Hugging Face 模型路径
-export MODEL_PATH=/path/to/Qwen2.5-7B-Instruct
-
-# GPQA 数据目录
-export DATASET_PATH=$(pwd)/ais_bench/datasets/gpqa
-```
-
-参数说明：
-
-- `EVAL_DATASET=gpqa`：加载 GPQA 数据集适配器；
-- `CORESET_METRIC=herding`：使用 Kernel Herding 进行样本筛选；
-- `CORESET_RATIO=0.2`：选择约 20% 的 GPQA 样本；
-- `LLM_MODEL=qwen25_7b`：用于组织输出目录；
-- `MODEL_PATH`：真正用于提取 Prompt 隐藏状态特征的模型路径；
-- `DATASET_PATH`：包含 `gpqa_diamond.csv` 的 GPQA 数据目录。
-
-## 3. 运行 GPQA 压缩
-
-```shell
-cd tools/herding_coreset_selector
-python -m herding
-```
-
-运行流程为：
-
-```text
-gpqa_diamond.csv
-        │
-        ▼
-构造 GPQA Prompt
-        │
-        ▼
-特征模型提取隐藏状态
-        │
-        ▼
-RBF Kernel + Kernel Herding
-        │
-        ▼
-按 CORESET_RATIO 选择代表性样本
-        │
-        ├── origin/gpqa_diamond.csv
-        └── coreset/gpqa_diamond.csv
-```
-
-## 4. 检查 GPQA 输出
-
-如果设置：
-
-```shell
-export LLM_MODEL=qwen25_7b
-```
-
-则输出目录为：
-
-```text
-benchmark/tools/herding_coreset_selector/datasets/
-└── gpqa/
-    └── herding/
-        └── qwen25_7b/
-            ├── origin/
-            │   ├── gpqa_diamond.csv
-            │   └── indices.json
-            └── coreset/
-                ├── gpqa_diamond.csv
-                └── indices.json
-```
-
-可以执行：
-
-```shell
-cd benchmark/tools/herding_coreset_selector
-
-ls -lh datasets/gpqa/herding/qwen25_7b/origin/
-ls -lh datasets/gpqa/herding/qwen25_7b/coreset/
-```
-
-其中：
-
-```text
-datasets/gpqa/herding/qwen25_7b/coreset/gpqa_diamond.csv
-```
-
-就是压缩后的 GPQA 数据集。
-
-## 5. 保存 GPQA Coreset 到 AISBench
-
-推荐将压缩后的 GPQA 单独保存到：
-
-```text
-benchmark/ais_bench/datasets/gpqa_coreset/
+benchmark/ais_bench/datasets/gpqa/gpqa_diamond.csv
 ```
 
 执行：
 
 ```shell
-cd benchmark
+cd benchmark/tools/herding_coreset_selector
 
-mkdir -p ais_bench/datasets/gpqa_coreset
-
-cp \
-  tools/herding_coreset_selector/datasets/gpqa/herding/qwen25_7b/coreset/gpqa_diamond.csv \
-  ais_bench/datasets/gpqa_coreset/gpqa_diamond.csv
-
-cp \
-  tools/herding_coreset_selector/datasets/gpqa/herding/qwen25_7b/coreset/indices.json \
-  ais_bench/datasets/gpqa_coreset/indices.json
+python -m herding \
+  --eval-dataset gpqa \
+  --dataset-path ../../ais_bench/datasets/gpqa \
+  --model-path /path/to/Qwen2.5-7B-Instruct \
+  --coreset-ratio 0.2
 ```
 
-保存后的目录结构为：
+如果模型目录名为 `Qwen2.5-7B-Instruct`，则结果写入：
 
 ```text
-benchmark/ais_bench/datasets/
-├── gpqa/
-│   └── gpqa_diamond.csv
-└── gpqa_coreset/
+datasets/gpqa/herding/Qwen2.5-7B-Instruct/
+├── origin/
+│   ├── gpqa_diamond.csv
+│   └── indices.json
+└── coreset/
     ├── gpqa_diamond.csv
     └── indices.json
 ```
 
-这样原始 GPQA 和压缩后的 GPQA Coreset 都保留在 AISBench 数据目录中，且不会相互覆盖。
-
-## 6. 修改压缩比例
-
 例如只保留约 10% 的样本：
 
 ```shell
-export CORESET_RATIO=0.1
-python -m herding
+python -m herding \
+  --eval-dataset gpqa \
+  --dataset-path ../../ais_bench/datasets/gpqa \
+  --model-path /path/to/Qwen2.5-7B-Instruct \
+  --coreset-ratio 0.1
 ```
 
-如果需要比较多个压缩比例，建议在每次运行后保存或重命名输出目录，避免不同实验结果相互覆盖。
+## 6. AIME2025 压缩示例
 
-# 接入新的数据集
+准备数据：
 
-如果需要处理新的数据格式，可以在 `herding/eval_datasets/` 中增加数据集适配器。
+```text
+benchmark/ais_bench/datasets/aime2025/aime2025.jsonl
+```
 
-适配器继承 `EvalDatasetBase` 并实现：
+执行：
+
+```shell
+python -m herding \
+  --eval-dataset aime2025 \
+  --dataset-path ../../ais_bench/datasets/aime2025 \
+  --model-path /path/to/Qwen2.5-7B-Instruct \
+  --coreset-ratio 0.2
+```
+
+## 7. 接入新的数据集
+
+在 `herding/eval_datasets/` 中新增适配器，并继承 `EvalDatasetBase`：
 
 ```python
+@reg_eval_dataset("my_dataset")
 class MyDataset(EvalDatasetBase):
+    def __init__(self, dataset_path, output_dir):
+        super().__init__(dataset_path, output_dir)
+        ...
+
     def dataset_size(self):
         ...
 
@@ -400,20 +180,6 @@ class MyDataset(EvalDatasetBase):
         ...
 ```
 
-然后使用 `reg_eval_dataset` 注册名称：
+然后在 `herding/eval_datasets/__init__.py` 中导入该适配器模块以完成注册，并在 `herding/__main__.py` 的 `SUPPORTED_DATASETS` 中增加对应名称。
 
-```python
-@reg_eval_dataset("my_dataset")
-class MyDataset(EvalDatasetBase):
-    ...
-```
-
-并在 `herding/eval_datasets/__init__.py` 中加入对应模块的导入逻辑。之后即可通过：
-
-```shell
-export EVAL_DATASET=my_dataset
-```
-
-加载该数据集。
-
-建议 `save_data_by_indices()` 保持原始数据格式不变，以便压缩结果可以直接保存到 AISBench 对应的数据目录。
+建议 `save_data_by_indices()` 保持原始数据格式不变，以便压缩结果可以直接用于后续 Benchmark 测评。

--- a/tools/herding_coreset_selector/README.md
+++ b/tools/herding_coreset_selector/README.md
@@ -1,0 +1,419 @@
+# Herding Coreset Selector
+
+## 简介
+
+Herding Coreset Selector 是一个用于评测数据集代表性样本筛选的独立 Coreset 工具。
+
+工具使用指定语言模型提取样本 Prompt 的隐藏状态特征，并基于 RBF Kernel 的 Kernel Herding 方法，从完整数据集中选择指定比例的代表性样本。生成结果保持原数据格式，同时保存样本在完整数据集中的索引，便于结果复现和追溯。
+
+## 工作流程
+
+```text
+原始评测数据
+    │
+    ▼
+构造样本 Prompt
+    │
+    ▼
+语言模型提取隐藏状态特征
+    │
+    ▼
+RBF Kernel
+    │
+    ▼
+Kernel Herding 选择代表性样本
+    │
+    ├── origin/   完整数据及索引
+    └── coreset/  压缩后的数据及索引
+    │
+    ▼
+复制到 ais_bench/datasets/ 对应目录
+```
+
+# Coreset 使用方法
+
+## 1. 环境准备
+
+安装运行依赖：
+
+```shell
+pip install numpy torch transformers tqdm
+```
+
+如果数据集适配器复用了 AISBench 中的数据集或 Prompt 组件，需要保证当前环境可以导入 `ais_bench`。在 Benchmark 仓库中执行：
+
+```shell
+cd benchmark
+pip install -e .
+```
+
+> AISBench 在这里主要用于提供数据集和 Prompt 相关组件；执行 Coreset 时不会启动 AISBench 模型评测流程。
+
+## 2. 准备数据
+
+数据集通过 `herding/eval_datasets/` 下的适配器接入。适配器负责：
+
+1. 获取数据集样本数量；
+2. 将样本转换为用于特征提取的 Prompt；
+3. 根据筛选出的索引，以原数据格式保存 Coreset。
+
+如果原始数据已经放在 AISBench 的数据目录：
+
+```text
+benchmark/ais_bench/datasets/
+```
+
+可以通过 `CORESET_BASE_DIR` 指定数据根目录：
+
+```shell
+cd benchmark
+export CORESET_BASE_DIR=$(pwd)/ais_bench/datasets
+```
+
+也可以通过 `DATASET_PATH` 直接指定当前数据集目录：
+
+```shell
+export DATASET_PATH=$(pwd)/ais_bench/datasets/<dataset_name>
+```
+
+`DATASET_PATH` 的具体形式由对应的数据集适配器决定。
+
+## 3. 配置参数
+
+### 必选参数
+
+| 环境变量 | 说明 | 示例 |
+| --- | --- | --- |
+| `EVAL_DATASET` | 数据集适配器注册名称 | `gpqa` |
+| `CORESET_METRIC` | Coreset 方法名称，同时用于输出目录命名 | `herding` |
+| `LLM_MODEL` | 特征模型标识名称，用于组织输出目录 | `qwen25_7b` |
+| `CORESET_RATIO` | Coreset 占完整数据集的比例 | `0.2` |
+
+### 模型与路径参数
+
+| 环境变量 | 说明 |
+| --- | --- |
+| `MODEL_PATH` | 用于提取隐藏状态特征的本地 Hugging Face 模型路径，建议显式设置 |
+| `CORESET_MODEL_PATH` | 特征模型路径的备用配置；未设置 `MODEL_PATH` 时使用 |
+| `CORESET_BASE_DIR` | 原始数据的基础目录 |
+| `DATASET_PATH` | 当前数据集的具体路径，可覆盖适配器默认路径 |
+
+通用配置示例：
+
+```shell
+export EVAL_DATASET=<dataset_name>
+export CORESET_METRIC=herding
+export CORESET_RATIO=0.2
+export LLM_MODEL=<model_name>
+export MODEL_PATH=/path/to/model
+export DATASET_PATH=/path/to/datasets/<dataset_name>
+```
+
+其中：
+
+```text
+CORESET_RATIO=0.2
+```
+
+表示从完整数据集中选择约 20% 的样本作为 Coreset。
+
+## 4. 运行 Coreset 压缩
+
+进入工具目录：
+
+```shell
+cd tools/herding_coreset_selector
+```
+
+执行：
+
+```shell
+python -m herding
+```
+
+工具会依次完成：
+
+```text
+读取数据
+  ↓
+构造 Prompt
+  ↓
+特征模型提取隐藏状态
+  ↓
+计算 RBF Kernel
+  ↓
+Kernel Herding 选择样本
+  ↓
+保存 origin 与 coreset
+```
+
+## 5. Coreset 输出
+
+从 `tools/herding_coreset_selector` 目录运行时，结果默认写入：
+
+```text
+datasets/
+└── <EVAL_DATASET>/
+    └── <CORESET_METRIC>/
+        └── <LLM_MODEL>/
+            ├── origin/
+            │   ├── <dataset_file>
+            │   └── indices.json
+            └── coreset/
+                ├── <dataset_file>
+                └── indices.json
+```
+
+其中：
+
+- `origin/<dataset_file>`：本次筛选对应的完整数据；
+- `origin/indices.json`：完整数据对应的原始索引；
+- `coreset/<dataset_file>`：压缩后筛选出的 Coreset 数据；
+- `coreset/indices.json`：Coreset 样本在完整数据中的原始索引。
+
+实际需要保留的压缩数据位于：
+
+```text
+coreset/<dataset_file>
+```
+
+建议同时保留 `coreset/indices.json`，方便后续追溯样本来源。
+
+## 6. 将压缩结果保存到 AISBench 数据目录
+
+推荐不要覆盖原始完整数据，而是在 `ais_bench/datasets/` 下为 Coreset 建立独立目录：
+
+```text
+benchmark/ais_bench/datasets/
+├── <dataset_name>/
+│   └── <original_dataset_file>
+└── <dataset_name>_coreset/
+    ├── <dataset_file>
+    └── indices.json
+```
+
+例如：
+
+```shell
+cd benchmark
+
+mkdir -p ais_bench/datasets/<dataset_name>_coreset
+
+cp \
+  tools/herding_coreset_selector/datasets/<dataset_name>/herding/<model_name>/coreset/<dataset_file> \
+  ais_bench/datasets/<dataset_name>_coreset/<dataset_file>
+
+cp \
+  tools/herding_coreset_selector/datasets/<dataset_name>/herding/<model_name>/coreset/indices.json \
+  ais_bench/datasets/<dataset_name>_coreset/indices.json
+```
+
+这样原始数据和压缩后的 Coreset 会分别保存在 AISBench 数据目录中，互不覆盖。
+
+# GPQA 压缩示例
+
+下面给出已经验证可以运行的 GPQA Coreset 压缩流程。
+
+## 1. 准备 GPQA 数据
+
+将 GPQA 数据放到：
+
+```text
+benchmark/
+└── ais_bench/
+    └── datasets/
+        └── gpqa/
+            ├── gpqa_diamond.csv
+            ├── gpqa_main.csv
+            ├── gpqa_extended.csv
+            └── ...
+```
+
+当前使用 `gpqa_diamond.csv` 进行 Coreset 压缩。
+
+运行前可以先确认文件存在：
+
+```shell
+cd benchmark
+ls -lh ais_bench/datasets/gpqa/gpqa_diamond.csv
+```
+
+## 2. 配置 GPQA 压缩参数
+
+```shell
+cd benchmark
+
+export EVAL_DATASET=gpqa
+export CORESET_METRIC=herding
+export CORESET_RATIO=0.2
+
+# 用于输出目录命名
+export LLM_MODEL=qwen25_7b
+
+# 替换为实际的本地 Hugging Face 模型路径
+export MODEL_PATH=/path/to/Qwen2.5-7B-Instruct
+
+# GPQA 数据目录
+export DATASET_PATH=$(pwd)/ais_bench/datasets/gpqa
+```
+
+参数说明：
+
+- `EVAL_DATASET=gpqa`：加载 GPQA 数据集适配器；
+- `CORESET_METRIC=herding`：使用 Kernel Herding 进行样本筛选；
+- `CORESET_RATIO=0.2`：选择约 20% 的 GPQA 样本；
+- `LLM_MODEL=qwen25_7b`：用于组织输出目录；
+- `MODEL_PATH`：真正用于提取 Prompt 隐藏状态特征的模型路径；
+- `DATASET_PATH`：包含 `gpqa_diamond.csv` 的 GPQA 数据目录。
+
+## 3. 运行 GPQA 压缩
+
+```shell
+cd tools/herding_coreset_selector
+python -m herding
+```
+
+运行流程为：
+
+```text
+gpqa_diamond.csv
+        │
+        ▼
+构造 GPQA Prompt
+        │
+        ▼
+特征模型提取隐藏状态
+        │
+        ▼
+RBF Kernel + Kernel Herding
+        │
+        ▼
+按 CORESET_RATIO 选择代表性样本
+        │
+        ├── origin/gpqa_diamond.csv
+        └── coreset/gpqa_diamond.csv
+```
+
+## 4. 检查 GPQA 输出
+
+如果设置：
+
+```shell
+export LLM_MODEL=qwen25_7b
+```
+
+则输出目录为：
+
+```text
+benchmark/tools/herding_coreset_selector/datasets/
+└── gpqa/
+    └── herding/
+        └── qwen25_7b/
+            ├── origin/
+            │   ├── gpqa_diamond.csv
+            │   └── indices.json
+            └── coreset/
+                ├── gpqa_diamond.csv
+                └── indices.json
+```
+
+可以执行：
+
+```shell
+cd benchmark/tools/herding_coreset_selector
+
+ls -lh datasets/gpqa/herding/qwen25_7b/origin/
+ls -lh datasets/gpqa/herding/qwen25_7b/coreset/
+```
+
+其中：
+
+```text
+datasets/gpqa/herding/qwen25_7b/coreset/gpqa_diamond.csv
+```
+
+就是压缩后的 GPQA 数据集。
+
+## 5. 保存 GPQA Coreset 到 AISBench
+
+推荐将压缩后的 GPQA 单独保存到：
+
+```text
+benchmark/ais_bench/datasets/gpqa_coreset/
+```
+
+执行：
+
+```shell
+cd benchmark
+
+mkdir -p ais_bench/datasets/gpqa_coreset
+
+cp \
+  tools/herding_coreset_selector/datasets/gpqa/herding/qwen25_7b/coreset/gpqa_diamond.csv \
+  ais_bench/datasets/gpqa_coreset/gpqa_diamond.csv
+
+cp \
+  tools/herding_coreset_selector/datasets/gpqa/herding/qwen25_7b/coreset/indices.json \
+  ais_bench/datasets/gpqa_coreset/indices.json
+```
+
+保存后的目录结构为：
+
+```text
+benchmark/ais_bench/datasets/
+├── gpqa/
+│   └── gpqa_diamond.csv
+└── gpqa_coreset/
+    ├── gpqa_diamond.csv
+    └── indices.json
+```
+
+这样原始 GPQA 和压缩后的 GPQA Coreset 都保留在 AISBench 数据目录中，且不会相互覆盖。
+
+## 6. 修改压缩比例
+
+例如只保留约 10% 的样本：
+
+```shell
+export CORESET_RATIO=0.1
+python -m herding
+```
+
+如果需要比较多个压缩比例，建议在每次运行后保存或重命名输出目录，避免不同实验结果相互覆盖。
+
+# 接入新的数据集
+
+如果需要处理新的数据格式，可以在 `herding/eval_datasets/` 中增加数据集适配器。
+
+适配器继承 `EvalDatasetBase` 并实现：
+
+```python
+class MyDataset(EvalDatasetBase):
+    def dataset_size(self):
+        ...
+
+    def dataset_prompts(self):
+        ...
+
+    def save_data_by_indices(self, indices, outpath):
+        ...
+```
+
+然后使用 `reg_eval_dataset` 注册名称：
+
+```python
+@reg_eval_dataset("my_dataset")
+class MyDataset(EvalDatasetBase):
+    ...
+```
+
+并在 `herding/eval_datasets/__init__.py` 中加入对应模块的导入逻辑。之后即可通过：
+
+```shell
+export EVAL_DATASET=my_dataset
+```
+
+加载该数据集。
+
+建议 `save_data_by_indices()` 保持原始数据格式不变，以便压缩结果可以直接保存到 AISBench 对应的数据目录。

--- a/tools/herding_coreset_selector/herding/__init__.py
+++ b/tools/herding_coreset_selector/herding/__init__.py
@@ -1,0 +1,25 @@
+from .features import load_model, generate_logits
+from .algorithm import features_to_coreset_matrix, coreset_indices
+from .eval_datasets import get_eval_dataset
+
+from tqdm import tqdm
+import time
+
+
+def generate_coreset(coreset_size):
+    model, tokenizer = load_model()
+    eval_dataset = get_eval_dataset()
+
+    prompts_generator = eval_dataset.dataset_prompts()
+    logits_generator = generate_logits(model, tokenizer, prompts_generator)
+    logits_generator = tqdm(
+        logits_generator,
+        total=eval_dataset.dataset_size(),
+        desc="features",
+    )
+    logits_matrix = features_to_coreset_matrix(logits_generator)
+
+    start = time.perf_counter()
+    indices = coreset_indices(logits_matrix, coreset_size)
+    print(f'    herding: {time.perf_counter() - start:.2f}s')
+    return indices

--- a/tools/herding_coreset_selector/herding/__init__.py
+++ b/tools/herding_coreset_selector/herding/__init__.py
@@ -1,14 +1,16 @@
-from .features import load_model, generate_logits
-from .algorithm import features_to_coreset_matrix, coreset_indices
-from .eval_datasets import get_eval_dataset
-
-from tqdm import tqdm
 import time
 
 
-def generate_coreset(coreset_size):
-    model, tokenizer = load_model()
-    eval_dataset = get_eval_dataset()
+def generate_coreset(coreset_size, eval_dataset, model_path):
+    """Generate coreset indices for an initialized evaluation dataset."""
+    # Keep package import lightweight so `python -m herding --help` does not
+    # import torch/transformers/numpy before command-line arguments are parsed.
+    from tqdm import tqdm
+
+    from .algorithm import coreset_indices, features_to_coreset_matrix
+    from .features import generate_logits, load_model
+
+    model, tokenizer = load_model(model_path)
 
     prompts_generator = eval_dataset.dataset_prompts()
     logits_generator = generate_logits(model, tokenizer, prompts_generator)
@@ -21,5 +23,5 @@ def generate_coreset(coreset_size):
 
     start = time.perf_counter()
     indices = coreset_indices(logits_matrix, coreset_size)
-    print(f'    herding: {time.perf_counter() - start:.2f}s')
+    print(f"    herding: {time.perf_counter() - start:.2f}s")
     return indices

--- a/tools/herding_coreset_selector/herding/__main__.py
+++ b/tools/herding_coreset_selector/herding/__main__.py
@@ -68,9 +68,7 @@ def parse_args():
 
 def _model_name(model_path: str) -> str:
     normalized = model_path.rstrip("/\\")
-    # CLI input may use either POSIX or Windows separators, regardless of the
-    # operating system on which the selector is executed.
-    name = Path(normalized.replace("\\", "/")).name
+    name = Path(normalized).name
     if not name:
         raise ValueError(f"Unable to infer model name from model path: {model_path!r}")
     return name

--- a/tools/herding_coreset_selector/herding/__main__.py
+++ b/tools/herding_coreset_selector/herding/__main__.py
@@ -1,0 +1,20 @@
+from herding import generate_coreset
+from herding.eval_datasets import get_eval_dataset
+from herding.eval_datasets.dataset_base import require_env
+
+CORESET_RATIO = float(require_env('CORESET_RATIO'))
+
+
+def main():
+    ds = get_eval_dataset()
+    indices = ds.load_indices()
+    ds.save_data_by_indices(indices, 'origin')
+    coreset_size = round(len(indices) * CORESET_RATIO)
+
+    modified_indices = generate_coreset(coreset_size)
+    output_path = ds.save_data_by_indices(modified_indices, 'coreset')
+    print(f'output: {output_path}')
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/herding_coreset_selector/herding/__main__.py
+++ b/tools/herding_coreset_selector/herding/__main__.py
@@ -2,7 +2,6 @@ import argparse
 from pathlib import Path
 
 
-SUPPORTED_DATASETS = ("gpqa", "aime2025")
 DEFAULT_CORESET_RATIO = 0.2
 DEFAULT_OUTPUT_DIR = "./datasets"
 CORESET_METHOD = "herding"
@@ -30,7 +29,7 @@ def parse_args():
     parser.add_argument(
         "--eval-dataset",
         required=True,
-        choices=SUPPORTED_DATASETS,
+
         help="Evaluation dataset adapter to use.",
     )
     parser.add_argument(
@@ -69,7 +68,9 @@ def parse_args():
 
 def _model_name(model_path: str) -> str:
     normalized = model_path.rstrip("/\\")
-    name = Path(normalized).name
+    # CLI input may use either POSIX or Windows separators, regardless of the
+    # operating system on which the selector is executed.
+    name = Path(normalized.replace("\\", "/")).name
     if not name:
         raise ValueError(f"Unable to infer model name from model path: {model_path!r}")
     return name

--- a/tools/herding_coreset_selector/herding/__main__.py
+++ b/tools/herding_coreset_selector/herding/__main__.py
@@ -1,19 +1,115 @@
-from herding import generate_coreset
-from herding.eval_datasets import get_eval_dataset
-from herding.eval_datasets.dataset_base import require_env
+import argparse
+from pathlib import Path
 
-CORESET_RATIO = float(require_env('CORESET_RATIO'))
+
+SUPPORTED_DATASETS = ("gpqa", "aime2025")
+DEFAULT_CORESET_RATIO = 0.2
+DEFAULT_OUTPUT_DIR = "./datasets"
+CORESET_METHOD = "herding"
+
+
+def _coreset_ratio(value: str) -> float:
+    """Validate coreset ratio passed from the command line."""
+    try:
+        ratio = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a floating-point number") from exc
+
+    if not 0 < ratio <= 1:
+        raise argparse.ArgumentTypeError("must be in the range (0, 1]")
+    return ratio
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Select representative evaluation samples with RBF Kernel Herding "
+            "using hidden-state features extracted from a Hugging Face model."
+        )
+    )
+    parser.add_argument(
+        "--eval-dataset",
+        required=True,
+        choices=SUPPORTED_DATASETS,
+        help="Evaluation dataset adapter to use.",
+    )
+    parser.add_argument(
+        "--dataset-path",
+        required=True,
+        help=(
+            "Directory containing the source evaluation dataset "
+            "(for example, gpqa_diamond.csv for GPQA)."
+        ),
+    )
+    parser.add_argument(
+        "--model-path",
+        required=True,
+        help="Local Hugging Face model path used to extract hidden-state features.",
+    )
+    parser.add_argument(
+        "--coreset-ratio",
+        type=_coreset_ratio,
+        default=DEFAULT_CORESET_RATIO,
+        help=(
+            "Fraction of the original dataset selected for the coreset, in (0, 1]. "
+            f"Default: {DEFAULT_CORESET_RATIO}."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help=(
+            "Root directory for generated results. The final path is "
+            "<output-dir>/<dataset>/herding/<model-name>/. "
+            f"Default: {DEFAULT_OUTPUT_DIR}."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _model_name(model_path: str) -> str:
+    normalized = model_path.rstrip("/\\")
+    name = Path(normalized).name
+    if not name:
+        raise ValueError(f"Unable to infer model name from model path: {model_path!r}")
+    return name
 
 
 def main():
-    ds = get_eval_dataset()
-    indices = ds.load_indices()
-    ds.save_data_by_indices(indices, 'origin')
-    coreset_size = round(len(indices) * CORESET_RATIO)
+    args = parse_args()
 
-    modified_indices = generate_coreset(coreset_size)
-    output_path = ds.save_data_by_indices(modified_indices, 'coreset')
-    print(f'output: {output_path}')
+    # Heavy dependencies are imported only after CLI parsing, so
+    # `python -m herding --help` remains a lightweight, self-contained entry.
+    from herding import generate_coreset
+    from herding.eval_datasets import get_eval_dataset
+
+    output_dir = (
+        Path(args.output_dir)
+        / args.eval_dataset
+        / CORESET_METHOD
+        / _model_name(args.model_path)
+    )
+
+    eval_dataset = get_eval_dataset(
+        args.eval_dataset,
+        dataset_path=args.dataset_path,
+        output_dir=str(output_dir),
+    )
+
+    indices = eval_dataset.load_indices()
+    if not indices:
+        raise ValueError("The evaluation dataset is empty; cannot generate a coreset.")
+
+    eval_dataset.save_data_by_indices(indices, "origin")
+    coreset_size = max(1, round(len(indices) * args.coreset_ratio))
+
+    selected_indices = generate_coreset(
+        coreset_size,
+        eval_dataset=eval_dataset,
+        model_path=args.model_path,
+    )
+    output_path = eval_dataset.save_data_by_indices(selected_indices, "coreset")
+    print(f"output: {output_path}")
 
 
 if __name__ == "__main__":

--- a/tools/herding_coreset_selector/herding/algorithm.py
+++ b/tools/herding_coreset_selector/herding/algorithm.py
@@ -1,0 +1,67 @@
+"""Kernel Herding: greedy MMD minimization, RBF kernel."""
+
+import numpy as np
+import torch
+from typing import Iterator
+
+
+BANDWIDTH_SAMPLE_CAP = 1000
+KERNEL_BATCH = 512
+DEFAULT_BANDWIDTH = 1.0
+
+
+def _rbf_kernel(X, Y, length_scale):
+    X_sq = np.sum(X ** 2, axis=1, keepdims=True)
+    Y_sq = np.sum(Y ** 2, axis=1, keepdims=True)
+    dist_sq = X_sq + Y_sq.T - 2.0 * (X @ Y.T)
+    return np.exp(-dist_sq / (2.0 * length_scale ** 2))
+
+
+def _median_heuristic(data):
+    sq = np.sum(data ** 2, axis=1, keepdims=True)
+    dist_sq = sq + sq.T - 2.0 * (data @ data.T)
+    n = data.shape[0]
+    dists = np.sqrt(dist_sq[np.triu_indices(n, k=1)])
+    return float(np.median(dists))
+
+
+def features_to_coreset_matrix(features_generator: Iterator[torch.Tensor]) -> np.ndarray:
+    return np.stack([t.cpu().numpy() for t in features_generator], axis=0)
+
+
+def coreset_indices(data, coreset_size, length_scale=None):
+    n = data.shape[0]
+    if coreset_size >= n:
+        return list(range(n))
+
+    if length_scale is None:
+        num_samples = min(n, BANDWIDTH_SAMPLE_CAP)
+        rng = np.random.default_rng(42)
+        idx = rng.choice(n, num_samples, replace=False)
+        length_scale = _median_heuristic(data[idx])
+        if length_scale <= 0:
+            length_scale = DEFAULT_BANDWIDTH
+
+    # kernel mean
+    K_sum = np.zeros(n, dtype=np.float64)
+    for i in range(0, n, KERNEL_BATCH):
+        end = min(i + KERNEL_BATCH, n)
+        K_sum += _rbf_kernel(data[i:end], data, length_scale).sum(axis=0)
+    K_mean = K_sum / n
+
+    # greedy selection
+    selected = []
+    selected_mask = np.zeros(n, dtype=bool)
+    K_selected_sum = np.zeros(n, dtype=np.float64)
+
+    for t in range(coreset_size):
+        score = K_mean - K_selected_sum / (t + 1)
+        score[selected_mask] = -np.inf
+        best_idx = int(np.argmax(score))
+        selected.append(best_idx)
+        selected_mask[best_idx] = True
+        K_selected_sum += _rbf_kernel(
+            data[best_idx:best_idx + 1], data, length_scale
+        ).ravel()
+
+    return selected

--- a/tools/herding_coreset_selector/herding/eval_datasets/__init__.py
+++ b/tools/herding_coreset_selector/herding/eval_datasets/__init__.py
@@ -1,0 +1,9 @@
+import os
+
+from herding.eval_datasets.dataset_base import get_eval_dataset
+
+_name = os.environ.get('EVAL_DATASET')
+if _name == 'gpqa':
+    from herding.eval_datasets import gpqa
+elif _name == 'aime2025':
+    from herding.eval_datasets import aime2025

--- a/tools/herding_coreset_selector/herding/eval_datasets/__init__.py
+++ b/tools/herding_coreset_selector/herding/eval_datasets/__init__.py
@@ -1,9 +1,17 @@
-import os
+from herding.eval_datasets.dataset_base import (
+    EVAL_DATASETS,
+    EvalDatasetBase,
+    get_eval_dataset,
+    reg_eval_dataset,
+)
 
-from herding.eval_datasets.dataset_base import get_eval_dataset
+# Import adapters so their registration decorators are executed.
+from herding.eval_datasets import aime2025 as _aime2025  # noqa: F401,E402
+from herding.eval_datasets import gpqa as _gpqa  # noqa: F401,E402
 
-_name = os.environ.get('EVAL_DATASET')
-if _name == 'gpqa':
-    from herding.eval_datasets import gpqa
-elif _name == 'aime2025':
-    from herding.eval_datasets import aime2025
+__all__ = [
+    "EVAL_DATASETS",
+    "EvalDatasetBase",
+    "get_eval_dataset",
+    "reg_eval_dataset",
+]

--- a/tools/herding_coreset_selector/herding/eval_datasets/aime2025.py
+++ b/tools/herding_coreset_selector/herding/eval_datasets/aime2025.py
@@ -1,61 +1,49 @@
-import os
 import json
+import os
 
 from ais_bench.benchmark.openicl.icl_prompt_template import PromptTemplate
-from ais_bench.benchmark.utils.config.build import build_dataset_from_cfg
 from ais_bench.benchmark.registry import ICL_PROMPT_TEMPLATES
 
-from herding.eval_datasets.dataset_base import (
-    EvalDatasetBase, reg_eval_dataset,
-    CFG_BASE_DATASET_DIR, CFG_CORESET_OUT_DIR,
-)
-
-DATASETS_PATH = os.environ.get('DATASET_PATH', f'{CFG_BASE_DATASET_DIR}/aime2025')
+from herding.eval_datasets.dataset_base import EvalDatasetBase, reg_eval_dataset
 
 
-def load_aime_data():
-    data = []
-    filepath = os.path.join(DATASETS_PATH, 'aime2025.jsonl')
-    if os.path.exists(filepath):
-        with open(filepath, 'r', encoding='utf-8') as f:
-            for line in f:
-                data.append(json.loads(line.strip()))
-    return data
-
-
-dataset = load_aime_data()
+FILENAME = "aime2025.jsonl"
 
 prompt_template_cfg = dict(
     type=PromptTemplate,
-    template='{question}\nPlease reason step by step, and put your final answer within \\boxed{}.',
+    template="{question}\nPlease reason step by step, and put your final answer within \\boxed{}.",
 )
 
 prompt_template = ICL_PROMPT_TEMPLATES.build(prompt_template_cfg)
 
 
-@reg_eval_dataset('aime2025')
+@reg_eval_dataset("aime2025")
 class Aime2025Dataset(EvalDatasetBase):
+    def __init__(self, dataset_path, output_dir):
+        super().__init__(dataset_path, output_dir)
+        self.dataset = self._load_data()
+
+    def _load_data(self):
+        filepath = os.path.join(self.dataset_path, FILENAME)
+        with open(filepath, "r", encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
     def dataset_size(self):
-        return len(dataset)
+        return len(self.dataset)
 
     def dataset_prompts(self):
-        for i in dataset:
-            yield prompt_template.generate_item(i)
+        for item in self.dataset:
+            yield prompt_template.generate_item(item)
 
     def save_data_by_indices(self, indices, outpath):
-        FILENAME = 'aime2025.jsonl'
-        filepath = os.path.join(DATASETS_PATH, FILENAME)
-        with open(filepath, 'r', encoding='utf-8') as f:
-            all_data = [json.loads(line.strip()) for line in f]
+        output_dir = os.path.join(self.output_dir, outpath)
+        os.makedirs(output_dir, exist_ok=True)
 
-        outpath = os.path.join(CFG_CORESET_OUT_DIR, outpath)
-        os.makedirs(outpath, exist_ok=True)
-
-        selected_data = [all_data[idx] for idx in indices]
-        output_filepath = os.path.join(outpath, FILENAME)
-        with open(output_filepath, 'w', encoding='utf-8') as f:
+        selected_data = [self.dataset[idx] for idx in indices]
+        output_filepath = os.path.join(output_dir, FILENAME)
+        with open(output_filepath, "w", encoding="utf-8") as f:
             for item in selected_data:
-                f.write(json.dumps(item, ensure_ascii=False) + '\n')
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
 
-        self.save_indices(indices, outpath)
-        return outpath
+        self.save_indices(indices, output_dir)
+        return output_dir

--- a/tools/herding_coreset_selector/herding/eval_datasets/aime2025.py
+++ b/tools/herding_coreset_selector/herding/eval_datasets/aime2025.py
@@ -1,0 +1,61 @@
+import os
+import json
+
+from ais_bench.benchmark.openicl.icl_prompt_template import PromptTemplate
+from ais_bench.benchmark.utils.config.build import build_dataset_from_cfg
+from ais_bench.benchmark.registry import ICL_PROMPT_TEMPLATES
+
+from herding.eval_datasets.dataset_base import (
+    EvalDatasetBase, reg_eval_dataset,
+    CFG_BASE_DATASET_DIR, CFG_CORESET_OUT_DIR,
+)
+
+DATASETS_PATH = os.environ.get('DATASET_PATH', f'{CFG_BASE_DATASET_DIR}/aime2025')
+
+
+def load_aime_data():
+    data = []
+    filepath = os.path.join(DATASETS_PATH, 'aime2025.jsonl')
+    if os.path.exists(filepath):
+        with open(filepath, 'r', encoding='utf-8') as f:
+            for line in f:
+                data.append(json.loads(line.strip()))
+    return data
+
+
+dataset = load_aime_data()
+
+prompt_template_cfg = dict(
+    type=PromptTemplate,
+    template='{question}\nPlease reason step by step, and put your final answer within \\boxed{}.',
+)
+
+prompt_template = ICL_PROMPT_TEMPLATES.build(prompt_template_cfg)
+
+
+@reg_eval_dataset('aime2025')
+class Aime2025Dataset(EvalDatasetBase):
+    def dataset_size(self):
+        return len(dataset)
+
+    def dataset_prompts(self):
+        for i in dataset:
+            yield prompt_template.generate_item(i)
+
+    def save_data_by_indices(self, indices, outpath):
+        FILENAME = 'aime2025.jsonl'
+        filepath = os.path.join(DATASETS_PATH, FILENAME)
+        with open(filepath, 'r', encoding='utf-8') as f:
+            all_data = [json.loads(line.strip()) for line in f]
+
+        outpath = os.path.join(CFG_CORESET_OUT_DIR, outpath)
+        os.makedirs(outpath, exist_ok=True)
+
+        selected_data = [all_data[idx] for idx in indices]
+        output_filepath = os.path.join(outpath, FILENAME)
+        with open(output_filepath, 'w', encoding='utf-8') as f:
+            for item in selected_data:
+                f.write(json.dumps(item, ensure_ascii=False) + '\n')
+
+        self.save_indices(indices, outpath)
+        return outpath

--- a/tools/herding_coreset_selector/herding/eval_datasets/dataset_base.py
+++ b/tools/herding_coreset_selector/herding/eval_datasets/dataset_base.py
@@ -1,0 +1,112 @@
+import os
+import json
+from abc import ABC, abstractmethod
+
+
+# --- Required environment variables --------------------------------------
+# Read eagerly with a clear error message instead of bare KeyError, so users
+# know which env vars to set when they see the failure.
+# This list is the union of all modules' requirements (dataset_base needs the
+# first three, __main__.py needs CORESET_RATIO) — listed together so a single
+# missing-var error tells the user everything they need to set.
+
+_REQUIRED_ENV_VARS = ('EVAL_DATASET', 'CORESET_METRIC', 'LLM_MODEL', 'CORESET_RATIO')
+
+
+def require_env(name: str) -> str:
+    """Read a required env var; raise a clear error if missing."""
+    val = os.environ.get(name)
+    if val is None:
+        raise RuntimeError(
+            f"Required environment variable {name!r} is not set. "
+            f"All required: {', '.join(_REQUIRED_ENV_VARS)}."
+        )
+    return val
+
+
+EVAL_DATASET = require_env('EVAL_DATASET')
+CORESET_METRIC = require_env('CORESET_METRIC')
+LLM_MODEL = require_env('LLM_MODEL')
+
+
+# --- Configurable paths --------------------------------------------------
+# Override via env vars if the defaults don't match your environment.
+
+CFG_BASE_DATASET_DIR = os.environ.get('CORESET_BASE_DIR', '/workspace/data')
+CFG_CORESET_OUT_DIR = f'./datasets/{EVAL_DATASET}/{CORESET_METRIC}/{LLM_MODEL}'
+
+
+# --- Dataset base class --------------------------------------------------
+
+class EvalDatasetBase(ABC):
+    """Base class for evaluation datasets.
+
+    Subclasses must implement:
+        - dataset_size
+        - dataset_prompts
+        - save_data_by_indices
+    """
+
+    @abstractmethod
+    def dataset_size(self) -> int:
+        """Return total number of items in the dataset."""
+
+    @abstractmethod
+    def dataset_prompts(self):
+        """Yield prompt strings one by one."""
+
+    @abstractmethod
+    def save_data_by_indices(self, indices, outpath):
+        """Save items at the given indices into outpath (a subdir of CFG_CORESET_OUT_DIR)."""
+
+    def load_indices(self):
+        return list(range(self.dataset_size()))
+
+    def save_indices(self, indices, outpath):
+        """
+        Save indices to indices.json in the output directory.
+
+        Args:
+            indices: List of indices to save
+            outpath: Output directory path
+        """
+        indices_path = os.path.join(outpath, 'indices.json')
+        with open(indices_path, 'w', encoding='utf-8') as f:
+            json.dump(indices, f)
+
+    def load_indices_from_strategy(self, strategy_name):
+        """
+        Load indices from a previously saved strategy.
+
+        Args:
+            strategy_name: Name of the strategy to load indices from
+
+        Returns:
+            List[int]: Loaded indices, or None if not found
+        """
+        indices_path = os.path.join(CFG_CORESET_OUT_DIR, strategy_name, 'indices.json')
+        if os.path.exists(indices_path):
+            with open(indices_path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        return None  # Graceful fallback
+
+
+EVAL_DATASETS = dict()
+
+
+def reg_eval_dataset(dataset_name):
+    def wrapper(dataset_cls):
+        EVAL_DATASETS[dataset_name] = dataset_cls
+        return dataset_cls
+    return wrapper
+
+
+def get_eval_dataset() -> EvalDatasetBase:
+    # !! This is NOT singleton
+    dataset_cls = EVAL_DATASETS.get(EVAL_DATASET, None)
+    if dataset_cls is None:
+        raise ValueError(
+            f'Unknown dataset "{EVAL_DATASET}". '
+            f'Registered: {list(EVAL_DATASETS.keys())}'
+        )
+    return dataset_cls()

--- a/tools/herding_coreset_selector/herding/eval_datasets/dataset_base.py
+++ b/tools/herding_coreset_selector/herding/eval_datasets/dataset_base.py
@@ -1,51 +1,14 @@
-import os
 import json
+import os
 from abc import ABC, abstractmethod
 
 
-# --- Required environment variables --------------------------------------
-# Read eagerly with a clear error message instead of bare KeyError, so users
-# know which env vars to set when they see the failure.
-# This list is the union of all modules' requirements (dataset_base needs the
-# first three, __main__.py needs CORESET_RATIO) — listed together so a single
-# missing-var error tells the user everything they need to set.
-
-_REQUIRED_ENV_VARS = ('EVAL_DATASET', 'CORESET_METRIC', 'LLM_MODEL', 'CORESET_RATIO')
-
-
-def require_env(name: str) -> str:
-    """Read a required env var; raise a clear error if missing."""
-    val = os.environ.get(name)
-    if val is None:
-        raise RuntimeError(
-            f"Required environment variable {name!r} is not set. "
-            f"All required: {', '.join(_REQUIRED_ENV_VARS)}."
-        )
-    return val
-
-
-EVAL_DATASET = require_env('EVAL_DATASET')
-CORESET_METRIC = require_env('CORESET_METRIC')
-LLM_MODEL = require_env('LLM_MODEL')
-
-
-# --- Configurable paths --------------------------------------------------
-# Override via env vars if the defaults don't match your environment.
-
-CFG_BASE_DATASET_DIR = os.environ.get('CORESET_BASE_DIR', '/workspace/data')
-CFG_CORESET_OUT_DIR = f'./datasets/{EVAL_DATASET}/{CORESET_METRIC}/{LLM_MODEL}'
-
-
-# --- Dataset base class --------------------------------------------------
-
 class EvalDatasetBase(ABC):
-    """Base class for evaluation datasets.
+    """Base class for evaluation datasets."""
 
-    Subclasses must implement:
-        - dataset_size
-        - dataset_prompts
-        - save_data_by_indices
-    """
+    def __init__(self, dataset_path, output_dir):
+        self.dataset_path = os.path.abspath(os.path.expanduser(dataset_path))
+        self.output_dir = os.path.abspath(os.path.expanduser(output_dir))
 
     @abstractmethod
     def dataset_size(self) -> int:
@@ -57,56 +20,44 @@ class EvalDatasetBase(ABC):
 
     @abstractmethod
     def save_data_by_indices(self, indices, outpath):
-        """Save items at the given indices into outpath (a subdir of CFG_CORESET_OUT_DIR)."""
+        """Save selected items into a subdirectory under ``self.output_dir``."""
 
     def load_indices(self):
         return list(range(self.dataset_size()))
 
-    def save_indices(self, indices, outpath):
-        """
-        Save indices to indices.json in the output directory.
-
-        Args:
-            indices: List of indices to save
-            outpath: Output directory path
-        """
-        indices_path = os.path.join(outpath, 'indices.json')
-        with open(indices_path, 'w', encoding='utf-8') as f:
+    @staticmethod
+    def save_indices(indices, outpath):
+        """Save selected source indices to ``indices.json``."""
+        indices_path = os.path.join(outpath, "indices.json")
+        with open(indices_path, "w", encoding="utf-8") as f:
             json.dump(indices, f)
 
     def load_indices_from_strategy(self, strategy_name):
-        """
-        Load indices from a previously saved strategy.
-
-        Args:
-            strategy_name: Name of the strategy to load indices from
-
-        Returns:
-            List[int]: Loaded indices, or None if not found
-        """
-        indices_path = os.path.join(CFG_CORESET_OUT_DIR, strategy_name, 'indices.json')
+        """Load indices saved under another strategy subdirectory, if present."""
+        indices_path = os.path.join(self.output_dir, strategy_name, "indices.json")
         if os.path.exists(indices_path):
-            with open(indices_path, 'r', encoding='utf-8') as f:
+            with open(indices_path, "r", encoding="utf-8") as f:
                 return json.load(f)
-        return None  # Graceful fallback
+        return None
 
 
-EVAL_DATASETS = dict()
+EVAL_DATASETS = {}
 
 
 def reg_eval_dataset(dataset_name):
     def wrapper(dataset_cls):
         EVAL_DATASETS[dataset_name] = dataset_cls
         return dataset_cls
+
     return wrapper
 
 
-def get_eval_dataset() -> EvalDatasetBase:
-    # !! This is NOT singleton
-    dataset_cls = EVAL_DATASETS.get(EVAL_DATASET, None)
+def get_eval_dataset(dataset_name, dataset_path, output_dir) -> EvalDatasetBase:
+    """Create a registered evaluation dataset adapter."""
+    dataset_cls = EVAL_DATASETS.get(dataset_name)
     if dataset_cls is None:
         raise ValueError(
-            f'Unknown dataset "{EVAL_DATASET}". '
-            f'Registered: {list(EVAL_DATASETS.keys())}'
+            f'Unknown dataset "{dataset_name}". '
+            f"Registered: {list(EVAL_DATASETS.keys())}"
         )
-    return dataset_cls()
+    return dataset_cls(dataset_path=dataset_path, output_dir=output_dir)

--- a/tools/herding_coreset_selector/herding/eval_datasets/gpqa.py
+++ b/tools/herding_coreset_selector/herding/eval_datasets/gpqa.py
@@ -1,0 +1,76 @@
+import os
+import csv
+
+from ais_bench.benchmark.openicl.icl_prompt_template import PromptTemplate
+from ais_bench.benchmark.datasets import GPQADataset
+from ais_bench.benchmark.utils.config.build import build_dataset_from_cfg
+from ais_bench.benchmark.registry import ICL_PROMPT_TEMPLATES
+
+from herding.eval_datasets.dataset_base import (
+    EvalDatasetBase, reg_eval_dataset,
+    CFG_BASE_DATASET_DIR, CFG_CORESET_OUT_DIR,
+)
+
+DATASETS_PATH = os.environ.get('DATASET_PATH', f'{CFG_BASE_DATASET_DIR}/gpqa')
+
+align_prompt = """
+Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: $LETTER' (without quotes) where LETTER is one of ABCD. Think step by step before answering.
+
+{question}
+
+A) {A}
+B) {B}
+C) {C}
+D) {D}
+""".strip()
+
+dataset_cfg = dict(
+    abbr='GPQA_diamond',
+    type=GPQADataset,
+    path=DATASETS_PATH,
+    name='gpqa_diamond.csv',
+    reader_cfg=dict(
+        input_columns=['question', 'A', 'B', 'C', 'D'],
+        output_column='answer',
+    ),
+)
+
+prompt_template_cfg = dict(
+    type=PromptTemplate,
+    template=align_prompt,
+)
+
+dataset = build_dataset_from_cfg(dataset_cfg).test
+prompt_template = ICL_PROMPT_TEMPLATES.build(prompt_template_cfg)
+
+
+@reg_eval_dataset('gpqa')
+class GpqaDataset(EvalDatasetBase):
+    def dataset_size(self):
+        return len(dataset)
+
+    def dataset_prompts(self):
+        for i in dataset:
+            yield prompt_template.generate_item(i)
+
+    def save_data_by_indices(self, indices, outpath):
+        FILENAME = 'gpqa_diamond.csv'
+        filepath = os.path.join(DATASETS_PATH, FILENAME)
+        with open(filepath, newline='', encoding='utf-8') as f:
+            data = list(csv.reader(f))
+
+        header = [data[0]]
+        data = data[1:]
+
+        outpath = os.path.join(CFG_CORESET_OUT_DIR, outpath)
+        os.makedirs(outpath, exist_ok=True)
+
+        rearranged_data = [data[idx] for idx in indices]
+        output_filepath = os.path.join(outpath, FILENAME)
+        with open(output_filepath, 'w', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            for line in (header + rearranged_data):
+                writer.writerow(line)
+
+        self.save_indices(indices, outpath)
+        return outpath

--- a/tools/herding_coreset_selector/herding/eval_datasets/gpqa.py
+++ b/tools/herding_coreset_selector/herding/eval_datasets/gpqa.py
@@ -1,17 +1,15 @@
-import os
 import csv
+import os
 
-from ais_bench.benchmark.openicl.icl_prompt_template import PromptTemplate
 from ais_bench.benchmark.datasets import GPQADataset
-from ais_bench.benchmark.utils.config.build import build_dataset_from_cfg
+from ais_bench.benchmark.openicl.icl_prompt_template import PromptTemplate
 from ais_bench.benchmark.registry import ICL_PROMPT_TEMPLATES
+from ais_bench.benchmark.utils.config.build import build_dataset_from_cfg
 
-from herding.eval_datasets.dataset_base import (
-    EvalDatasetBase, reg_eval_dataset,
-    CFG_BASE_DATASET_DIR, CFG_CORESET_OUT_DIR,
-)
+from herding.eval_datasets.dataset_base import EvalDatasetBase, reg_eval_dataset
 
-DATASETS_PATH = os.environ.get('DATASET_PATH', f'{CFG_BASE_DATASET_DIR}/gpqa')
+
+FILENAME = "gpqa_diamond.csv"
 
 align_prompt = """
 Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: $LETTER' (without quotes) where LETTER is one of ABCD. Think step by step before answering.
@@ -24,53 +22,54 @@ C) {C}
 D) {D}
 """.strip()
 
-dataset_cfg = dict(
-    abbr='GPQA_diamond',
-    type=GPQADataset,
-    path=DATASETS_PATH,
-    name='gpqa_diamond.csv',
-    reader_cfg=dict(
-        input_columns=['question', 'A', 'B', 'C', 'D'],
-        output_column='answer',
-    ),
-)
-
 prompt_template_cfg = dict(
     type=PromptTemplate,
     template=align_prompt,
 )
 
-dataset = build_dataset_from_cfg(dataset_cfg).test
 prompt_template = ICL_PROMPT_TEMPLATES.build(prompt_template_cfg)
 
 
-@reg_eval_dataset('gpqa')
+@reg_eval_dataset("gpqa")
 class GpqaDataset(EvalDatasetBase):
+    def __init__(self, dataset_path, output_dir):
+        super().__init__(dataset_path, output_dir)
+
+        dataset_cfg = dict(
+            abbr="GPQA_diamond",
+            type=GPQADataset,
+            path=self.dataset_path,
+            name=FILENAME,
+            reader_cfg=dict(
+                input_columns=["question", "A", "B", "C", "D"],
+                output_column="answer",
+            ),
+        )
+        self.dataset = build_dataset_from_cfg(dataset_cfg).test
+
     def dataset_size(self):
-        return len(dataset)
+        return len(self.dataset)
 
     def dataset_prompts(self):
-        for i in dataset:
-            yield prompt_template.generate_item(i)
+        for item in self.dataset:
+            yield prompt_template.generate_item(item)
 
     def save_data_by_indices(self, indices, outpath):
-        FILENAME = 'gpqa_diamond.csv'
-        filepath = os.path.join(DATASETS_PATH, FILENAME)
-        with open(filepath, newline='', encoding='utf-8') as f:
+        filepath = os.path.join(self.dataset_path, FILENAME)
+        with open(filepath, newline="", encoding="utf-8") as f:
             data = list(csv.reader(f))
 
         header = [data[0]]
         data = data[1:]
 
-        outpath = os.path.join(CFG_CORESET_OUT_DIR, outpath)
-        os.makedirs(outpath, exist_ok=True)
+        output_dir = os.path.join(self.output_dir, outpath)
+        os.makedirs(output_dir, exist_ok=True)
 
         rearranged_data = [data[idx] for idx in indices]
-        output_filepath = os.path.join(outpath, FILENAME)
-        with open(output_filepath, 'w', encoding='utf-8') as f:
+        output_filepath = os.path.join(output_dir, FILENAME)
+        with open(output_filepath, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            for line in (header + rearranged_data):
-                writer.writerow(line)
+            writer.writerows(header + rearranged_data)
 
-        self.save_indices(indices, outpath)
-        return outpath
+        self.save_indices(indices, output_dir)
+        return output_dir

--- a/tools/herding_coreset_selector/herding/features.py
+++ b/tools/herding_coreset_selector/herding/features.py
@@ -1,0 +1,35 @@
+import os
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+DEFAULT_MODEL_PATH = os.environ.get(
+    'CORESET_MODEL_PATH',
+    os.environ.get('MODEL_PATH', '/workspace/raw_models/Qwen3-4B-Instruct-2507'),
+)
+
+
+def load_model(model_path=None):
+    if model_path is None:
+        model_path = os.environ.get('MODEL_PATH', DEFAULT_MODEL_PATH)
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    model = AutoModelForCausalLM.from_pretrained(model_path, device_map='auto')
+    model.eval()
+    return model, tokenizer
+
+
+def generate_logits(model, tokenizer, prompts_generator):
+    for prompt in prompts_generator:
+        model_inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+        with torch.no_grad():
+            outputs = model.generate(
+                model_inputs.input_ids,
+                max_new_tokens=2,
+                do_sample=False,
+                output_hidden_states=True,
+                return_dict_in_generate=True,
+            )
+        # first generated step, last layer, last position
+        last_layer_idx = model.config.num_hidden_layers
+        first_token_hidden = outputs.hidden_states[1][last_layer_idx][:, -1, :]
+        yield first_token_hidden.squeeze(0)

--- a/tools/herding_coreset_selector/herding/features.py
+++ b/tools/herding_coreset_selector/herding/features.py
@@ -1,19 +1,11 @@
-import os
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
-DEFAULT_MODEL_PATH = os.environ.get(
-    'CORESET_MODEL_PATH',
-    os.environ.get('MODEL_PATH', '/workspace/raw_models/Qwen3-4B-Instruct-2507'),
-)
-
-
-def load_model(model_path=None):
-    if model_path is None:
-        model_path = os.environ.get('MODEL_PATH', DEFAULT_MODEL_PATH)
+def load_model(model_path):
+    """Load the Hugging Face model used for hidden-state feature extraction."""
     tokenizer = AutoTokenizer.from_pretrained(model_path)
-    model = AutoModelForCausalLM.from_pretrained(model_path, device_map='auto')
+    model = AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
     model.eval()
     return model, tokenizer
 


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [x] Feature（功能新增）
- [ ] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Relates to #475

## 🔍 Motivation / 变更动机

本 PR 在 `benchmark/tools/herding_coreset_selector` 下新增一个独立的 **Herding Coreset Selector** 工具，用于对大语言模型 Benchmark，尤其是量化模型评测场景中的评测数据集进行代表性样本筛选和压缩。

在量化模型的开发和验证过程中，通常需要针对多个模型、不同量化算法、量化精度以及不同配置重复执行 Benchmark。如果每次实验都使用完整评测集，会产生较大的模型推理开销和评测时间成本。随着待比较模型或量化配置数量增加，这部分重复计算成本会更加明显。

因此，本工具希望在尽量保留原始评测数据分布和代表性的前提下，从完整数据集中选取一个规模更小的 **Coreset**，供后续量化效果验证、方案快速筛选以及多组配置对比使用，从而减少重复 Benchmark 所需的计算资源和时间。

具体而言，该工具：

1. 使用指定的本地 Hugging Face Causal Language Model 对评测样本对应的 Prompt 进行前向生成，并提取模型隐藏状态作为样本的语义特征表示；
2. 基于样本隐藏状态计算 **RBF（Radial Basis Function）Kernel**；
3. 使用 **Kernel Herding** 的贪心选择策略，使所选 Coreset 在 Kernel 特征空间中尽可能接近完整数据集的整体分布；
4. 根据用户指定的 `coreset_ratio` 自动确定需要保留的样本数量；
5. 在保存 Coreset 的同时保留对应样本在完整评测集中的原始索引，便于实验复现、结果追踪及不同 Coreset 策略之间进行比较；
6. 保持原始评测数据的文件格式，使压缩后的数据可以较方便地继续用于后续 Benchmark 流程。

该功能作为 `benchmark/tools` 下的独立工具提供，不修改现有 Benchmark 的默认执行流程，也不会在未主动调用时增加额外的模型加载或计算开销。

## 📝 Modification / 修改内容

本 PR 主要新增 `benchmark/tools/herding_coreset_selector`，包括 Coreset 生成入口、隐藏状态特征提取、Kernel Herding 算法实现、评测数据集适配层及对应使用文档。

### 1. 新增 Herding Coreset Selector 命令行工具

新增模块化命令行入口，可通过以下方式调用：

```shell
python -m herding \
  --eval-dataset <dataset_name> \
  --dataset-path <dataset_path> \
  --model-path <model_path> \
  --coreset-ratio <ratio> \
  --output-dir <output_dir>
```

目前主要支持以下参数：

- `--eval-dataset`
  - 指定待压缩的评测数据集适配器；
  - 当前已实现 `gpqa` 和 `aime2025`。

- `--dataset-path`
  - 指定原始评测数据所在目录。

- `--model-path`
  - 指定用于提取样本隐藏状态特征的本地 Hugging Face 模型路径。

- `--coreset-ratio`
  - 指定 Coreset 占完整评测集的比例；
  - 有效范围为 `(0, 1]`；
  - 默认值为 `0.2`；
  - 根据数据集大小计算实际 Coreset 样本数量，并保证非空数据集至少选择 1 个样本。

- `--output-dir`
  - 指定 Coreset 生成结果的输出根目录；
  - 默认值为 `./datasets`。

同时对 `coreset_ratio` 增加命令行参数合法性校验，避免比例小于等于 0 或大于 1。

CLI 参数解析阶段不会立即加载 `torch`、`transformers`、`numpy` 等较重依赖，因此执行：

```shell
python -m herding --help
```

时无需进行模型初始化，可快速查看工具帮助信息。

### 2. 新增基于大语言模型隐藏状态的特征提取

新增 `herding/features.py`，负责加载用于特征提取的 Hugging Face 模型和 tokenizer。

工具通过：

```python
AutoTokenizer.from_pretrained(...)
AutoModelForCausalLM.from_pretrained(..., device_map="auto")
```

加载指定模型，并以 `eval` 模式进行特征提取。

针对每个评测样本：

1. 首先由对应的数据集适配器构造 Benchmark Prompt；
2. 对 Prompt 进行 tokenize；
3. 使用模型执行确定性生成；
4. 获取生成过程中最后层的隐藏状态；
5. 将得到的隐藏状态向量作为该样本参与 Coreset 选择的特征表示。

整个特征提取过程使用 `torch.no_grad()`，避免构建反向传播计算图；同时通过 generator 逐条处理 Prompt，并使用 `tqdm` 显示特征提取进度。

### 3. 新增 RBF Kernel Herding 样本选择算法

新增 `herding/algorithm.py`，实现基于 **RBF Kernel** 的 Kernel Herding Coreset 选择逻辑。

主要流程包括：

#### RBF Kernel 计算

根据样本隐藏状态之间的欧氏距离计算 RBF Kernel：

```text
K(x, y) = exp(-||x-y||² / (2 * length_scale²))
```

从而在非线性 Kernel 特征空间中衡量不同评测样本之间的相似性。

#### Kernel bandwidth 自动估计

当用户未显式指定 Kernel bandwidth 时，使用 **median heuristic** 根据样本之间的距离自动估计 RBF Kernel 的 `length_scale`。

对于较大的数据集，bandwidth 估计最多随机采样 1000 条特征，避免为了估计 Kernel 参数而构建过大的距离矩阵。

随机采样使用固定随机种子，以提升同一输入条件下算法行为的可复现性。

如果估计出的 bandwidth 无效或小于等于 0，则回退至默认值。

#### 分批计算 Kernel Mean

为避免直接一次性构造完整的 `N × N` Kernel Matrix，Kernel mean 采用 batch 方式计算。

当前 Kernel batch size 为 512，从而降低较大评测集下 Kernel 计算阶段的瞬时内存压力。

#### Greedy Kernel Herding

在得到完整数据集的 Kernel mean 后，通过迭代式贪心选择：

1. 计算当前已选样本集合与完整数据集 Kernel mean 之间的差异；
2. 从尚未选择的样本中选取当前得分最高的样本；
3. 更新已选集合对应的 Kernel 统计；
4. 重复执行，直到达到目标 Coreset 大小。

当请求的 Coreset 大小大于等于原始数据集大小时，直接返回完整数据集索引。

### 4. 新增统一的数据集适配接口

新增 `herding/eval_datasets/` 数据集适配模块，并提供抽象基类 `EvalDatasetBase`。

数据集适配器统一负责：

- 获取数据集大小；
- 根据 Benchmark 数据构造用于模型特征提取的 Prompt；
- 根据筛选后的原始索引保存数据；
- 保持原始数据文件格式；
- 保存所选样本对应的原始索引。

同时新增数据集注册机制：

```python
@reg_eval_dataset("<dataset_name>")
```

后续新增其他 Benchmark 数据集时，只需要实现对应 Adapter 并完成注册，无需修改 Kernel Herding 的核心算法和特征提取流程。

### 5. 新增 GPQA 数据集支持

新增 `herding/eval_datasets/gpqa.py`。

GPQA Adapter：

- 复用 AISBench 中已有的 `GPQADataset` 数据集加载能力；
- 使用 AISBench `PromptTemplate` 构造与 GPQA Benchmark 对应的多选题 Prompt；
- 默认读取：

```text
gpqa_diamond.csv
```

- Coreset 输出仍保持 CSV 格式；
- 保留原 CSV header；
- 根据 Kernel Herding 返回的索引重新选择对应数据行；
- 同时保存 `indices.json`，记录样本在完整 GPQA 数据集中的原始位置。

### 6. 新增 AIME2025 数据集支持

新增 `herding/eval_datasets/aime2025.py`。

AIME2025 Adapter：

- 默认读取：

```text
aime2025.jsonl
```

- 复用 AISBench Prompt 组件构造数学推理 Prompt；
- Prompt 中保留 step-by-step reasoning 以及最终答案使用 `\boxed{}` 的格式要求；
- Coreset 结果继续以 JSONL 格式输出；
- 同时保存对应的 `indices.json`。

### 7. 保存完整数据与 Coreset 原始索引

每次执行 Coreset 生成时，同时输出完整输入数据和筛选结果。

默认目录结构如下：

```text
datasets/
└── <eval_dataset>/
    └── herding/
        └── <model_name>/
            ├── origin/
            │   ├── <dataset_file>
            │   └── indices.json
            └── coreset/
                ├── <dataset_file>
                └── indices.json
```

其中：

- `origin/<dataset_file>`
  - 保存本次 Herding 输入所对应的完整评测数据；

- `origin/indices.json`
  - 保存完整数据对应的原始索引；

- `coreset/<dataset_file>`
  - 保存 Kernel Herding 筛选得到的 Coreset；

- `coreset/indices.json`
  - 保存 Coreset 样本在完整评测集中的原始索引。

输出目录中 `<model_name>` 会根据 `--model-path` 最后一级目录名称自动生成。

这种组织方式可以明确记录：

```text
数据集
+ Coreset 方法
+ 特征提取模型
+ 原始数据
+ 筛选结果
+ 原始索引
```

便于后续比较不同特征模型或不同 Coreset 配置下的量化 Benchmark 结果，同时提升实验复现和问题追踪能力。

### 8. 新增使用文档

新增：

```text
benchmark/tools/herding_coreset_selector/README.md
```

文档包括：

- 工具功能说明；
- Python 依赖安装方式；
- AISBench 本地安装说明；
- CLI 参数说明；
- Coreset 生成流程；
- 输出目录说明；
- GPQA 使用示例；
- AIME2025 使用示例；
- 不同 `coreset_ratio` 的调用方式；
- 新评测数据集 Adapter 的扩展方式。

当前工具运行需要：

```text
numpy
torch
transformers
tqdm
```

数据集 Prompt 和部分加载逻辑会复用 AISBench 已有组件，因此需要保证运行环境可以正常导入 `ais_bench`。

## 📐 Associated Test Results / 关联测试结果

当前主要进行了手动功能验证。

已验证 Herding Coreset Selector 可以完成以下完整流程：

```text
加载原始评测数据
        ↓
通过数据集 Adapter 构造 Prompt
        ↓
加载指定 Hugging Face 模型
        ↓
逐样本提取隐藏状态特征
        ↓
转换为 Coreset 特征矩阵
        ↓
估计 RBF Kernel bandwidth
        ↓
计算 Kernel mean
        ↓
执行 Kernel Herding 样本选择
        ↓
保存 origin 数据及 indices.json
        ↓
保存 coreset 数据及 indices.json
```

重点检查内容包括：

- CLI 入口可以正常解析参数及显示 `--help`；
- `coreset_ratio` 对 `(0, 1]` 范围进行参数校验；
- 可以正常加载指定本地 Hugging Face 模型并提取隐藏状态；
- Kernel Herding 可以根据目标 Coreset 大小返回对应样本索引；
- Coreset 样本不会重复选择；
- GPQA 输出保持原 CSV 数据格式及 header；
- AIME2025 输出保持原 JSONL 数据格式；
- `origin/indices.json` 与完整数据对应；
- `coreset/indices.json` 可以追踪筛选样本在原始数据集中的索引；
- 输出路径可以根据数据集名称、Herding 方法及特征模型名称进行组织；
- 非空数据集在较小 `coreset_ratio` 下仍至少生成 1 条 Coreset 样本；
- 当 Coreset 大小覆盖完整数据集时，可以直接保留完整数据索引；
- Python 模块可正常完成语法编译检查。

当前 PR 主要为独立工具新增，尚未修改现有 Benchmark 默认执行链路。

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

无向后不兼容变更。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

不影响现有 Benchmark 流程，该工具仅在主动调用时独立运行。

## 🌟 Use cases (Optional) / 使用案例（可选）

用于大模型量化测评前的评测集压缩，以降低多次量化实验中的重复评测成本。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [x] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
|`/pr_check`| 手动重新触发 PR 合入质量检查工作流（PR Quality Check），并在 PR 上评论即可生效。 / Manually re-runs the PR Quality Check workflow by commenting on the pull request. |
