### PR TITLE
fix: response anomaly model_name fallback and CLI-only enable switch

### DIFF
--- a/ais_bench/benchmark/cli/argument_parser.py
+++ b/ais_bench/benchmark/cli/argument_parser.py
@@ -124,10 +124,12 @@ class ArgumentParser():
         )
         parser.add_argument(
             '--response-anomaly',
-            action=argparse.BooleanOptionalAction,
-            default=None,
-            help='Enable or disable msProbe response anomaly detection. '
-            'The command-line value overrides response_anomaly.enabled in the config file. '
+            action='store_true',
+            default=False,
+            help='Enable msProbe response anomaly detection. This command-line '
+            'switch is the only way to enable the feature; detection is disabled '
+            'when the flag is absent (response_anomaly.enabled in the config '
+            'file is not supported and is ignored). '
             'Only supported in all/infer/infer_judge modes; perf and Agent modes are unsupported.'
         )
         parser.add_argument(

--- a/ais_bench/benchmark/cli/config_manager.py
+++ b/ais_bench/benchmark/cli/config_manager.py
@@ -314,11 +314,18 @@ class ConfigManager:
         # is a task label (e.g. 'vllm-api-general-chat') unrelated to the
         # served model, so it would silently miss the keys in msProbe's
         # mtype_config.json and token2category. When model_name is not set,
-        # fall back to the model_path directory basename (the de-facto model
-        # name, same default the config generator uses) instead.
+        # derive it from the most specific source available, in order (each
+        # path resolved to its directory basename, the same default the
+        # config generator uses): explicit model_name is handled above by the
+        # ``not model_anomaly_cfg.get('model_name')`` guard; then model-level
+        # model_path, global model_name, global model_path, and finally the
+        # model 'path' field.
         if not model_anomaly_cfg.get('model_name'):
-            fallback = global_cfg.get('model_name') or self._model_name_from_path(
-                model_anomaly_cfg.get('model_path') or model_cfg.get('path')
+            fallback = (
+                self._model_name_from_path(model_anomaly_cfg.get('model_path'))
+                or global_cfg.get('model_name')
+                or self._model_name_from_path(global_cfg.get('model_path'))
+                or self._model_name_from_path(model_cfg.get('path'))
             )
             if fallback:
                 model_anomaly_cfg['model_name'] = fallback

--- a/ais_bench/benchmark/cli/config_manager.py
+++ b/ais_bench/benchmark/cli/config_manager.py
@@ -162,10 +162,21 @@ class ConfigManager:
         """Apply CLI overrides and defaults to the global anomaly config."""
         raw_anomaly_cfg = self.cfg.get('response_anomaly') or {}
         global_cfg = dict(raw_anomaly_cfg) if isinstance(raw_anomaly_cfg, dict) else {}
-        cli_enabled = getattr(self.args, 'response_anomaly', None)
-        if isinstance(cli_enabled, bool):
-            global_cfg['enabled'] = cli_enabled
-        global_cfg.setdefault('enabled', False)
+        # The enabled switch is command-line only (--response-anomaly); an
+        # 'enabled' key in the config file is not a supported enable path.
+        # Warn and drop it so it can never silently enable detection.
+        if 'enabled' in global_cfg:
+            self.logger.warning(
+                "response_anomaly.enabled in the config file is not "
+                "supported; use the --response-anomaly command-line switch "
+                "to enable response anomaly detection. The configured "
+                "value is ignored."
+            )
+            global_cfg.pop('enabled')
+        # Strictly a real boolean from the CLI; anything else (missing
+        # attribute, mocks) means the switch was not passed -> disabled.
+        cli_enabled = getattr(self.args, 'response_anomaly', False)
+        global_cfg['enabled'] = cli_enabled if isinstance(cli_enabled, bool) else False
         configured_top_logprobs = global_cfg.pop('top_logprobs', None)
         global_cfg.setdefault('msprobe_config_path', None)
         cli_payload_retention = getattr(

--- a/ais_bench/benchmark/cli/config_manager.py
+++ b/ais_bench/benchmark/cli/config_manager.py
@@ -287,6 +287,7 @@ class ConfigManager:
         self._validate_response_anomaly_model_resources(
             model_cfg, model_anomaly_cfg
         )
+        self._validate_response_anomaly_model_name(model_cfg, model_anomaly_cfg)
         self._validate_response_anomaly_resource_paths(
             model_cfg, model_anomaly_cfg
         )
@@ -298,10 +299,18 @@ class ConfigManager:
         model_anomaly_cfg = dict(model_cfg.get('response_anomaly') or {})
         configured_top_logprobs = model_anomaly_cfg.pop('top_logprobs', None)
         self._validate_response_anomaly_top_logprobs(configured_top_logprobs)
-        model_anomaly_cfg.setdefault(
-            'model_name',
-            global_cfg.get('model_name') or model_cfg.get('abbr'),
-        )
+        # NOTE: model_name intentionally has no model-abbr fallback. The abbr
+        # is a task label (e.g. 'vllm-api-general-chat') unrelated to the
+        # served model, so it would silently miss the keys in msProbe's
+        # mtype_config.json and token2category. When model_name is not set,
+        # fall back to the model_path directory basename (the de-facto model
+        # name, same default the config generator uses) instead.
+        if not model_anomaly_cfg.get('model_name'):
+            fallback = global_cfg.get('model_name') or self._model_name_from_path(
+                model_anomaly_cfg.get('model_path') or model_cfg.get('path')
+            )
+            if fallback:
+                model_anomaly_cfg['model_name'] = fallback
         for key in (
             'model_path',
             'msprobe_config_path',
@@ -311,6 +320,43 @@ class ConfigManager:
             if key not in model_anomaly_cfg:
                 model_anomaly_cfg[key] = global_cfg.get(key)
         return model_anomaly_cfg
+
+    @staticmethod
+    def _model_name_from_path(model_path):
+        """Derive the de-facto model name from the model directory basename."""
+        if not model_path:
+            return None
+        basename = osp.basename(osp.normpath(str(model_path).strip()))
+        return basename or None
+
+    @staticmethod
+    def _validate_response_anomaly_model_name(model_cfg, model_anomaly_cfg):
+        """Fail fast when no reliable msProbe model name can be determined."""
+        if model_anomaly_cfg.get('model_name'):
+            return
+        has_explicit_resources = bool(
+            model_anomaly_cfg.get('msprobe_mtype_path')
+            and model_anomaly_cfg.get('msprobe_token2category_dir')
+        )
+        raise AISBenchConfigError(
+            TMAN_CODES.UNKNOWN_ERROR,
+            f"response_anomaly is enabled for model "
+            f"'{model_cfg.get('abbr', '')}' but response_anomaly.model_name "
+            "is not set and cannot be inferred from a model directory. The "
+            "model abbr is a task label unrelated to the served model and "
+            "is not used as a fallback. "
+            + (
+                "Since explicit msProbe resource paths are configured, set "
+                "response_anomaly.model_name to the key used in "
+                "msprobe_mtype_path and in the token2category file names."
+                if has_explicit_resources
+                else "Set response_anomaly.model_name explicitly (it must "
+                "match the keys in msProbe's mtype_config.json and the "
+                "token2category file names), or set model "
+                "'path'/model_path to the local model directory so the "
+                "name can be derived from its basename."
+            ),
+        )
 
     @staticmethod
     def _resolve_response_anomaly_model_path(model_cfg, model_anomaly_cfg):

--- a/ais_bench/benchmark/cli/config_manager.py
+++ b/ais_bench/benchmark/cli/config_manager.py
@@ -360,9 +360,7 @@ class ConfigManager:
             TMAN_CODES.UNKNOWN_ERROR,
             f"response_anomaly is enabled for model "
             f"'{model_cfg.get('abbr', '')}' but response_anomaly.model_name "
-            "is not set and cannot be inferred from a model directory. The "
-            "model abbr is a task label unrelated to the served model and "
-            "is not used as a fallback. "
+            "is not set and cannot be inferred from a model directory. "
             + (
                 "Since explicit msProbe resource paths are configured, set "
                 "response_anomaly.model_name to the key used in "

--- a/ais_bench/benchmark/utils/response_anomaly.py
+++ b/ais_bench/benchmark/utils/response_anomaly.py
@@ -453,9 +453,15 @@ class ResponseAnomalyCoordinator:
                 len(inherited),
             )
         if not model_name_warned and not anomaly_cfg.get("model_name"):
+            # ConfigManager normally resolves model_name (explicit value, or
+            # the model_path basename) before the task runs, so this branch
+            # only triggers on manually built configs. The detector receives
+            # None as the model name in that case; warn truthfully instead
+            # of claiming an abbr fallback that never happens.
             self.logger.warning(
-                "response_anomaly.model_name is not set; falling back to model "
-                "abbr '%s'. msProbe model matching may be degraded.",
+                "response_anomaly.model_name is not set; msProbe will be "
+                "called without a model name and model matching may be "
+                "degraded. Set response_anomaly.model_name for model '%s'.",
                 task.model_cfg.get("abbr"),
             )
             model_name_warned = True

--- a/tests/UT/cli/test_config_manager.py
+++ b/tests/UT/cli/test_config_manager.py
@@ -1043,7 +1043,66 @@ class TestConfigManager(unittest.TestCase):
         self.assertIn('ais_bench-gen-response-anomaly-config', message)
 
     def test_response_anomaly_accepts_explicit_msprobe_paths(self):
-        """显式配置 mtype + token2category（真实存在）时无需 model_path。"""
+        """显式配置 mtype + token2category（真实存在）+ model_name 时无需 model_path。"""
+        import os as _os
+
+        mtype_path = _os.path.join(self.tokenizer_dir, 'mtype_config.json')
+        tk2cat_dir = _os.path.join(self.tokenizer_dir, 'token2category')
+        open(mtype_path, 'w').close()
+        _os.makedirs(tk2cat_dir, exist_ok=True)
+
+        self.args.mode = 'all'
+        self.args.response_anomaly = True
+        config_manager = ConfigManager(self.args)
+        config_manager.cfg = {
+            'models': [
+                self._service_model(
+                    path='',
+                    response_anomaly={
+                        'model_name': 'Qwen3-30B-A3B',
+                        'msprobe_mtype_path': mtype_path,
+                        'msprobe_token2category_dir': tk2cat_dir,
+                    },
+                )
+            ],
+            'datasets': [],
+            'cli_args': {},
+        }
+
+        config_manager._init_response_anomaly_config()
+
+        model_anomaly_cfg = config_manager.cfg['models'][0]['response_anomaly']
+        self.assertEqual(model_anomaly_cfg['msprobe_mtype_path'], mtype_path)
+        self.assertEqual(model_anomaly_cfg['model_name'], 'Qwen3-30B-A3B')
+        self.assertIsNone(model_anomaly_cfg['model_path'])
+
+    def test_response_anomaly_model_name_falls_back_to_path_basename(self):
+        """未配置 model_name 时回退 model_path 目录名，而不是模型 abbr。"""
+        self.args.mode = 'all'
+        self.args.response_anomaly = True
+        config_manager = ConfigManager(self.args)
+        config_manager.cfg = {
+            'models': [
+                self._service_model(
+                    abbr='vllm-api-general-chat',
+                    response_anomaly={},
+                )
+            ],
+            'datasets': [],
+            'cli_args': {},
+        }
+
+        config_manager._init_response_anomaly_config()
+
+        model_anomaly_cfg = config_manager.cfg['models'][0]['response_anomaly']
+        self.assertEqual(
+            model_anomaly_cfg['model_name'],
+            os.path.basename(os.path.normpath(self.tokenizer_dir)),
+        )
+        self.assertNotEqual(model_anomaly_cfg['model_name'], 'vllm-api-general-chat')
+
+    def test_response_anomaly_explicit_paths_require_model_name(self):
+        """显式 msprobe 路径但缺 model_name 时应启动报错，而非静默用 abbr 匹配失败。"""
         import os as _os
 
         mtype_path = _os.path.join(self.tokenizer_dir, 'mtype_config.json')
@@ -1068,11 +1127,9 @@ class TestConfigManager(unittest.TestCase):
             'cli_args': {},
         }
 
-        config_manager._init_response_anomaly_config()
-
-        model_anomaly_cfg = config_manager.cfg['models'][0]['response_anomaly']
-        self.assertEqual(model_anomaly_cfg['msprobe_mtype_path'], mtype_path)
-        self.assertIsNone(model_anomaly_cfg['model_path'])
+        with self.assertRaises(AISBenchConfigError) as cm:
+            config_manager._init_response_anomaly_config()
+        self.assertIn('model_name', str(cm.exception))
 
     def test_response_anomaly_rejects_nonexistent_msprobe_paths(self):
         """显式配置的 msProbe 路径不存在时启动即报错，而不是运行期全 failed。"""
@@ -1084,6 +1141,7 @@ class TestConfigManager(unittest.TestCase):
                 self._service_model(
                     path='',
                     response_anomaly={
+                        'model_name': 'Qwen3-30B-A3B',
                         'msprobe_mtype_path': '/workspace/missing/mtype_config.json',
                         'msprobe_token2category_dir': '/workspace/missing/token2category',
                     },

--- a/tests/UT/cli/test_config_manager.py
+++ b/tests/UT/cli/test_config_manager.py
@@ -1138,6 +1138,59 @@ class TestConfigManager(unittest.TestCase):
         )
         self.assertNotEqual(model_anomaly_cfg['model_name'], 'vllm-api-general-chat')
 
+    def test_response_anomaly_model_name_falls_back_to_global_model_path(self):
+        """顶层全局块 model_path（未填 model_name）也参与 model_name 推导。"""
+        import os as _os
+
+        global_model_dir = _os.path.join(self.tokenizer_dir, 'Qwen3-30B-A3B')
+        _os.makedirs(global_model_dir, exist_ok=True)
+
+        self.args.mode = 'all'
+        self.args.response_anomaly = True
+        config_manager = ConfigManager(self.args)
+        config_manager.cfg = {
+            'response_anomaly': {'model_path': global_model_dir},
+            'models': [
+                self._service_model(path='', response_anomaly={}),
+            ],
+            'datasets': [],
+            'cli_args': {},
+        }
+
+        config_manager._init_response_anomaly_config()
+
+        model_anomaly_cfg = config_manager.cfg['models'][0]['response_anomaly']
+        self.assertEqual(model_anomaly_cfg['model_name'], 'Qwen3-30B-A3B')
+
+    def test_response_anomaly_model_level_model_path_beats_global(self):
+        """模型级 model_path 优先于全局块 model_path 推导 model_name。"""
+        import os as _os
+
+        global_dir = _os.path.join(self.tokenizer_dir, 'GlobalModel')
+        model_dir = _os.path.join(self.tokenizer_dir, 'ModelLevelModel')
+        _os.makedirs(global_dir, exist_ok=True)
+        _os.makedirs(model_dir, exist_ok=True)
+
+        self.args.mode = 'all'
+        self.args.response_anomaly = True
+        config_manager = ConfigManager(self.args)
+        config_manager.cfg = {
+            'response_anomaly': {'model_path': global_dir},
+            'models': [
+                self._service_model(
+                    path='',
+                    response_anomaly={'model_path': model_dir},
+                ),
+            ],
+            'datasets': [],
+            'cli_args': {},
+        }
+
+        config_manager._init_response_anomaly_config()
+
+        model_anomaly_cfg = config_manager.cfg['models'][0]['response_anomaly']
+        self.assertEqual(model_anomaly_cfg['model_name'], 'ModelLevelModel')
+
     def test_response_anomaly_explicit_paths_require_model_name(self):
         """显式 msprobe 路径但缺 model_name 时应启动报错，而非静默用 abbr 匹配失败。"""
         import os as _os

--- a/tests/UT/cli/test_config_manager.py
+++ b/tests/UT/cli/test_config_manager.py
@@ -734,6 +734,43 @@ class TestConfigManager(unittest.TestCase):
         with self.assertRaises(AISBenchConfigError):
             config_manager._init_response_anomaly_config()
 
+    def test_response_anomaly_config_enabled_key_is_ignored(self):
+        """配置文件中的 response_anomaly.enabled 不再生效：开关仅支持命令行。"""
+        self.args.mode = 'all'
+        self.args.response_anomaly = False  # 命令行未传 --response-anomaly
+        config_manager = ConfigManager(self.args)
+        config_manager.cfg = {
+            'response_anomaly': {'enabled': True},  # 配置文件写 enabled=True
+            'models': [self._service_model()],
+            'datasets': [{'abbr': 'dataset'}],
+            'cli_args': {},
+        }
+
+        config_manager._init_response_anomaly_config()
+
+        # 配置文件的 enabled 被忽略，最终以命令行为准：未启用
+        self.assertFalse(config_manager.cfg['response_anomaly']['enabled'])
+        # 未启用时不注入 logprobs 请求参数
+        generation_kwargs = config_manager.cfg['models'][0]['generation_kwargs']
+        self.assertNotIn('response_anomaly_enabled', generation_kwargs)
+
+    def test_response_anomaly_cli_switch_enables_detection(self):
+        """仅命令行 --response-anomaly 能开启检测（无 --no- 关闭形态）。"""
+        self.args.mode = 'all'
+        self.args.response_anomaly = True
+        config_manager = ConfigManager(self.args)
+        config_manager.cfg = {
+            'models': [self._service_model()],
+            'datasets': [{'abbr': 'dataset'}],
+            'cli_args': {},
+        }
+
+        config_manager._init_response_anomaly_config()
+
+        self.assertTrue(config_manager.cfg['response_anomaly']['enabled'])
+        generation_kwargs = config_manager.cfg['models'][0]['generation_kwargs']
+        self.assertTrue(generation_kwargs['response_anomaly_enabled'])
+
     def test_response_anomaly_injects_request_kwargs(self):
         """启用响应异常检测时为 service 模型注入 logprobs 与内部开关。"""
         self.args.mode = 'all'


### PR DESCRIPTION
**PR Type / PR类型**
- [ ] Feature（功能新增）
- [x] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [ ] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Relates to #468

## 🔍 Motivation / 变更动机

**提交 2（开关语义）**：功能开关此前同时接受命令行（--response-anomaly / --no-response-anomaly）与配置文件（response_anomaly.enabled）两个来源，命令行优先。单一开关存在双通道容易误启用（配置文件残留 enabled=True 即静默开启），且 --no- 形态冗余。改为：--response-anomaly 是唯一使能方式，不传即关闭；配置文件的 enabled 键被忽略并告警（选项 B）。非开关配置（payload_retention、payload_storage、模型级 msprobe 资源）不受影响。

`response_anomaly.model_name` 未配置时，ConfigManager 此前回退到模型 `abbr`（config_manager.py 原 `setdefault('model_name', global or model_cfg.get('abbr'))`）。但 `abbr` 是任务标识（如 `vllm-api-general-chat`），与实际服务的模型（如 Qwen3-30B-A3B）无关，拿它去匹配 msProbe 的 `mtype_config.json` 键和 `token2category/<模型名>_<词表>.json` 文件名几乎必然 miss。两种合法配置场景下后果：

1. **显式配置 msprobe 路径但漏配 model_name**：用户以真实模型名生成了 msProbe 配置，却因回退到 abbr 而匹配不上，生僻字/乱码检测静默失效——Case 仍标 `completed`，用户拿到看似正常实则缺项的结果（静默假阴性）。
2. **model_path 自动生成配置**：生成产物以 abbr 为键命名，数据虽正确但埋雷——日后切换到真实模型名的 msProbe 配置（或复用他人配置）时键对不上，检测静默失效。

另外协调器中的告警文案与实际行为不符：文案称 "falling back to model abbr"，但 `_detect_case` 实际传给 detector 的是 `None`，从未真正回退到 abbr。

## 📝 Modification / 修改内容

**提交 2：`--response-anomaly` 改为仅命令行使能（c320176）**
- `argument_parser.py`：`--response-anomaly` 改为 `store_true`（默认 False），移除 `--no-response-anomaly`；help 文案说明开关仅命令行
- `config_manager.py`：`enabled` 仅取自 CLI 解析出的布尔值（非布尔一律视为未开启）；配置文件出现 `enabled` 键时告警并丢弃，杜绝配置残留静默开启
- 测试：新增“配置文件 enabled 被忽略”“CLI 开关为唯一使能路径”用例；57 个用例全过；实测验证 `--no-response-anomaly` 已被 argparse 拒绝

**`ais_bench/benchmark/cli/config_manager.py`**
- `model_name` 解析顺序改为：模型级配置 > 全局配置 > **`model 'path'/model_path 目录名`**（事实上的模型名，与配置生成工具 `gen_model_config.py` 的默认一致）；**abbr 不再作为回退源**
- 当无法推断出可靠名称（无 model_name 且无模型目录）时，**配置初始化阶段 fail-fast 报错**并给出两种修复指引（显式配置 model_name / 配置模型目录），替代静默使用错误名称；报错信息按"显式 msprobe 路径"与"无任何资源"两种场景分别提示
- 校验顺序调整：先资源校验（model_path 或显式 msprobe 三件套）再 model_name 校验，确保显式路径场景的报错信息准确

**`ais_bench/benchmark/utils/response_anomaly.py`**
- 修正协调器告警：如实说明"将以无模型名方式调用 msProbe"，不再声称存在从未发生的 abbr 回退

**`tests/UT/cli/test_config_manager.py`**
- 新增：model_name 回退到 model_path 目录名（而非 abbr）的正向用例
- 新增：显式 msprobe 路径但缺 model_name 时应启动报错的用例
- 更新：显式路径用例补充 model_name；不存在路径用例补充 model_name 使其命中路径校验

## 📐 Associated Test Results / 关联测试结果

本机执行 `python -m unittest tests.UT.cli.test_config_manager`：55 个用例全部通过（含 3 个新增/更新用例）。
`tests/UT/cli/test_workers.py`、`tests/UT/utils/test_response_anomaly.py` 无回归（后者 1 skip 为 zstandard 可选依赖守卫，属预期）。
`test_argument_parser` 有 1 个失败为 master 上已存在的环境相关问题（本机 CPU 核数导致 `--max-num-workers` 上限为 1），与本 PR 无关，已在干净 master 上复现确认。

## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

行为变更（有意的）：原先"未配置 model_name 且无模型目录"的配置会静默以 abbr 运行，现在会启动报错。受影响用户需显式配置 `response_anomaly.model_name` 或将模型 `path` 指向本地模型目录（后者多数场景已满足，可自动从目录名推断）。由于旧行为本身产生错误的检测结果，此报错视为暴露问题而非破坏功能。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

无。

## 🌟 Use cases (Optional) / 使用案例（可选）

配置了模型目录但未配 model_name 的用户（最常见场景）将自动获得正确的模型名（目录名），不再需要额外配置；显式 msprobe 路径的用户漏配 model_name 时会得到明确报错而非静默退化。

## ✅ Checklist / 检查列表

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 lint 工具来修复潜在的 lint 问题。
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。（新增回退/报错用例覆盖两种场景）
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [x] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。（文档 #486 已按新行为描述 model_name 回退语义，代码注释同步说明）

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。（行为变更仅影响异常检测配置初始化，见上方 BC-breaking 说明）
- [x] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @flame-hu
- Relevant Module Owners / 相关模块负责人: @flame-hu
- Other Collaboration Notes / 其他协作说明：与文档 PR #486 配套（该 PR 已描述正确的回退语义，本 PR 使代码与文档一致）。发现过程：设计文档删除后的文档审查中定位到此问题。

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
|`/pr_check`| 手动重新触发 PR 合入质量检查工作流（PR Quality Check），并在 PR 上评论即可生效。 / Manually re-runs the PR Quality Check workflow by commenting on the pull request. |
