### PR TITLE
fix: skip id: lines in streaming response parsing

### DIFF
--- a/ais_bench/benchmark/models/api_models/base_api.py
+++ b/ais_bench/benchmark/models/api_models/base_api.py
@@ -462,6 +462,8 @@ class BaseAPIModel(BaseModel):
                     chunk = chunk.decode("utf-8")
                     if chunk.startswith(":"):
                         continue
+                    if chunk.startswith("id:"):
+                        continue
                     chunk = chunk.removeprefix("data:").strip()
                     if chunk == "[DONE]":
                         break


### PR DESCRIPTION
**PR Type / PR类型**
- [ ] Feature（功能新增）
- [x] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

Related Issue | 关联 Issue
Fixes #482 

## 🔍 Motivation / 变更动机

问题背景：

在与某些流式 API 服务（如 OpenAI-compatible、vLLM 等）交互时，服务会返回包含元数据的流式响应
这些元数据行采用 id: xxxx 的格式，不是有效的 JSON 数据
当前代码尝试将这些行解析为 JSON，导致 json.JSONDecodeError 错误
请求因此失败

影响范围：

所有使用流式 API 的模型评估都会遇到此问题
特别是与支持流式输出的服务（OpenAI API、vLLM、Ollama 等）的集成

## 📝 Modification / 修改内容

- 文件： ais_bench/benchmark/models/api_models/base_api.py 
- 方法： stream_infer (第 452-483 行) 
- 具体位置： 第 465 行后添加，新增跳过 id: xxx 行逻辑


