### PR TITLE
[bugfix] add docker buildx in base dockerfile & ak ae append bugfix

### DIFF
--- a/ais_bench/benchmark/cli/argument_parser.py
+++ b/ais_bench/benchmark/cli/argument_parser.py
@@ -240,6 +240,7 @@ class ArgumentParser():
             dest='agent_kwarg',
             help="Additional agent kwarg in 'key=value' format "
             "(can be used multiple times)",
+            action='append',
             nargs='+',
             type=str,
             default=None,
@@ -250,6 +251,7 @@ class ArgumentParser():
             dest='agent_env',
             help="Environment variable for the agent in 'KEY=VALUE' format "
             "(can be used multiple times)",
+            action='append',
             nargs='+',
             type=str,
             default=None,

--- a/ais_bench/benchmark/utils/agent_params.py
+++ b/ais_bench/benchmark/utils/agent_params.py
@@ -114,15 +114,35 @@ _DISCOVERY_HINTS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
 }
 
 
-def parse_kwarg_strings(kwargs_list: list[str] | None) -> dict[str, Any]:
+def _flatten_env_items(items):
+    """Flatten ``['K=V']`` / ``[['K=V'], ['K2=V2']]`` into a flat string list.
+
+    ``--ae``/``--ak`` use ``action='append' + nargs='+'`` so repeated flags
+    produce a list of lists; a single flag with several values also yields a
+    nested list. Flattening keeps both shapes working.
+    """
+    if items is None:
+        return []
+    out: list[str] = []
+    for item in items:
+        if isinstance(item, (list, tuple)):
+            out.extend(_flatten_env_items(item))
+        else:
+            out.append(item)
+    return out
+
+
+def parse_kwarg_strings(kwargs_list: list | None) -> dict[str, Any]:
     """Parse ``key=value`` strings into a dict (values parsed as JSON literals).
 
-    Mirrors harbor's ``harbor.cli.utils.parse_kwargs`` without importing harbor.
+    Accepts a flat ``['key=value', ...]`` list or the nested list produced by
+    repeated ``--ak`` flags. Mirrors harbor's ``harbor.cli.utils.parse_kwargs``
+    without importing harbor.
     """
     if not kwargs_list:
         return {}
     result: dict[str, Any] = {}
-    for item in kwargs_list:
+    for item in _flatten_env_items(kwargs_list):
         if "=" not in item:
             raise ValueError(f"Invalid kwarg format: {item}. Expected key=value")
         key, value = item.split("=", 1)
@@ -142,12 +162,16 @@ def parse_kwarg_strings(kwargs_list: list[str] | None) -> dict[str, Any]:
     return result
 
 
-def parse_env_strings(env_list: list[str] | None) -> dict[str, str]:
-    """Parse ``KEY=VALUE`` strings into a dict of strings."""
+def parse_env_strings(env_list: list | None) -> dict[str, str]:
+    """Parse ``KEY=VALUE`` strings into a dict of strings.
+
+    Accepts a flat ``['KEY=VALUE', ...]`` list or the nested list produced by
+    repeated ``--ae`` flags.
+    """
     if not env_list:
         return {}
     result: dict[str, str] = {}
-    for item in env_list:
+    for item in _flatten_env_items(env_list):
         if "=" not in item:
             raise ValueError(f"Invalid env var format: {item}. Expected KEY=VALUE")
         key, value = item.split("=", 1)

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -221,6 +221,14 @@ if [ ${dockerd_version_status} -ne 0 ]; then
     exit 1
 fi
 
+buildx_version_output=$(docker run --rm ${image_name} docker buildx version 2>&1)
+buildx_version_status=$?
+if [ ${buildx_version_status} -ne 0 ]; then
+    echo "错误：镜像中 docker buildx version 执行失败（退出码: ${buildx_version_status}）"
+    echo "输出：${buildx_version_output}"
+    exit 1
+fi
+
 # dockerd 二进制存在性二次校验（Docker 27.x 输出与 docker --version 同格式，需确保调用的是 dockerd 而非 docker）
 dockerd_which_output=$(docker run --rm ${image_name} which dockerd 2>&1)
 if [ $? -ne 0 ] || [ -z "${dockerd_which_output}" ]; then
