### PR TITLE
feat: 新增 agent-runtime 镜像（harbor-only）与双模式拉起脚本

### DIFF
--- a/docker/agent_runtime/Dockerfile.agent-runtime
+++ b/docker/agent_runtime/Dockerfile.agent-runtime
@@ -1,0 +1,130 @@
+# AISBench Agent Runtime Dockerfile (harbor-only 精简版)
+#
+# 在现有 aisbench_benchmark 基础镜像（已含 docker engine + compose + ais_bench）之上，
+# 追加 harbor 隔离 venv，构建 harbor 测评运行环境：
+#   - harbor 从 AISBench/harbor fork 的 git 仓库直接安装（带 deps_path / --agent-deps
+#     功能；upstream PyPI 同版本号 0.21.0 无此字段，故不能用 PyPI 包）。
+#     GitHub 访问经 gh-proxy.com 镜像前缀加速，仓库地址可用构建参数覆盖
+#   - venv 内放置 ais_bench wrapper（shebang 指向 venv python），让 harbor_agent_task.py
+#     的 subprocess 用 venv python，正确加载 venv-local 的 harbor 包
+#
+# 构建上下文布局：
+#   ./Dockerfile.agent-runtime
+#   ./patches/harbor_compose_patch.py
+#
+# 构建方式（BASE_IMAGE 换成实际基镜像 tag）：
+#   docker build --network host \
+#       -f Dockerfile.agent-runtime \
+#       -t aisbench/agent-runtime:harbor-only \
+#       --build-arg BASE_IMAGE=ghcr.io/aisbench/aisbench_benchmark:v3.1-<date>-master-ubuntu24.04-py312-aarch64 \
+#       .
+#
+# 使用方式（DinD 模式，推荐直接用 start_agent_runtime.sh 一键拉起）：
+#   ./start_agent_runtime.sh \
+#       --image aisbench/agent-runtime:harbor-only \
+#       --dataset /path/to/terminal-bench-2 \
+#       --case-images /path/to/case-images.tar.gz \
+#       --agent-deps /path/to/agent-deps \
+#       --agent terminus-2
+#   docker exec -it agent-runtime bash
+#   agent_env harbor                          # 激活 harbor venv
+#   ais_bench ais_bench/configs/agent_example/harbor_agent_task.py --mode agent ...
+#
+# 关键点：外层容器必须 --cgroupns=host 并 rw 挂载宿主 /sys/fs/cgroup，
+# 否则内层 runc 会报 "cannot enter cgroupv2 ... it is in threaded mode"。
+# 手动 docker run 的完整参数见 start_agent_runtime.sh。
+# 详细步骤见 USAGE.md。
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+# agent runtime 相关路径
+ENV AGENT_VENVS_ROOT=/opt/venvs
+ENV AGENT_PACKS_ROOT=/opt/agent-resources/packs
+
+RUN mkdir -p ${AGENT_VENVS_ROOT} ${AGENT_PACKS_ROOT}
+
+# ============================================================
+# venv: harbor
+# harbor 隔离在独立 venv，不污染 ais_bench 主环境。
+# harbor 本体从 AISBench/harbor fork 仓库直接安装（deps_path 功能），
+# git 访问经 gh-proxy.com 镜像加速，依赖包从华为镜像解析。
+#
+# --system-site-packages: venv 能看到基镜像里已装好的 ais_bench_benchmark
+# --copies: 强制拷贝 python 二进制，避免 symlink 丢失 venv 身份
+# ============================================================
+ARG HARBOR_REPO=https://gh-proxy.com/https://github.com/AISBench/harbor.git
+RUN python3.12 -m venv ${AGENT_VENVS_ROOT}/harbor --system-site-packages --copies && \
+    ${AGENT_VENVS_ROOT}/harbor/bin/pip install --no-cache-dir --upgrade pip \
+        -i https://repo.huaweicloud.com/repository/pypi/simple \
+        --trusted-host repo.huaweicloud.com \
+        --default-timeout=120 --retries=5 && \
+    ${AGENT_VENVS_ROOT}/harbor/bin/pip install --no-cache-dir \
+        -i https://repo.huaweicloud.com/repository/pypi/simple \
+        --trusted-host repo.huaweicloud.com \
+        --default-timeout=120 --retries=5 \
+        "harbor @ git+${HARBOR_REPO}"
+
+# ============================================================
+# harbor venv 内放置 ais_bench 命令（关键）
+# harbor_agent_task.py 用 sys.executable 启动子进程：若主进程是系统 python，
+# 子进程找不到 venv-local 的 harbor 包。wrapper 的 shebang 指向 venv python，
+# 用户 agent_env harbor 后 PATH 命中它 → 主进程 sys.executable 即 venv python
+# ============================================================
+RUN cat > ${AGENT_VENVS_ROOT}/harbor/bin/ais_bench <<'PYEOF'
+#!/opt/venvs/harbor/bin/python
+# -*- coding: utf-8 -*-
+"""harbor venv 内置 ais_bench wrapper
+启动时使用 harbor venv 的 python，让 subprocess.Popen 启动 harbor venv 的 python，
+从而能正确加载 venv local site-packages（AISBench fork harbor 在此）。
+"""
+import re
+import sys
+try:
+    from ais_bench.benchmark.cli.main import main
+except ImportError as e:
+    sys.stderr.write(f"[error] failed to import ais_bench: {e}\n")
+    sys.stderr.write("[hint] 检查 harbor venv 是否启用 --system-site-packages（需看到系统 ais_bench）\n")
+    sys.exit(2)
+if __name__ == "__main__":
+    sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+    sys.exit(main())
+PYEOF
+RUN chmod +x ${AGENT_VENVS_ROOT}/harbor/bin/ais_bench
+
+# ============================================================
+# Patch harbor 的 docker compose 模板
+# openEuler/RHEL 宿主默认 seccomp profile 拦截 clone3，内层 trial 容器中
+# OpenBLAS/NumPy 初始化线程会报 pthread_create failed: Operation not permitted。
+# patch 给所有模板的 main service 补 security_opt: [seccomp=unconfined]，
+# 并补 network_mode: host（已显式声明 network_mode 的模板如 no-network 不覆盖）。
+# DinD 模式下此 patch 无副作用（子容器本就用 Docker 官方默认 profile）
+# ============================================================
+COPY patches/harbor_compose_patch.py /tmp/harbor_compose_patch.py
+RUN HARBOR_DIR=$(${AGENT_VENVS_ROOT}/harbor/bin/python -c "import harbor, os; print(os.path.dirname(harbor.__file__))") && \
+    for f in ${HARBOR_DIR}/environments/docker/docker-compose-*.yaml; do \
+        [ -f "$f" ] || continue; \
+        cp "$f" "$f.bak"; \
+        python3.12 /tmp/harbor_compose_patch.py "$f"; \
+    done && \
+    rm -f /tmp/harbor_compose_patch.py
+
+# ============================================================
+# 便捷函数：激活 harbor venv
+# 用户在容器内 `agent_env harbor` 激活后，可照常执行原生 ais_bench / harbor 命令
+# ============================================================
+RUN cat >> /etc/bash.bashrc <<'EOF'
+
+# AISBench Agent venv 激活便捷函数
+agent_env() {
+    case "$1" in
+        harbor) source /opt/venvs/harbor/bin/activate ;;
+        *) echo "usage: agent_env harbor" ;;
+    esac
+}
+EOF
+
+WORKDIR /benchmark