@@ -246,14 +254,22 @@ if ! echo "${dockerd_version_output}" | grep -F "Docker version" > /dev/null 2>&
     echo "实际输出：${dockerd_version_output}"
     exit 1
 fi
+# buildx 插件存在性校验（harbor 依赖 docker buildx build）
+if ! echo "${buildx_version_output}" | grep -F "buildx" > /dev/null 2>&1; then
+    echo "错误：buildx 验证失败，未找到预期内容：buildx"
+    echo "实际输出：${buildx_version_output}"
+    exit 1
+fi
 
 # 版本号校验：Docker >= 20.0，Docker Compose >= 2.0.0
 docker_ver=$(echo "${docker_version_output}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 compose_ver=$(echo "${compose_version_output}" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
 dockerd_ver=$(echo "${dockerd_version_output}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+buildx_ver=$(echo "${buildx_version_output}" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
 
 docker_major=$(echo "${docker_ver}" | cut -d. -f1)
 compose_major=$(echo "${compose_ver}" | cut -d. -f1)
+buildx_major=$(echo "${buildx_ver}" | cut -d. -f1)
 
 # 进一步校验：dockerd 与 docker 版本号应一致，确保不是同一二进制被误调用两次
 if [ "${docker_ver}" != "${dockerd_ver}" ]; then
@@ -271,8 +287,16 @@ if [ -z "${compose_ver}" ] || [ "${compose_major}" -lt 2 ]; then
     exit 1
 fi
 
+# buildx 版本为 0.x 系列，仅需确认能解析出版本号（存在性即通过）
+if [ -z "${buildx_ver}" ]; then
+    echo "错误：无法从 docker buildx version 输出中解析出版本号"
+    echo "实际输出：${buildx_version_output}"
+    exit 1
+fi
+
 echo "Docker 验证通过：${docker_ver}"
 echo "Docker Compose 验证通过：${compose_ver}"
+echo "buildx 验证通过：${buildx_ver}"
 echo "dockerd 验证通过：${dockerd_version_output}"
 
 if [ "$push" == "1" ]; then

--- a/docker/openeuler/Dockerfile.py310.openeuler22.03
+++ b/docker/openeuler/Dockerfile.py310.openeuler22.03
@@ -113,11 +113,13 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /benchmark /benchmark
 COPY --from=builder /usr/share/nltk_data /usr/share/nltk_data
 
-# 安装 Docker Engine (>= 20.0) 与 Docker Compose v2 (>= 2.0.0)，用于支持 terminal-bench 等 agent 测评中的嵌套容器执行
+# 安装 Docker Engine (>= 20.0) 与 Docker Compose v2 (>= 2.0.0)、buildx 插件，用于支持 terminal-bench 等 agent 测评中的嵌套容器执行
 # 依赖包已上传至华为云 OBS：
 #   docker-${DOCKER_VERSION}-${ARCH}.tgz
 #   docker-compose-linux-${ARCH}
+#   buildx-v${BUILDX_VERSION}.linux-${ARCH}
 ARG DOCKER_VERSION=27.3.1
+ARG BUILDX_VERSION=0.36.1
 RUN ARCH=$(uname -m) && \
     dnf install -y iptables curl && \
     curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/docker-${DOCKER_VERSION}-${ARCH}.tgz" \
@@ -129,9 +131,13 @@ RUN ARCH=$(uname -m) && \
     curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/docker-compose-linux-${ARCH}" \
         -o /usr/local/lib/docker/cli-plugins/docker-compose && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
+    curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/buildx-v${BUILDX_VERSION}.linux-${ARCH}" \
+        -o /usr/local/lib/docker/cli-plugins/docker-buildx && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx && \
     dnf clean all && \
     docker --version && \
     docker compose version && \
+    docker buildx version && \
     dockerd --version
 
 WORKDIR /benchmark

--- a/docker/openeuler/Dockerfile.py311.openeuler24.03
+++ b/docker/openeuler/Dockerfile.py311.openeuler24.03
@@ -105,11 +105,13 @@ COPY --from=builder /usr/lib64/python3.11/site-packages /usr/lib64/python3.11/si
 COPY --from=builder /usr/lib/python3.11/site-packages /usr/lib/python3.11/site-packages
 COPY --from=builder /benchmark /benchmark
 
-# 安装 Docker Engine (>= 20.0) 与 Docker Compose v2 (>= 2.0.0)，用于支持 terminal-bench 等 agent 测评中的嵌套容器执行
+# 安装 Docker Engine (>= 20.0) 与 Docker Compose v2 (>= 2.0.0)、buildx 插件，用于支持 terminal-bench 等 agent 测评中的嵌套容器执行
 # 依赖包已上传至华为云 OBS：
 #   docker-${DOCKER_VERSION}-${ARCH}.tgz
 #   docker-compose-linux-${ARCH}
+#   buildx-v${BUILDX_VERSION}.linux-${ARCH}
 ARG DOCKER_VERSION=27.3.1
+ARG BUILDX_VERSION=0.36.1
 RUN ARCH=$(uname -m) && \
     dnf install -y iptables curl && \
     curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/docker-${DOCKER_VERSION}-${ARCH}.tgz" \
@@ -121,9 +123,13 @@ RUN ARCH=$(uname -m) && \
     curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/docker-compose-linux-${ARCH}" \
         -o /usr/local/lib/docker/cli-plugins/docker-compose && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
+    curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/buildx-v${BUILDX_VERSION}.linux-${ARCH}" \
+        -o /usr/local/lib/docker/cli-plugins/docker-buildx && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx && \
     dnf clean all && \
     docker --version && \
     docker compose version && \
+    docker buildx version && \
     dockerd --version
 
 WORKDIR /benchmark

--- a/docker/ubuntu/Dockerfile.py310.ubuntu22.04
+++ b/docker/ubuntu/Dockerfile.py310.ubuntu22.04
@@ -148,11 +148,13 @@ COPY --from=builder /usr/lib/python3/dist-packages /usr/lib/python3/dist-package
 COPY --from=builder /benchmark /benchmark
 COPY --from=builder /usr/share/nltk_data /usr/share/nltk_data
 
-# 安装 Docker Engine (>= 20.0) 与 Docker Compose v2 (>= 2.0.0)，用于支持 terminal-bench 等 agent 测评中的嵌套容器执行
+# 安装 Docker Engine (>= 20.0) 与 Docker Compose v2 (>= 2.0.0)、buildx 插件，用于支持 terminal-bench 等 agent 测评中的嵌套容器执行
 # 依赖包已上传至华为云 OBS：
 #   docker-${DOCKER_VERSION}-${ARCH}.tgz
 #   docker-compose-linux-${ARCH}
+#   buildx-v${BUILDX_VERSION}.linux-${ARCH}
 ARG DOCKER_VERSION=27.3.1
+ARG BUILDX_VERSION=0.36.1
 RUN ARCH=$(uname -m) && \
     apt-get update && \
     apt-get install -y --no-install-recommends iptables && \
@@ -165,10 +167,14 @@ RUN ARCH=$(uname -m) && \
     curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/docker-compose-linux-${ARCH}" \
         -o /usr/local/lib/docker/cli-plugins/docker-compose && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
+    curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/buildx-v${BUILDX_VERSION}.linux-${ARCH}" \
+        -o /usr/local/lib/docker/cli-plugins/docker-buildx && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     docker --version && \
     docker compose version && \
+    docker buildx version && \
     dockerd --version
 
 WORKDIR /benchmark

--- a/docker/ubuntu/Dockerfile.py312.ubuntu24.04
+++ b/docker/ubuntu/Dockerfile.py312.ubuntu24.04
@@ -151,6 +151,10 @@ COPY --from=builder /usr/share/nltk_data /usr/share/nltk_data
 #   docker-${DOCKER_VERSION}-${ARCH}.tgz
 #   docker-compose-linux-${ARCH}
 ARG DOCKER_VERSION=27.3.1
+# buildx 插件用于 harbor 的 `docker buildx build`（见 harbor/src/harbor/environments/docker/utils.py）
+# 资源已上传至华为云 OBS：
+#   buildx-v${BUILDX_VERSION}-${ARCH}
+ARG BUILDX_VERSION=0.36.1
 RUN ARCH=$(uname -m) && \
     apt-get update && \
     apt-get install -y --no-install-recommends iptables && \
@@ -163,10 +167,14 @@ RUN ARCH=$(uname -m) && \
     curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/docker-compose-linux-${ARCH}" \
         -o /usr/local/lib/docker/cli-plugins/docker-compose && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
+    curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/buildx-v${BUILDX_VERSION}-${ARCH}" \
+        -o /usr/local/lib/docker/cli-plugins/docker-buildx && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     docker --version && \
     docker compose version && \
+    docker buildx version && \
     dockerd --version
 
 WORKDIR /benchmark

--- a/docker/ubuntu/Dockerfile.py312.ubuntu24.04
+++ b/docker/ubuntu/Dockerfile.py312.ubuntu24.04
@@ -153,7 +153,7 @@ COPY --from=builder /usr/share/nltk_data /usr/share/nltk_data
 ARG DOCKER_VERSION=27.3.1
 # buildx 插件用于 harbor 的 `docker buildx build`（见 harbor/src/harbor/environments/docker/utils.py）
 # 资源已上传至华为云 OBS：
-#   buildx-v${BUILDX_VERSION}-${ARCH}
+#   buildx-v${BUILDX_VERSION}.linux-${ARCH}
 ARG BUILDX_VERSION=0.36.1
 RUN ARCH=$(uname -m) && \
     apt-get update && \
@@ -167,7 +167,7 @@ RUN ARCH=$(uname -m) && \
     curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/docker-compose-linux-${ARCH}" \
         -o /usr/local/lib/docker/cli-plugins/docker-compose && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
-    curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/buildx-v${BUILDX_VERSION}-${ARCH}" \
+    curl -fsSL "https://aisbench.obs.cn-north-4.myhuaweicloud.com/images/resources/buildx-v${BUILDX_VERSION}.linux-${ARCH}" \
         -o /usr/local/lib/docker/cli-plugins/docker-buildx && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx && \
     apt-get clean && \

--- a/tests/UT/cli/test_workers.py
+++ b/tests/UT/cli/test_workers.py
@@ -1126,3 +1126,54 @@ class TestAgentEval:
         })
         worker._apply_cli_args(cfg)
         assert cfg["datasets"][0]["args"]["extra_docker_compose"] == ["/cli.yaml"]