--- a/docker/agent_runtime/USAGE.md
+++ b/docker/agent_runtime/USAGE.md
@@ -339,20 +339,54 @@ ais_bench ais_bench/configs/agent_example/harbor_agent_task.py \
     --model openai/<模型名>
 ```
 
+**只跑指定的 case**（任选其一，可与上面参数自由组合）：
+
+```bash
+# 方式 1：--include-task-name 按 task 名过滤（推荐）
+#   匹配对象 = task.toml 的 [task] name 字段（如 sys-report、terminal-bench/fix-git）
+#   支持 glob 通配；可空格分隔多个，也可重复传参
+--include-task-name sys-report
+--include-task-name "terminal-bench/fix-git" "*hello*"
+
+# 方式 2：--exclude-task-name 反向排除（匹配规则同上），可与 include 组合
+
+# 方式 3：-p 直接指向单个 case 目录（等效于只跑该 case）
+-p /data/terminal-bench-2/sys-report
+```
+
+> `--n-tasks N` 表示"最多取 N 个任务"，与过滤参数叠加生效：
+> 先按 include/exclude 筛选，再截取前 N 个。要精确跑某一个 case，
+> 用 `--include-task-name` 而不要只靠 `--n-tasks 1`（后者取的是数据集里第一个任务）。
+
 参数说明：
 
 | 参数 | 说明 |
 |---|---|
 | `-a` | agent 名（须与 deps bundle 前缀、第 5 步构建的 agent 一致） |
 | `--agent-deps` | deps bundle 目录（dind 固定 `/opt/agent-resources/deps`；socket 为启动时的宿主原路径，文件夹模式自动匹配 bundle） |
-| `-p` | 数据集目录（dind 固定 `/opt/data/terminal-bench-2`；socket 为启动时的宿主原路径） |
-| `--n-tasks` | 抽取的任务数；**首次务必 `1`** 冒烟 |
+| `-p` | 数据集目录（dind 固定 `/opt/data/terminal-bench-2`；socket 为启动时的宿主原路径）；**也支持直接指向单个 case 子目录** |
+| `--include-task-name <名>` | **只跑指定 case**：匹配 `task.toml` 的 `[task] name`，支持 glob、可多个（如 `--include-task-name sys-report` 或 `"terminal-bench/*"`） |
+| `--exclude-task-name <名>` | 排除匹配的 case（规则同 include），可与 include 组合 |
+| `--n-tasks` | 最多抽取的任务数（与过滤参数叠加）；**首次冒烟务必 `1`** |
 | `--api-base` | OpenAI 兼容服务地址（以 `/v1` 结尾） |
 | `--model` | **必须带 litellm provider 前缀**；OpenAI 兼容接口一律 `openai/<模型名>`，如 `openai/Qwen2.5-7B-Instruct` |
 | `--agent-api-key <key>` | 模型服务需要鉴权时传（可选） |
 | `--n-concurrent N` | 并发 trial 数（默认配置 5，可按资源调整） |
 | `-k N` | 每个 task 的尝试次数 |
 | `--ae KEY=VALUE` | 注入 trial 容器/tmux 会话的环境变量，可重复（如 `--ae OPENAI_API_KEY=xxx`） |
+| `--ak KEY=VALUE` | 传给 agent 的额外 kwarg，可重复（进阶用法） |
+| `--agent-import-path <m:C>` | 自定义 agent 导入路径（`module.path:ClassName`），配合 `-a` 使用 |
+| `-d <name@version>` | 远端数据集（registry 或包），与 `-p` 二选一 |
+| `-e <环境>` | harbor 环境类型（docker/daytona/e2b/modal…，默认 docker） |
+| `--timeout-multiplier X` | case 超时时间倍率（慢模型/长任务可调大） |
+| `--max-retries N` | trial 失败自动重试次数 |
+| `--host-network` | trial 容器共享宿主网络栈（镜像内 compose 模板已默认 host，一般无需再传） |
+| `--force-build/--no-force-build` | 是否强制重建 case 环境（prebuilt 镜像场景无需关心） |
+| `--delete/--no-delete` | 结束后是否删除 trial 容器（排查时 `--no-delete` 保留现场） |
+| `--purge-exception-cases` | 配合 `--reuse`：先清掉上次异常退出的 case 再自动重跑 |
+| `-q` / `-y` | 抑制单 trial 进度显示 / 自动确认环境变量提示 |
+| `--env-file <path>` | 从 .env 文件读取环境变量 |
+| `--monitor-port <port>` | harbor monitor HTTP 服务端口（默认 0 = 关闭） |
 | `--disable-verification` | 跳过 verifier 打分（链路调试用；正常评测勿加） |
 
 预期日志关键行（以 dind 模式路径为例，socket 模式对应路径为宿主原路径）：

--- a/docker/agent_runtime/USAGE.md
+++ b/docker/agent_runtime/USAGE.md
@@ -1,0 +1,438 @@
+# AISBench harbor agent-runtime 操作文档（harbor-only / 双模式）
+
+本文档面向在**目标机**上从零跑通 harbor（terminal-bench-2）agent 测评的操作者。
+
+`start_agent_runtime.sh` 支持两种模式（`--mode` 参数）：
+
+| 模式 | 默认 | 原理 | 隔离性 | case 镜像准备 |
+|---|---|---|---|---|
+| `socket`（DooD） | **是** | 挂载宿主机 `/var/run/docker.sock`，trial 容器由**宿主机 daemon** 拉起 | 弱（容器内等价于宿主机 daemon 控制权） | **零准备**，宿主机已有镜像直接可见 |
+| `dind`（DinD） | 否 | `--privileged` 容器内拉起独立 dockerd，trial 容器只存在于里层 | 强（与宿主机 Docker 环境完全隔离） | 需要 case 镜像包 |
+
+无强隔离需求直接用默认 socket 模式（最简路径）；安全要求高的环境用 `--mode dind`。
+
+---
+
+## 0. 前提与资产
+
+### 0.1 目标机环境要求
+
+| 项 | 要求 |
+|---|---|
+| OS | Linux（宿主 cgroup v2；openEuler/RHEL 系已验证 seccomp 兼容） |
+| Docker | 已安装并可运行（`docker info` 正常） |
+| 架构 | aarch64（镜像为 arm64 版） |
+| 网络 | 目标机需能访问模型服务（`--api-base`）；**评测过程本身不需要外网** |
+| 权限 | socket 模式：普通 docker 权限即可；dind 模式：需能执行 `docker run --privileged` |
+
+自检命令：
+
+```bash
+docker info | grep -i "cgroup version"    # 预期：Cgroup Version: 2
+uname -m                                   # 预期：aarch64
+```
+
+### 0.2 资产清单（仓库 `docker/agent_runtime/` 目录 + 内部网盘镜像包）
+
+| 文件 | 用途 | 是否必需 |
+|---|---|---|
+| `aisbench-agent-runtime-harbor-only.tar.gz` | 打包好的 agent-runtime 镜像（860MB，内部网盘下载） | 路径 A（推荐）必需 |
+| `start_agent_runtime.sh` | 一键启动脚本（默认 socket 模式，`--mode dind` 切强隔离） | 必需 |
+| `sync_images.sh` | dind 模式增量补充：宿主机 → 容器内 daemon 镜像直传 | 可选（仅 dind 用） |
+| `Dockerfile.agent-runtime` | 镜像构建文件 | 仅路径 B（重建）需要 |
+| `patches/harbor_compose_patch.py` | harbor compose 模板 seccomp patch | 仅路径 B 需要（已烧进镜像） |
+| 基镜像 `ghcr.io/aisbench/aisbench_benchmark:v3.1-20260903-master-ubuntu24.04-py312-aarch64` | 构建 agent-runtime 镜像的底座 | 仅路径 B 需要 |
+
+### 0.3 需要自备的素材
+
+| 素材 | 说明 | 传入脚本的参数 | 适用模式 |
+|---|---|---|---|
+| tb2 数据集目录 | terminal-bench-2 任务集目录 | `--dataset` | 两模式 |
+| case 镜像包 | `docker save` 打出的 tar / tar.gz | `--case-images` | **仅 dind**（socket 直接用宿主机镜像） |
+| agent deps bundle 目录 | agent 离线依赖包（可现做，见第 5 步） | `--agent-deps` | 两模式 |
+
+> **数据集目录结构**：每个任务一个子目录，内含 `task.toml`、`instruction.md`、
+> `environment/`（docker-compose 或 Dockerfile）、`tests/`。
+>
+> **镜像包内容**（仅 dind）：数据集中所有 case 用到的运行镜像（task.toml
+> `[environment]` `docker_image` 字段对应的镜像），供内层 daemon 离线使用。
+
+---
+
+## 1. 导入 agent-runtime 镜像（路径 A，推荐）
+
+```bash
+gunzip -c aisbench-agent-runtime-harbor-only.tar.gz | docker load
+```
+
+预期输出：
+
+```
+Loaded image: aisbench/agent-runtime:harbor-only
+```
+
+确认：
+
+```bash
+docker images aisbench/agent-runtime
+# REPOSITORY                  TAG           IMAGE ID       CREATED         SIZE
+# aisbench/agent-runtime      harbor-only   ...            ...             约 2.5GB
+```
+
+### 1b. （可选）路径 B：从基镜像重建镜像
+
+仅当需要改动 Dockerfile 或无法使用离线包时执行。**构建过程需访问华为 PyPI 镜像源与 gh-proxy.com（GitHub 镜像加速）**：
+
+```bash
+cd docker/agent_runtime          # 仓库 checkout 目录内
+docker build --network host \
+    -f Dockerfile.agent-runtime \
+    -t aisbench/agent-runtime:harbor-only \
+    --build-arg BASE_IMAGE=ghcr.io/aisbench/aisbench_benchmark:v3.1-20260903-master-ubuntu24.04-py312-aarch64 \
+    .
+```
+
+构建完成后跳过第 1 步，直接进入第 2 步。
+
+---
+
+## 2. 准备素材
+
+### 2.1 tb2 数据集目录
+
+放到任意宿主路径，例如 `/data/terminal-bench-2`。要求目录下直接是各任务子目录。
+
+> 挂载方式按模式不同：
+> - **socket 模式**：按「宿主机原路径透传」挂载（容器内外同路径，如 `/data/terminal-bench-2`），
+>   因此 `--dataset` 必须传**真实绝对路径**（不能是含符号链接的缩写路径，脚本会校验）。
+> - **dind 模式**：挂到容器内固定路径 `/opt/data/terminal-bench-2`（只读）。
+
+### 2.2 case 镜像包（仅 `--mode dind` 需要）
+
+> **socket 模式完全跳过本节**：trial 容器由宿主机 daemon 拉起，宿主机上已有的
+> case 镜像直接可见，零导入。宿主机缺镜像时 `docker pull` 或 `docker load` 离线包即可。
+
+在有这些镜像的机器上打包（任意一台能 `docker pull`/已有镜像的机器）：
+
+```bash
+# 单镜像
+docker save alexgshaw/headless-terminal:20260430 | gzip > case-images.tar.gz
+
+# 多镜像合并一个包
+docker save -o case-images.tar \
+    alexgshaw/headless-terminal:20260430 \
+    <其他 case 镜像>...
+gzip case-images.tar
+```
+
+> gzip 压缩与否均可，脚本按 `/opt/agent-resources/images/case-images.tar` 挂载后
+> 直接 `docker load -i`（load 原生支持读 gzip 流）。
+
+**增量补充（仅 dind）**：不想重打全量包时，宿主机执行 `sync_images.sh`，通过
+`docker save | docker exec -i docker load` 管道把缺失镜像直传进容器内 daemon
+（不在宿主机落中间文件）：
+
+```bash
+./sync_images.sh --list              # 只看差异清单
+./sync_images.sh --all               # 宿主机全量差集直传
+./sync_images.sh fix-git regex-log   # 按任务名同步
+```
+
+### 2.3 agent deps bundle 目录
+
+先建一个空目录即可（推荐在容器内现做，见第 5 步）：
+
+```bash
+mkdir -p /data/agent-deps
+```
+
+若已有离线 bundle（如 `terminus-2-debian-12-aarch64.tar.gz`），直接放进该目录。
+
+**bundle 命名规则（重要）**：`<agent>-<os-id>-<version-id>-<arch>.tar.gz`，
+运行时 harbor 按 trial 容器内实测的 `/etc/os-release` + `uname -m` 精确匹配文件名，
+例如 case 镜像是 Debian 12 底 → 需要 `terminus-2-debian-12-aarch64.tar.gz`。
+bundle 构建时的 `--base-image` 必须与 case 运行镜像**同族**（glibc/系统库一致）。
+
+---
+
+## 3. 一键启动 agent-runtime 容器
+
+> **注意**：下文命令中的 `/data/terminal-bench-2`、`/data/agent-deps` 均为**示例路径**，
+> 请替换成你机器上真实存在的绝对路径（脚本会预检，目录不存在会直接报错退出）。
+
+```bash
+cd docker/agent_runtime          # 仓库 checkout 目录内
+chmod +x start_agent_runtime.sh   # 首次执行前
+
+# ---- 默认 socket 模式（推荐，无需镜像包）----
+./start_agent_runtime.sh \
+    --image aisbench/agent-runtime:harbor-only \
+    --dataset /data/terminal-bench-2 \
+    --agent-deps /data/agent-deps \
+    --agent terminus-2
+
+# ---- dind 模式（强隔离，需要镜像包）----
+./start_agent_runtime.sh --mode dind \
+    --image aisbench/agent-runtime:harbor-only \
+    --dataset /data/terminal-bench-2 \
+    --case-images /data/case-images.tar.gz \
+    --agent-deps /data/agent-deps \
+    --agent terminus-2
+```
+
+可选参数：
+
+| 参数 | 默认值 | 说明 |
+|---|---|---|
+| `--mode` | `socket` | `socket`（DooD，复用宿主机 daemon）/ `dind`（强隔离，独立 daemon） |
+| `--name` | `agent-runtime` | 容器名 |
+| `--trials-dir` | `~/harbor-trials` | 评测产物持久化到宿主机的目录（dind 模式对应容器内 `/benchmark/outputs`；socket 模式容器内外同路径） |
+| `--docker-sock` | `/var/run/docker.sock` | 仅 socket 模式：宿主机 docker socket 路径 |
+
+预期输出（关键行）——socket 模式：
+
+```
+==> 启动容器 agent-runtime（socket 模式，复用宿主机 daemon）
+<容器ID>
+==> 校验容器内 docker 通道（应直连宿主机 daemon）
+==> 宿主机 daemon 就绪（容器内可见 alexgshaw/*:20260430 镜像 89 个）
+
+======================================================================
+ 模式: socket ｜ 容器已就绪，进入容器：
+     docker exec -it agent-runtime bash
+======================================================================
+```
+
+dind 模式额外输出：
+
+```
+==> 启动容器 agent-runtime（dind 模式，privileged / 独立 daemon）
+<容器ID>
+==> 容器内启动 dockerd
+==> 内层 dockerd 就绪
+==> 导入 case 镜像包（可能需要数分钟）
+Loaded image: alexgshaw/headless-terminal:20260430
+==> 内层 daemon 镜像列表：
+REPOSITORY                    TAG        SIZE
+alexgshaw/headless-terminal   20260430   174MB
+```
+
+脚本自动完成的事：
+
+- 公共：写 `/root/RUN_HINT.txt`（登录容器自动打印，内含按模式生成的命令模板）。
+- socket：挂载 docker.sock → 校验容器内 `docker info` → 统计可见 case 镜像数
+  （为 0 时 WARN 提醒宿主机先备镜像）。
+- dind：`--privileged + --cgroupns=host` 启动 → 容器内拉起 dockerd（180s 就绪等待）
+  → `docker load` case 镜像包。
+
+> **socket 模式路径约束**：数据集 / agent deps / 产物目录按「宿主机原路径透传」挂载
+> （容器内外同路径），保证 harbor 为 trial 容器生成的 bind mount 在宿主机 daemon 上
+> 能正确解析。因此 `--dataset`、`--agent-deps` 必须传真实绝对路径（脚本会校验）。
+
+---
+
+## 4. 进入容器并自检
+
+```bash
+docker exec -it agent-runtime bash
+```
+
+登录后会自动打印 RUN_HINT（含你的 agent 名与命令模板）。依次自检：
+
+```bash
+# 1) docker 通道正常
+docker info | head -5        # socket 模式：宿主机 daemon 信息；dind 模式：内层独立 daemon
+docker images                # case 镜像在列表里（socket 模式应看到宿主机全部镜像）
+
+# 2) harbor venv 可用
+agent_env harbor
+harbor --version                                    # 0.21.0（AISBench fork）
+python -c "from harbor.models.trial.config import AgentConfig; AgentConfig(deps_path='/tmp'); print('deps_path OK')"
+
+# 3) 挂载素材在位（路径按模式不同，以 RUN_HINT 打印为准）
+# socket 模式：宿主机原路径（示例值 = 启动参数）
+ls /data/terminal-bench-2            # --dataset 的值
+ls /data/agent-deps                  # --agent-deps 的值
+# dind 模式：固定挂载点
+ls /opt/data/terminal-bench-2        # 数据集任务目录
+ls /opt/agent-resources/deps         # deps bundle（可为空，下一步构建）
+ls /opt/agent-resources/images/      # case-images.tar
+```
+
+---
+
+## 5. （bundle 目录为空时）容器内构建 agent deps bundle
+
+在容器内（`agent_env harbor` 已激活）执行（`--out` 按模式取对应 deps 目录）：
+
+```bash
+# dind 模式（固定挂载点）
+harbor agent-deps build \
+    -a terminus-2 \
+    --base-image alexgshaw/headless-terminal:20260430 \
+    --out /opt/agent-resources/deps \
+    -m mock-model \
+    --host-network
+
+# socket 模式（--out 填启动时 --agent-deps 的宿主机原路径）
+harbor agent-deps build \
+    -a terminus-2 \
+    --base-image alexgshaw/headless-terminal:20260430 \
+    --out /data/agent-deps \
+    -m mock-model \
+    --host-network
+```
+
+说明：
+
+| 参数 | 说明 |
+|---|---|
+| `-a` | agent 名，与后续 ais_bench `-a` 一致 |
+| `--base-image` | **与 tb2 case 运行镜像同族**（最稳妥：直接用 case 镜像本身。dind 模式下已 load 进内层 daemon 不会重新拉取；socket 模式下直接用宿主机镜像） |
+| `--out` | 输出目录（按模式取上面对应路径）；产物自动命名为 `terminus-2-<os>-<ver>-<arch>.tar.gz` |
+| `-m` | terminus-2 必填（构造要求），构建过程**不调用 LLM**，任意值即可 |
+| `--host-network` | 构建容器共享网络，安装依赖可出网 |
+
+预期输出末尾：
+
+```
+Built agent deps bundle: /data/agent-deps/terminus-2-debian-12-aarch64.tar.gz
+```
+
+构建产物落在宿主机 `--agent-deps` 挂载目录（该挂载为读写），下次可直接复用。
+
+> 若多种 case 底镜像族不同（如 debian-12 和 ubuntu-24.04 混杂），按各底镜像分别构建，
+> bundle 全放同一目录，运行时按 os-release 自动匹配。
+
+---
+
+## 6. 运行评测
+
+仍在容器内、`agent_env harbor` 已激活。
+
+**socket 模式**：先 `cd` 进产物目录（保证 ais_bench work_dir 落在同路径透传挂载上，
+trial 容器才能按宿主机路径正确 bind mount），配置路径用容器内绝对路径，
+`--agent-deps` / `-p` 用启动时的宿主机原路径：
+
+```bash
+cd <启动时 --trials-dir 的宿主机路径>   # 如 ~/harbor-trials
+ais_bench /benchmark/ais_bench/configs/agent_example/harbor_agent_task.py \
+    --mode agent \
+    -a terminus-2 \
+    --agent-deps /data/agent-deps \
+    -p /data/terminal-bench-2 \
+    --n-tasks 1 \
+    --api-base http://<模型服务IP>:<端口>/v1 \
+    --model openai/<模型名>
+```
+
+**dind 模式**（容器内固定路径）：
+
+```bash
+ais_bench ais_bench/configs/agent_example/harbor_agent_task.py \
+    --mode agent \
+    -a terminus-2 \
+    --agent-deps /opt/agent-resources/deps \
+    -p /opt/data/terminal-bench-2 \
+    --n-tasks 1 \
+    --api-base http://<模型服务IP>:<端口>/v1 \
+    --model openai/<模型名>
+```
+
+参数说明：
+
+| 参数 | 说明 |
+|---|---|
+| `-a` | agent 名（须与 deps bundle 前缀、第 5 步构建的 agent 一致） |
+| `--agent-deps` | deps bundle 目录（dind 固定 `/opt/agent-resources/deps`；socket 为启动时的宿主原路径，文件夹模式自动匹配 bundle） |
+| `-p` | 数据集目录（dind 固定 `/opt/data/terminal-bench-2`；socket 为启动时的宿主原路径） |
+| `--n-tasks` | 抽取的任务数；**首次务必 `1`** 冒烟 |
+| `--api-base` | OpenAI 兼容服务地址（以 `/v1` 结尾） |
+| `--model` | **必须带 litellm provider 前缀**；OpenAI 兼容接口一律 `openai/<模型名>`，如 `openai/Qwen2.5-7B-Instruct` |
+| `--agent-api-key <key>` | 模型服务需要鉴权时传（可选） |
+| `--n-concurrent N` | 并发 trial 数（默认配置 5，可按资源调整） |
+| `-k N` | 每个 task 的尝试次数 |
+| `--ae KEY=VALUE` | 注入 trial 容器/tmux 会话的环境变量，可重复（如 `--ae OPENAI_API_KEY=xxx`） |
+| `--disable-verification` | 跳过 verifier 打分（链路调试用；正常评测勿加） |
+
+预期日志关键行（以 dind 模式路径为例，socket 模式对应路径为宿主原路径）：
+
+```
+Running Harbor Job:   0%|  | 0/1
+Installing offline agent deps from /opt/agent-resources/deps
+Selected offline deps bundle /opt/agent-resources/deps/terminus-2-debian-12-aarch64.tar.gz
+Installed offline agent deps for terminus-2 ...
+<agent 与 LLM 交互日志>
+Evaluation results saved to outputs/default/<时间戳>/results/...
++------------+-----------+-------------------------+-----------+ ...
+| agent      | model_name| dataset                 | avg_score | ...
++------------+-----------+-------------------------+-----------+ ...
+write summary csv to /benchmark/outputs/default/<时间戳>/summary/...
+```
+
+> 依赖服务无鉴权时可不传 key（ais_bench 有默认占位 key）。
+> 若服务仅限特定 Authorization，务必传 `--agent-api-key` 或 `--ae OPENAI_API_KEY=<值>`。
+
+---
+
+## 7. 查看结果
+
+**宿主机**（`--trials-dir` 对应目录，默认 `~/harbor-trials`）：
+
+```
+~/harbor-trials/default/<时间戳>/
+├── configs/            # 本次运行的配置快照
+├── results/
+│   └── terminus-2/
+│       ├── harbor_terminal-bench-2.json      # 汇总结果
+│       └── harbor_terminal-bench-2/
+│           └── details/                       # harbor 原生产物（trajectory、verifier 日志等）
+└── summary/summary_<时间戳>.csv              # 汇总表
+```
+
+**容器内**：dind 模式对应 `/benchmark/outputs/`（同一份数据）；
+socket 模式下容器内路径与宿主机路径相同（同路径透传挂载）。
+
+单条 trial 详细产物（agent 执行轨迹、verifier 输出）在
+`results/terminus-2/harbor_terminal-bench-2/details/<task>__<随机串>/` 下。
+
+> socket 模式下产物由 trial 容器内 root 写入，宿主机普通用户删除可能报
+> Permission denied，清理方法见第 9 节。
+
+---
+
+## 8. 停止与重跑
+
+```bash
+# 宿主机执行
+docker rm -f agent-runtime
+```
+
+- **dind 模式**：内层 dockerd 与 trial 容器随外层容器一起销毁，无需单独清理；
+  镜像缓存随之清空（重建容器后重新 load）。
+- **socket 模式**：trial 容器由宿主机 daemon 拉起、独立于外层容器。harbor 正常结束
+  会自动回收 trial 容器；异常残留时 `docker ps -a | grep <task名>` 查到后
+  `docker rm -f` 清理。宿主机镜像不受任何影响。
+- 重跑评测：直接重新执行第 3 步一键脚本（产物目录 `--trials-dir` 内容保留，多次运行按时间戳隔离）。
+- 换数据集/镜像包/agent：改对应参数重跑第 3 步即可。
+- 镜像无需重复导入（socket 模式永远不需要；dind 模式仅在外层容器被删后需要）。
+
+---
+
+## 9. 故障排查
+
+| 症状 | 原因与处理 |
+|---|---|
+| （socket）启动报「容器内 docker 不可用（socket 挂载失败？）」 | docker.sock 挂载失败：确认宿主机 `/var/run/docker.sock` 存在且可读；非默认路径用 `--docker-sock` 指定 |
+| （socket）启动 WARN「宿主机上未发现 tb2 case 镜像」 | 宿主机没有 case 镜像：`docker pull` 或 `docker load` 离线包（tag 形如 `alexgshaw/<case>:20260430`） |
+| （socket）宿主机删除产物报 Permission denied | trial 容器内 root 写入的产物文件：`docker run --rm -v <产物目录>:/x alpine rm -rf /x/<子目录>` 清理 |
+| （socket）trial 容器内数据集目录为空 | `--dataset`/`--agent-deps` 传了符号链接缩写路径，宿主机 daemon 解析不到：改用真实绝对路径（脚本会校验，一般不会发生） |
+| `cannot enter cgroupv2 "/sys/fs/cgroup/docker" ... threaded mode`（dind） | 启动脚本版本过旧。确认用带 `--cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw` 的 `start_agent_runtime.sh` |
+| 卡在 `==> 容器内启动 dockerd` 180s 超时（dind） | 进容器看 `cat /tmp/dockerd.log`；确认外层容器是 `--privileged` 启动 |
+| `No offline deps bundle for agent 'terminus-2' on <os> <ver> (<arch>)` | bundle 缺失或命名不匹配。报错会给出期望文件名，按第 5 步用同族 base-image 补建 |
+| `litellm.BadRequestError: LLM Provider NOT provided` | `--model` 未带 provider 前缀，改为 `--model openai/<模型名>` |
+| `litellm.InternalServerError: ... Connection error` | 模型服务地址不通：检查 `--api-base` 是否以 `/v1` 结尾、IP/端口可达（容器内 `curl http://<ip>:<port>/v1/models` 验证） |
+| 内层拉镜像超时/失败（dind） | case 镜像不在 case-images 包里：把缺失镜像 `docker save` 合入镜像包重建容器，或用 `sync_images.sh` 增量直传 |
+| `pthread_create failed: Operation not permitted`（openEuler/RHEL 宿主） | compose 模板 seccomp patch 未生效（不应发生，已烧进镜像）；进容器检查 `grep -r seccomp /opt/venvs/harbor/lib/python3.12/site-packages/harbor/environments/docker/docker-compose-prebuilt.yaml` |
+| 容器已存在报错 | `docker rm -f agent-runtime` 或换 `--name` |
+| 产物没出现在宿主机 trials 目录 | 确认启动脚本用了 `--trials-dir` 挂载（dind 模式为 `-v <trials-dir>:/benchmark/outputs`）；socket 模式下确认 ais_bench 是在 `cd <trials-dir>` 之后运行的 |

--- a/docker/agent_runtime/patches/harbor_compose_patch.py
+++ b/docker/agent_runtime/patches/harbor_compose_patch.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Patch harbor 的 docker compose 模板（适配 harbor 0.20.0 多模板布局）：
+#   1. 给 services.main 追加 security_opt: ["seccomp=unconfined"]
+#      openEuler/RHEL 宿主默认 seccomp profile 拦截 clone3，导致 trial 容器中
+#      OpenBLAS/NumPy 初始化线程报 pthread_create failed: Operation not permitted
+#   2. 给 services.main 设置 network_mode: "host"（仅当其未显式声明 network_mode 时，
+#      例如 docker-compose-no-network.yaml 的 main 已是 none，则保留不动）
+#
+# harbor 0.20.0 的 compose 模板（python3.12 site-packages/harbor/environments/docker/）：
+#   docker-compose-prebuilt.yaml   main 用预构建镜像（trial 默认路径之一）
+#   docker-compose-build.yaml      main 从 Dockerfile 构建（trial 默认路径之一）
+#   其余（no-network / egress-control / windows-keepalive）按上面规则自然跳过或仅加 seccomp
+# （harbor 0.6.1 的旧布局是单文件 docker-compose-base.yaml，本脚本同样兼容）
+#
+# 用法：harbor_compose_patch.py <compose.yaml> [更多 compose.yaml ...]
+#
+# 与 Dockerfile.agent-runtime 的 RUN 段配合：从 build context COPY 进镜像后调用。
+# 用独立脚本而不是 RUN 内联 heredoc，是为了绕开 BuildKit 对 RUN 内嵌多行引号字符串的
+# 解析限制（Dockerfile 1.0 起就不支持引号内裸换行 + 续行符的混合写法）。
+
+import sys
+
+import yaml
+
+
+def patch_file(path: str) -> int:
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f) or {}
+
+    services = cfg.setdefault("services", {})
+    if "main" not in services:
+        print(f"skip (no main service): {path}")
+        return 0
+
+    svc = services["main"]
+
+    opts = svc.setdefault("security_opt", [])
+    if "seccomp=unconfined" not in opts:
+        opts.append("seccomp=unconfined")
+
+    # 尊重显式 network_mode（如 no-network 模板的 none），其余补 host 直连
+    if not svc.get("network_mode"):
+        svc["network_mode"] = "host"
+
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f, sort_keys=False, allow_unicode=True)
+
+    print("patched:", path)
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: harbor_compose_patch.py <path/to/compose.yaml> [more.yaml ...]",
+              file=sys.stderr)
+        return 2
+    for path in sys.argv[1:]:
+        ret = patch_file(path)
+        if ret != 0:
+            return ret
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/agent_runtime/start_agent_runtime.sh
+++ b/docker/agent_runtime/start_agent_runtime.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# ============================================================================
+# AISBench harbor agent-runtime 一键启动脚本（双模式）
+#
+# 模式一：socket 模式（默认，DooD——复用宿主机 docker daemon）
+#   原理：挂载宿主机 /var/run/docker.sock 进容器，容器内 docker 命令直接操作
+#         宿主机 daemon。trial 容器由宿主机 dockerd 拉起，宿主机上已有的
+#         case 镜像直接可见，无需任何镜像导入/打包动作。
+#   约束：数据集 / agent deps / 产物目录 按「宿主机原路径透传」挂载（容器内
+#         外同路径），保证 harbor 为 trial 容器生成的 bind mount 在宿主机
+#         daemon 上能正确解析。
+#   安全：容器内拿到 docker.sock 等价于宿主机 root 级 daemon 控制权，请勿在
+#         该容器内运行不受信任的指令。
+#
+# 模式二：dind 模式（--mode dind，强隔离——容器内独立 daemon）
+#   原理：--privileged + --cgroupns=host 在容器内拉起独立 dockerd，trial 容器
+#         只出现在内层 daemon，不触碰宿主机 daemon。
+#   代价：需要提前准备 case 镜像包（--case-images），启动时自动
+#         docker load 进内层 daemon（全量导入，耗时数分钟；增量补充可用
+#         sync_images.sh 从宿主机差集直传）。
+#
+# 用法：
+#   # 默认 socket 模式
+#   ./start_agent_runtime.sh \
+#       --image         aisbench/agent-runtime:harbor-only \
+#       --dataset       /abs/path/terminal-bench-2 \   # tb2 数据集（绝对路径）
+#       --agent-deps    /abs/path/agent-deps-dir \     # agent deps bundle
+#       --agent         terminus-2 \
+#       [--name agent-runtime] [--trials-dir ~/harbor-trials]
+#
+#   # dind 模式（强隔离）
+#   ./start_agent_runtime.sh --mode dind \
+#       --image aisbench/agent-runtime:harbor-only \
+#       --dataset /abs/path/terminal-bench-2 \
+#       --case-images /abs/path/case-images.tar[.gz] \
+#       --agent-deps /abs/path/agent-deps-dir \
+#       --agent terminus-2 \
+#       [--name agent-runtime] [--trials-dir ~/harbor-trials]
+# ============================================================================
+set -euo pipefail
+
+CONTAINER_NAME="agent-runtime"
+MODE="socket"
+TRIALS_DIR="${HOME}/harbor-trials"
+DOCKER_SOCK="/var/run/docker.sock"
+
+usage() { grep '^#' "$0" | head -46; exit 1; }
+die() { echo "[start_agent_runtime] ERROR: $*" >&2; exit 1; }
+
+IMAGE="" DATASET="" CASE_IMAGES="" AGENT_DEPS="" AGENT=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --image)      IMAGE="$2"; shift 2 ;;
+        --mode)       MODE="$2"; shift 2 ;;
+        --dataset)    DATASET="$2"; shift 2 ;;
+        --case-images) CASE_IMAGES="$2"; shift 2 ;;
+        --agent-deps) AGENT_DEPS="$2"; shift 2 ;;
+        --agent)      AGENT="$2"; shift 2 ;;
+        --name)       CONTAINER_NAME="$2"; shift 2 ;;
+        --trials-dir) TRIALS_DIR="$2"; shift 2 ;;
+        --docker-sock) DOCKER_SOCK="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) die "未知参数: $1（--help 查看用法）" ;;
+    esac
+done
+
+[ "$MODE" = "socket" ] || [ "$MODE" = "dind" ] \
+    || die "--mode 仅支持 socket | dind（默认 socket）"
+[ -n "$IMAGE" ]      || die "缺少 --image"
+[ -n "$DATASET" ]    || die "缺少 --dataset（tb2 数据集目录，绝对路径）"
+[ -n "$AGENT_DEPS" ] || die "缺少 --agent-deps（agent deps bundle 目录，绝对路径）"
+[ -n "$AGENT" ]      || die "缺少 --agent（agent 名称，如 terminus-2）"
+
+# 同路径透传挂载要求绝对路径（socket 模式硬约束；dind 模式同样统一）
+for p in "$DATASET" "$AGENT_DEPS"; do
+    [ -d "$p" ] || die "目录不存在: $p"
+    [ "$p" = "$(cd "$p" && pwd)" ] || die "必须使用绝对路径（不含符号链接尾巴）: $p"
+done
+
+if [ "$MODE" = "socket" ]; then
+    [ -S "$DOCKER_SOCK" ] || die "宿主机 docker socket 不存在: $DOCKER_SOCK"
+else
+    [ -n "$CASE_IMAGES" ] || die "dind 模式缺少 --case-images（case 镜像包 tar/tar.gz）"
+    [ -f "$CASE_IMAGES" ] || die "case 镜像包不存在: $CASE_IMAGES"
+fi
+
+docker image inspect "$IMAGE" >/dev/null 2>&1 \
+    || die "本机没有镜像 $IMAGE（先 docker load 离线包）"
+
+if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    die "容器 $CONTAINER_NAME 已存在，请先 docker rm -f $CONTAINER_NAME 或用 --name 换名"
+fi
+
+mkdir -p "$TRIALS_DIR"
+TRIALS_DIR_ABS="$(cd "$TRIALS_DIR" && pwd)"
+
+# ---------------------------------------------------------------------------
+# 1. 启动外层容器
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "socket" ]; then
+    echo "==> 启动容器 $CONTAINER_NAME（socket 模式，复用宿主机 daemon）"
+    docker run -d --name "$CONTAINER_NAME" \
+        -v "$DOCKER_SOCK":/var/run/docker.sock \
+        -v "$DATASET":"$DATASET" \
+        -v "$AGENT_DEPS":"$AGENT_DEPS" \
+        -v "$TRIALS_DIR_ABS":"$TRIALS_DIR_ABS" \
+        "$IMAGE" sleep infinity
+else
+    echo "==> 启动容器 $CONTAINER_NAME（dind 模式，privileged / 独立 daemon）"
+    # --cgroupns=host + rw 挂载宿主 cgroup2：
+    #   DinD 下内层 runc 需在外层容器 cgroup 下创建子 cgroup；若外层容器落在
+    #   systemd user session（domain threaded）的 cgroup 里，private cgroupns
+    #   会让 runc 报 "cannot enter cgroupv2 ... it is in threaded mode"。
+    #   共享宿主 cgroupns 并 rw 挂载后，内层 daemon 直接操作宿主 cgroup 树。
+    docker run -d --privileged --name "$CONTAINER_NAME" \
+        --cgroupns=host \
+        -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+        -v "$DATASET":/opt/data/terminal-bench-2:ro \
+        -v "$CASE_IMAGES":/opt/agent-resources/images/case-images.tar:ro \
+        -v "$AGENT_DEPS":/opt/agent-resources/deps \
+        -v "$TRIALS_DIR_ABS":/benchmark/outputs \
+        "$IMAGE" sleep infinity
+fi
+
+# ---------------------------------------------------------------------------
+# 2. 准备容器内 docker daemon
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "socket" ]; then
+    echo "==> 校验容器内 docker 通道（应直连宿主机 daemon）"
+    docker exec "$CONTAINER_NAME" docker info >/dev/null 2>&1 \
+        || die "容器内 docker 不可用（socket 挂载失败？）"
+    N_IMAGES=$(docker exec "$CONTAINER_NAME" docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+        | grep -c '^alexgshaw/.*:20260430$' || true)
+    echo "==> 宿主机 daemon 就绪（容器内可见 alexgshaw/*:20260430 镜像 ${N_IMAGES} 个）"
+    if [ "${N_IMAGES:-0}" = "0" ]; then
+        echo "[start_agent_runtime] WARN: 宿主机上未发现 tb2 case 镜像（alexgshaw/*:20260430），" >&2
+        echo "    请先在宿主机准备 case 镜像（docker pull 或 package_images.sh 产物 docker load）。" >&2
+    fi
+else
+    echo "==> 容器内启动 dockerd"
+    docker exec -d "$CONTAINER_NAME" bash -c 'nohup dockerd > /tmp/dockerd.log 2>&1 &'
+
+    DEADLINE=$((SECONDS + 180))
+    until docker exec "$CONTAINER_NAME" docker info >/dev/null 2>&1; do
+        if [ $SECONDS -ge $DEADLINE ]; then
+            echo "[start_agent_runtime] WARN: 内层 dockerd 180s 未就绪，请进容器看 /tmp/dockerd.log" >&2
+            break
+        fi
+        sleep 2
+    done
+    if docker exec "$CONTAINER_NAME" docker info >/dev/null 2>&1; then
+        echo "==> 内层 dockerd 就绪"
+    fi
+
+    # -----------------------------------------------------------------------
+    # 3.（仅 dind）case 镜像包导入内层 daemon
+    # -----------------------------------------------------------------------
+    if docker exec "$CONTAINER_NAME" docker info >/dev/null 2>&1; then
+        echo "==> 导入 case 镜像包（可能需要数分钟）"
+        docker exec "$CONTAINER_NAME" docker load -i /opt/agent-resources/images/case-images.tar
+        echo "==> 内层 daemon 镜像列表："
+        docker exec "$CONTAINER_NAME" docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.Size}}'
+    else
+        echo "[start_agent_runtime] WARN: 跳过 case 镜像导入（dockerd 未就绪），进容器后手动执行:" >&2
+        echo "    docker load -i /opt/agent-resources/images/case-images.tar" >&2
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 4. 写入运行指引（登录容器时自动打印）
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "socket" ]; then
+    RUN_HINT_BODY=$(cat <<EOF
+================ AISBench harbor agent runtime（socket / DooD）================
+docker daemon : 复用宿主机 daemon（挂载 $DOCKER_SOCK）
+case 镜像     : 直接使用宿主机已有镜像，无需导入
+数据集        : $DATASET            （宿主机原路径，容器内同路径可见）
+agent deps    : $AGENT_DEPS         （同上，--agent-deps 参数值）
+评测产物      : $TRIALS_DIR_ABS     （同上，宿主机直接可见）
+
+注意1：trial 容器由宿主机 dockerd 拉起，宿主机 docker ps 可见
+注意2：本容器内 docker 命令等价于宿主机 docker，勿执行不受信任操作
+注意3：--model 需带 litellm provider 前缀，OpenAI 兼容接口用 openai/，
+
+运行命令模板（先 cd 进产物目录，保证 work_dir 落在同路径透传挂载上）：
+    cd $TRIALS_DIR_ABS
+    agent_env harbor
+    ais_bench /benchmark/ais_bench/configs/agent_example/harbor_agent_task.py \\
+        --mode agent \\
+        -a $AGENT \\
+        --agent-deps $AGENT_DEPS \\
+        -p $DATASET \\
+        --n-tasks 1 \\
+        --api-base http://xxx.xx.xx.xx:8080/v1 \\
+        --model openai/xxx
+
+首次运行建议 --n-tasks 1 只跑一个 case。
+================ AISBench harbor agent runtime（socket / DooD）================
+EOF
+)
+else
+    RUN_HINT_BODY=$(cat <<EOF
+================ AISBench harbor agent runtime（DinD）================
+内层 dockerd : 已由启动脚本拉起（日志 /tmp/dockerd.log）
+case 镜像     : 已 load 进内层 daemon
+agent deps   : /opt/agent-resources/deps          (--agent-deps)
+数据集       : /opt/data/terminal-bench-2         (-p)
+评测产物     : /benchmark/outputs（宿主机 --trials-dir）
+
+注意：--model 需带 litellm provider 前缀，OpenAI 兼容接口用 openai/，
+例如 --model openai/Qwen2.5-7B-Instruct
+
+激活 harbor venv：
+    agent_env harbor
+
+运行命令模板（--api-base / --model 请按实际模型服务填写）：
+    ais_bench ais_bench/configs/agent_example/harbor_agent_task.py \\
+        --mode agent \\
+        -a $AGENT \\
+        --agent-deps /opt/agent-resources/deps \\
+        -p /opt/data/terminal-bench-2 \\
+        --n-tasks 1 \\
+        --api-base http://xxx.xx.xx.xx:8080/v1 \\
+        --model openai/xxx
+
+首次运行建议 --n-tasks 1 只跑一个 case。
+================ AISBench harbor agent runtime（DinD）================
+EOF
+)
+fi
+
+docker exec -i "$CONTAINER_NAME" bash -c "cat > /root/RUN_HINT.txt" <<EOF
+$RUN_HINT_BODY
+EOF
+docker exec "$CONTAINER_NAME" bash -c "grep -q RUN_HINT.txt /etc/bash.bashrc || \
+    echo '[ -f /root/RUN_HINT.txt ] && cat /root/RUN_HINT.txt' >> /etc/bash.bashrc"
+
+# ---------------------------------------------------------------------------
+# 5. 提示用户进入容器
+# ---------------------------------------------------------------------------
+echo ""
+echo "======================================================================"
+echo " 模式: $MODE ｜ 容器已就绪，进入容器："
+echo "     docker exec -it $CONTAINER_NAME bash"
+echo " 进入后按 RUN_HINT.txt 中的命令模板执行即可（会自动打印）。"
+echo "======================================================================"

--- a/docker/agent_runtime/sync_images.sh
+++ b/docker/agent_runtime/sync_images.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# sync_images.sh
+#
+# 将 host dockerd 上的 case 镜像流式导入 runtime 容器的 DinD daemon。
+#
+# 背景：
+#   agent-runtime 容器内置独立 dockerd（DinD），trial 容器由它拉起，
+#   因此 case 环境镜像必须存在于容器内 daemon 的本地缓存。
+#   宿主机/CI 环境通常无法直连 Docker Hub（registry-1.docker.io 被墙），
+#   但 case 镜像可通过离线包（docker load）预先装载到 host dockerd 上
+#   （参见 terminal-bench-2-1 仓库的 package_images.sh 产物）。
+#   本脚本提供 host -> 容器 的批量搬运通道：docker save | docker exec -i docker load，
+#   管道直传，不在 host 落任何中间文件。
+#
+# 本脚本在 host 上执行（不是容器内）。
+#
+# 用法:
+#   sync_images.sh <case_name>...     # 按目录名同步指定 case，如 sync_images.sh fix-git regex-log
+#   sync_images.sh --all              # 同步 host 上全部缺失的 case 镜像
+#   sync_images.sh --list             # 只显示差异清单，不导入
+#   sync_images.sh -h, --help
+#
+# 可通过环境变量覆盖默认值:
+#   CONTAINER   runtime 容器名（默认 agent-runtime）
+#   PREFIX      镜像仓库前缀（默认 alexgshaw/）
+#   TAG         镜像 tag（默认 20260430）
+
+set -eo pipefail
+
+CONTAINER="${CONTAINER:-agent-runtime}"
+PREFIX="${PREFIX:-alexgshaw/}"
+TAG="${TAG:-20260430}"
+
+log()  { echo "[$(date +%H:%M:%S)] $*"; }
+fail() { echo "[错误] $*" >&2; exit 1; }
+
+usage() { sed -n '2,26p' "$0"; }
+
+# 按前缀 + tag 过滤镜像名（从 stdin 读列表）
+filter_images() {
+    awk -v p="$PREFIX" -v t=":$TAG" \
+        'substr($0,1,length(p))==p && substr($0,length($0)-length(t)+1)==t'
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+esac
+
+# ---- 前置检查：host docker 与 runtime 容器均可用 ----
+command -v docker >/dev/null || fail "host 上未找到 docker 命令"
+docker info >/dev/null 2>&1 || fail "host dockerd 不可用"
+docker exec "$CONTAINER" docker info >/dev/null 2>&1 \
+    || fail "runtime 容器 $CONTAINER 不可达或其内部 dockerd 未就绪"
+
+# ---- 计算待同步清单 ----
+if [ "${1:-}" = "--all" ] || [ "${1:-}" = "--list" ]; then
+    # 差集 = host 全集 - 容器内已有
+    mapfile -t pending < <(
+        docker images --format '{{.Repository}}:{{.Tag}}' | filter_images | sort -u > /tmp/.sync_host.$$
+        docker exec "$CONTAINER" docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | filter_images | sort -u > /tmp/.sync_have.$$
+        comm -23 /tmp/.sync_host.$$ /tmp/.sync_have.$$
+        rm -f /tmp/.sync_host.$$ /tmp/.sync_have.$$
+    )
+    mode="${1}"
+else
+    [ $# -ge 1 ] || { usage; exit 1; }
+    pending=()
+    for c in "$@"; do
+        img="${PREFIX%/}/${c}:${TAG}"
+        docker image inspect "$img" >/dev/null 2>&1 || { log "跳过 $c：host 上不存在 $img"; continue; }
+        pending+=("$img")
+    done
+    mode="named"
+fi
+
+if [ "${#pending[@]}" -eq 0 ]; then
+    log "没有需要同步的镜像（容器内已齐全或 host 上不存在）"
+    exit 0
+fi
+
+log "待导入 ${#pending[@]} 个镜像："
+printf '  - %s\n' "${pending[@]}"
+
+[ "$mode" = "--list" ] && exit 0
+
+# ---- 管道直传：host docker save -> 容器内 docker load ----
+log "开始导入（流式传输，不落盘）..."
+docker save "${pending[@]}" | docker exec -i "$CONTAINER" docker load
+log "完成。容器内当前 ${PREFIX%.}/*:${TAG} 镜像数：$(docker exec "$CONTAINER" docker images --format '{{.Repository}}:{{.Tag}}' | filter_images | wc -l)"


### PR DESCRIPTION
## 概述

为 AISBench 提供 agent-runtime 容器化运行方案：一个 **harbor-only 精简运行时镜像** + **双模式拉起脚本**。默认 socket 模式挂载宿主 `docker.sock` 复用宿主机 dockerd，trial 容器直接使用宿主机已有 case 镜像，**零镜像导入**；可选 `--mode dind` 提供强隔离运行环境。

## 变更内容（5 文件，+968 行）

| 文件 | 说明 |
|---|---|
| `docker/agent_runtime/Dockerfile.agent-runtime` | harbor-only 运行时镜像：harbor fork 经 gh-proxy.com 镜像从 git 仓库直接安装（支持 `deps_path` / `--agent-deps` 离线安装），并内置 compose patch |
| `docker/agent_runtime/patches/harbor_compose_patch.py` | 修正 harbor 生成的 compose 配置（`seccomp=unconfined` + `network_mode=host`），兼容 openEuler/RHEL 宿主机 |
| `docker/agent_runtime/start_agent_runtime.sh` | 双模式拉起脚本：默认 socket 模式（复用宿主 dockerd，零镜像导入）；`--mode dind` 强隔离（`--privileged` + 容器内独立 daemon + case 镜像包自动导入） |
| `docker/agent_runtime/sync_images.sh` | dind 模式的增量镜像同步补充工具 |
| `docker/agent_runtime/USAGE.md` | 镜像构建、双模式启动、运行评测与故障排查文档 |

## 验证

- [x] **socket 模式**：默认模式拉起，挂载宿主 `docker.sock`，trial 容器直接复用宿主机已有 case 镜像（如 `alexgshaw/fix-git`），零镜像导入
- [x] **端到端评测**：容器内通过 `ais_bench` + terminus-2 agent 对 terminal-bench 真实任务 `fix-git` 完成评测，全流程跑通
- [x] **dind 模式**：`--mode dind` 拉起验证，容器内独立 dockerd + case 镜像包自动导入

**镜像构建（`--no-cache` 全量构建成功）**：

![docker build](https://github.com/Huafubing/benchmark/releases/download/pr531-screenshots/docker-build.png)

**容器内运行环境（`agent_env harbor` 激活后 harbor CLI 可用）**：

![harbor CLI](https://github.com/Huafubing/benchmark/releases/download/pr531-screenshots/harbor-cli.png)

复现步骤与测试命令见 `docker/agent_runtime/USAGE.md`。

## 关联

取代并关闭 #499（历史提交混杂实验性方案，本 PR 基于 master 重新整理为单一 commit）。