+
+    def test_apply_cli_args_repeated_ae_ak_expect_merges_all_pairs(self):
+        """重复 --ae/--ak 产生嵌套列表，_apply_cli_args 应合并全部 KEY=VALUE，而非只留最后一个。"""
+        worker = self._make_worker(
+            self._make_args(
+                agent_env=[
+                    ["ANTHROPIC_AUTH_TOKEN=sk-aaa"],
+                    ["ANTHROPIC_API_KEY=sk-bbb"],
+                    ["CLAUDE_CODE_EFFORT_LEVEL=max"],
+                    ["CLAUDE_CODE_MAX_OUTPUT_TOKENS=131072"],
+                ],
+                agent_kwarg=[
+                    ["disallowed_tools=WebSearch"],
+                    ["max_tokens=4096"],
+                ],
+            )
+        )
+        cfg = MockConfigDict({
+            "models": [{"abbr": "m"}],
+            "datasets": [],
+            "work_dir": "/tmp",
+            "cli_args": MagicMock(debug=False),
+        })
+        worker._apply_cli_args(cfg)
+        assert cfg["models"][0]["agent_env"] == {
+            "ANTHROPIC_AUTH_TOKEN": "sk-aaa",
+            "ANTHROPIC_API_KEY": "sk-bbb",
+            "CLAUDE_CODE_EFFORT_LEVEL": "max",
+            "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "131072",
+        }
+        assert cfg["models"][0]["agent_kwargs"] == {
+            "disallowed_tools": "WebSearch",
+            "max_tokens": 4096,
+        }
+
+    def test_apply_cli_args_agent_env_expect_cli_wins_over_config(self):
+        """同一环境变量 config 与 CLI 都提供时，应以 CLI 值为准覆盖。"""
+        worker = self._make_worker(
+            self._make_args(agent_env=[["CLAUDE_CODE_MAX_OUTPUT_TOKENS=131072"]])
+        )
+        cfg = MockConfigDict({
+            "models": [{
+                "abbr": "m",
+                "agent_env": {"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "8192"},
+            }],
+            "datasets": [],
+            "work_dir": "/tmp",
+            "cli_args": MagicMock(debug=False),
+        })
+        worker._apply_cli_args(cfg)
+        assert cfg["models"][0]["agent_env"]["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] == "131072"

--- a/tests/UT/utils/test_agent_params.py
+++ b/tests/UT/utils/test_agent_params.py
@@ -43,6 +43,23 @@ class TestParseKwargStrings(unittest.TestCase):
         # "=value" has "=", so it parses to an empty key, no raise
         self.assertEqual(parse_kwarg_strings(["=value"]), {"": "value"})
 
+    def test_nested_list_from_repeated_flag(self):
+        # --ak with action='append' + nargs='+' yields a list of lists
+        self.assertEqual(
+            parse_kwarg_strings(
+                [["disallowed_tools=WebSearch"], ["max_tokens=4096"]]
+            ),
+            {"disallowed_tools": "WebSearch", "max_tokens": 4096},
+        )
+        # single flag, multiple values also nests
+        self.assertEqual(
+            parse_kwarg_strings([["a=1", "b=x"]]), {"a": 1, "b": "x"}
+        )
+        # deeper nesting is flattened too
+        self.assertEqual(
+            parse_kwarg_strings([[["a=1"], ["b=2"]]]), {"a": 1, "b": 2}
+        )
+
 
 class TestParseEnvStrings(unittest.TestCase):
     def test_none(self):
@@ -62,6 +79,33 @@ class TestParseEnvStrings(unittest.TestCase):
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):
             parse_env_strings(["invalid"])
+
+    def test_nested_list_from_repeated_flag(self):
+        # --ae with action='append' + nargs='+' yields a list of lists
+        self.assertEqual(
+            parse_env_strings(
+                [
+                    ["ANTHROPIC_AUTH_TOKEN=sk-aaa"],
+                    ["ANTHROPIC_API_KEY=sk-bbb"],
+                    ["CLAUDE_CODE_EFFORT_LEVEL=max"],
+                    ["CLAUDE_CODE_MAX_OUTPUT_TOKENS=131072"],
+                ]
+            ),
+            {
+                "ANTHROPIC_AUTH_TOKEN": "sk-aaa",
+                "ANTHROPIC_API_KEY": "sk-bbb",
+                "CLAUDE_CODE_EFFORT_LEVEL": "max",
+                "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "131072",
+            },
+        )
+        # single flag, multiple values also nests
+        self.assertEqual(
+            parse_env_strings([["A=1", "B=2"]]), {"A": "1", "B": "2"}
+        )
+        # deeper nesting is flattened too
+        self.assertEqual(
+            parse_env_strings([[["A=1"], ["B=2"]]]), {"A": "1", "B": "2"}
+        )
 
 
 class TestAgentParamAdapterTranslate(unittest.TestCase):


### PR DESCRIPTION
Thanks for your contribution; we appreciate it a lot. The following instructions will make your pull request healthier and help you get feedback more easily. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
感谢您的贡献，我们非常重视。以下说明将使您的拉取请求更健康，更易于获得反馈。如果您不理解某些项目，请不要担心，只需提交拉取请求并从维护人员那里寻求帮助即可。

**PR Type / PR类型**
- [ ] Feature（功能新增）
- [x] Bugfix（Bug 修复）
- [ ] Docs（文档更新）
- [x] CI/CD（持续集成/持续部署）
- [ ] Refactor（代码重构）
- [ ] Perf（性能优化）
- [ ] Dependency（依赖项更新）
- [ ] Test-Cases（测试用例更新）
- [ ] Other（其他）

**Related Issue | 关联 Issue**
Fixes #(issue ID / issue 编号) / Relates to #(issue ID / issue 编号)
Fixes #536 
Fixes #535 

## 🔍 Motivation / 变更动机

Please describe the motivation of this PR and the goal you want to achieve through this PR.
请描述您的拉取请求的动机和您希望通过此拉取请求实现的目标。
基于harbor进行agent测评时会涉及到使用docker的部分插件，之前只集成了docker compose，实际上harbor在用side-car模式运行时会使用docker buildx这个额外的docker插件.
同时当前集成harbor的命令还不完善，--ae --ak 实际上无法正确传入多个环境变量或者agent参数

## 📝 Modification / 修改内容

Please briefly describe what modification is made in this PR.
请简要描述此拉取请求中进行的修改。
1. docker file中补充安装buildx
2. --ae和--ak的命令行添加action=append支持传入多个参数

## 📐 Associated Test Results / 关联测试结果

Please provide links to the related test results, such as CI pipelines, test reports, etc.
请提供相关测试结果的链接，例如 CI 管道、测试报告等。
构建成功
<img width="1765" height="1085" alt="image" src="https://github.com/user-attachments/assets/176469be-dff0-445a-b6f8-57a354a24851" />
deepswe side-car模式正常拉起：
<img width="897" height="933" alt="image" src="https://github.com/user-attachments/assets/3dac150d-90f8-47c8-bdc5-60bccae7ee94" />

传入多个环境变量，配置中实际有多个环境变量：
<img width="1366" height="928" alt="image" src="https://github.com/user-attachments/assets/7eadf53e-c32c-46a0-85a6-3a0fbb4d83c7" />


## ⚠️ BC-breaking (Optional) / 向后不兼容变更（可选）

Does the modification introduce changes that break the backward compatibility of the downstream repositories? If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
是否引入了会破坏下游存储库向后兼容性的更改？如果是，请描述它如何破坏兼容性，以及下游项目应该如何修改其代码以保持与此 PR 的兼容性。

## ⚠️ Performance degradation (Optional) / 性能下降（可选）

If the modification introduces performance degradation, please describe the impact of the performance degradation and the expected performance improvement.
如果引入了性能下降，请描述性能下降的影响和预期的性能改进。

## 🌟 Use cases (Optional) / 使用案例（可选）

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.
如果此拉取请求引入了新功能，最好在此处列出一些用例并更新文档。

## ✅ Checklist / 检查列表

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues. / 使用预提交或其他 linting 工具来修复潜在的 lint 问题。
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests. / 修复的 Bug 已完全由单元测试覆盖，导致 Bug 的情况应在单元测试中添加。
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. / 此拉取请求中的修改已完全由单元测试覆盖。如果不是，请添加更多单元测试以确保正确性。
- [ ] All relevant documentation (API docs, docstrings, example tutorials) has been updated to reflect these changes. / 所有相关文档（API 文档、文档字符串、示例教程）已更新以反映这些更改。

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects. / 如果此拉取请求对下游或其他相关项目有潜在影响，应在那些项目中测试此 PR。
- [ ] CLA has been signed and all committers have signed the CLA in this PR. / CLA 已签署，且本 PR 中的所有提交者均已签署 CLA。

## 👥 Collaboration Info / 协作信息
- Suggested Reviewers / 建议审核人: @xxx
- Relevant Module Owners / 相关模块负责人: @xxx
- Other Collaboration Notes / 其他协作说明：

## 🌟 Useful CI Command / 实用的CI命令
|   Command / 命令   |   Introduction / 介绍  |
| ---- | ----- |
|`/gemini review`| Performs a code review for the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 执行代码审核。 |
|`/gemini summary`| Provides a summary of the current pull request in its current state by Gemini. / 对当前拉取请求在当前状态下由 Gemini 提供摘要。 |
|`/gemini help`| Displays a list of available commands of Gemini. / 显示 Gemini 可用命令的列表。 |
|`/readthedocs build`| Triggers a build of the documentation for the current pull request in its current state by Read the Docs. / 触发当前拉取请求在当前状态下由 Read the Docs 构建文档。 |
|`/pr_check`| 手动重新触发 PR 合入质量检查工作流（PR Quality Check），并在 PR 上评论即可生效。 / Manually re-runs the PR Quality Check workflow by commenting on the pull request. |
